### PR TITLE
feat: add typedoc support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,8 @@
         "ts-loader": "^9.3.1",
         "ts-mocha": "^8.0.0",
         "ts-node": "^10.3.0",
+        "typedoc": "^0.23.20",
+        "typedoc-plugin-markdown": "^3.13.6",
         "typescript": "^4.8.2"
       },
       "engines": {
@@ -17020,6 +17022,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/docusaurus-plugin-typedoc": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-0.17.5.tgz",
+      "integrity": "sha512-mMTk4lRy2+wQ7fmMOv6RLfKkoGnHkBLE8qUoPfWFoqUYDDDInwVQKxz12FNnQx86eJSLgBiZmuY/zB/bYsZQlQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": ">=0.22.0",
+        "typedoc-plugin-markdown": ">=3.11.10"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.14",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
@@ -26511,6 +26523,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -27717,6 +27735,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/luxon": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.1.0.tgz",
@@ -27828,6 +27852,18 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.2.tgz",
+      "integrity": "sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/match-sorter": {
@@ -35248,6 +35284,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -37808,6 +37855,60 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.23.20",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.20.tgz",
+      "integrity": "sha512-nfb4Mx05ZZZXux3zPcLuc7+3TVePDW3jTdEBqXdQzJUyEILxoprgPIiTChbvci9crkqNJG9YESmfCptuh9Gn3g==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.0.19",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.11.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.6.tgz",
+      "integrity": "sha512-ISSc9v3BK7HkokxSBuJPttXox4tJ6hP0N9wfSIk0fmLN67+eqtAxbk97gs2nDiuha+RTO5eW9gdeAb+RPP0mgg==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.23.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
@@ -39188,6 +39289,18 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -41136,6 +41249,8 @@
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^2.2.0",
         "@tsconfig/docusaurus": "^1.0.5",
+        "docusaurus-plugin-typedoc": "^0.17.5",
+        "typedoc-plugin-markdown": "^3.13.6",
         "typescript": "^4.7.4"
       },
       "engines": {
@@ -50846,18 +50961,20 @@
     "@takaro/docs": {
       "version": "file:packages/web-docs",
       "requires": {
-        "@docusaurus/core": "2.2.0",
-        "@docusaurus/module-type-aliases": "2.2.0",
-        "@docusaurus/preset-classic": "2.2.0",
-        "@docusaurus/theme-mermaid": "2.2.0",
+        "@docusaurus/core": "^2.2.0",
+        "@docusaurus/module-type-aliases": "^2.2.0",
+        "@docusaurus/preset-classic": "^2.2.0",
+        "@docusaurus/theme-mermaid": "^2.2.0",
         "@mdx-js/react": "^1.6.22",
         "@tsconfig/docusaurus": "^1.0.5",
         "@types/react": "17.0.2",
         "@types/react-dom": "17.0.2",
         "clsx": "^1.2.1",
+        "docusaurus-plugin-typedoc": "^0.17.5",
         "prism-react-renderer": "^1.3.5",
         "react": "17.0.2",
         "react-dom": "17.0.2",
+        "typedoc-plugin-markdown": "^3.13.6",
         "typescript": "^4.7.4"
       },
       "dependencies": {
@@ -50987,7 +51104,7 @@
             "@docusaurus/react-loadable": "5.5.2",
             "@docusaurus/types": "2.2.0",
             "@types/history": "^4.7.11",
-            "@types/react": "17.0.2",
+            "@types/react": "*",
             "@types/react-router-config": "*",
             "@types/react-router-dom": "*",
             "react-helmet-async": "*",
@@ -51130,7 +51247,7 @@
           "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
           "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
           "requires": {
-            "@types/react": "17.0.2",
+            "@types/react": "*",
             "prop-types": "^15.6.2"
           }
         },
@@ -51178,7 +51295,7 @@
             "@docusaurus/plugin-content-pages": "2.2.0",
             "@docusaurus/utils": "2.2.0",
             "@types/history": "^4.7.11",
-            "@types/react": "17.0.2",
+            "@types/react": "*",
             "@types/react-router-config": "*",
             "clsx": "^1.2.1",
             "parse-numeric-range": "^1.3.0",
@@ -51231,7 +51348,7 @@
           "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
           "requires": {
             "@types/history": "^4.7.11",
-            "@types/react": "17.0.2",
+            "@types/react": "*",
             "commander": "^5.1.0",
             "joi": "^17.6.0",
             "react-helmet-async": "^1.3.0",
@@ -52037,7 +52154,7 @@
           "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
           "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
           "requires": {
-            "@types/react": "17.0.2",
+            "@types/react": "*",
             "prop-types": "^15.6.2"
           }
         },
@@ -53474,7 +53591,7 @@
       "integrity": "sha512-Fv/5kb2STAEMT3wHzdKQK2z8xKq38EDIGVrutYLmQVVLe+4orDFquU52hQrULnEHinMKv9FSA6lf9+uNT1ITtA==",
       "requires": {
         "@types/history": "^4.7.11",
-        "@types/react": "17.0.2"
+        "@types/react": "*"
       },
       "dependencies": {
         "@types/react": {
@@ -53494,7 +53611,7 @@
       "integrity": "sha512-db1mx37a1EJDf1XeX8jJN7R3PZABmJQXR8r28yUjVMFSjkmnQo6X6pOEEmNl+Tp2gYQOGPdYbFIipBtdElZ3Yg==",
       "requires": {
         "@types/history": "^4.7.11",
-        "@types/react": "17.0.2",
+        "@types/react": "*",
         "@types/react-router": "*"
       },
       "dependencies": {
@@ -53515,7 +53632,7 @@
       "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
       "requires": {
         "@types/history": "^4.7.11",
-        "@types/react": "17.0.2",
+        "@types/react": "*",
         "@types/react-router": "*"
       },
       "dependencies": {
@@ -58039,6 +58156,13 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "docusaurus-plugin-typedoc": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-0.17.5.tgz",
+      "integrity": "sha512-mMTk4lRy2+wQ7fmMOv6RLfKkoGnHkBLE8qUoPfWFoqUYDDDInwVQKxz12FNnQx86eJSLgBiZmuY/zB/bYsZQlQ==",
+      "dev": true,
+      "requires": {}
     },
     "dom-accessibility-api": {
       "version": "0.5.14",
@@ -64970,6 +65094,12 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -65898,6 +66028,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "luxon": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.1.0.tgz",
@@ -65977,6 +66113,12 @@
       "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
       "dev": true,
       "requires": {}
+    },
+    "marked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.2.tgz",
+      "integrity": "sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ==",
+      "dev": true
     },
     "match-sorter": {
       "version": "6.3.1",
@@ -71212,6 +71354,17 @@
         "rechoir": "^0.6.2"
       }
     },
+    "shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -73182,6 +73335,47 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.23.20",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.20.tgz",
+      "integrity": "sha512-nfb4Mx05ZZZXux3zPcLuc7+3TVePDW3jTdEBqXdQzJUyEILxoprgPIiTChbvci9crkqNJG9YESmfCptuh9Gn3g==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.0.19",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.11.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.6.tgz",
+      "integrity": "sha512-ISSc9v3BK7HkokxSBuJPttXox4tJ6hP0N9wfSIk0fmLN67+eqtAxbk97gs2nDiuha+RTO5eW9gdeAb+RPP0mgg==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7"
+      }
+    },
     "typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
@@ -74039,6 +74233,18 @@
           "optional": true
         }
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "ts-loader": "^9.3.1",
     "ts-mocha": "^8.0.0",
     "ts-node": "^10.3.0",
+    "typedoc": "^0.23.20",
+    "typedoc-plugin-markdown": "^3.13.6",
     "typescript": "^4.8.2"
   },
   "keywords": [],

--- a/packages/lib-components/src/hooks/useValidationResolver.ts
+++ b/packages/lib-components/src/hooks/useValidationResolver.ts
@@ -3,7 +3,7 @@ import * as yup from 'yup';
 
 export const useValidationSchema = (validationSchema: yup.AnyObjectSchema) =>
   useCallback(
-    async (data) => {
+    async (data: any) => {
       try {
         const values = await validationSchema.validate(data, {
           abortEarly: false,

--- a/packages/lib-components/src/views/Welcome/index.tsx
+++ b/packages/lib-components/src/views/Welcome/index.tsx
@@ -115,7 +115,7 @@ export const Welcome: FC = () => {
           <ContentWrapper>
             <ContentContainer>
               <Tile game="7 days to die"></Tile>
-              <Tile game="rust">Rust</Tile>
+              <Tile game="rust"></Tile>
             </ContentContainer>
           </ContentWrapper>
         </Grid>

--- a/packages/lib-db/src/__tests__/queryBuilder.integration.test.ts
+++ b/packages/lib-db/src/__tests__/queryBuilder.integration.test.ts
@@ -4,6 +4,7 @@ import {
 } from '../knex';
 import { QueryBuilder, SortDirection } from '../queryBuilder';
 import { expect } from '@takaro/test';
+import { TakaroDTO } from '@takaro/util';
 import { TakaroModel } from '../TakaroModel';
 import { Model } from 'objection';
 
@@ -43,6 +44,10 @@ class TestUserModel extends TakaroModel {
   };
 }
 
+class TestUserDTO extends TakaroDTO<TestUserDTO> {
+  name: string;
+}
+
 describe('QueryBuilder', () => {
   beforeEach(async () => {
     const knex = await NOT_DOMAIN_SCOPED_getKnex();
@@ -75,7 +80,7 @@ describe('QueryBuilder', () => {
     await TestUserModel.query().insert({ name: 'test2' });
     await TestUserModel.query().insert({ name: 'test3' });
 
-    const res = await new QueryBuilder<TestUserModel>({
+    const res = await new QueryBuilder<TestUserModel, TestUserDTO>({
       filters: { name: 'test2' },
     }).build(TestUserModel.query());
 
@@ -91,7 +96,7 @@ describe('QueryBuilder', () => {
       await TestUserModel.query().insert({ name: `test${number}` });
     }
 
-    const res = await new QueryBuilder<TestUserModel>({
+    const res = await new QueryBuilder<TestUserModel, TestUserDTO>({
       page: 2,
       limit: 10,
       sortBy: 'name',
@@ -108,7 +113,7 @@ describe('QueryBuilder', () => {
     await TestUserModel.query().insert({ name: 'test2' });
     await TestUserModel.query().insert({ name: 'test3' });
 
-    const res = await new QueryBuilder<TestUserModel>({
+    const res = await new QueryBuilder<TestUserModel, TestUserDTO>({
       sortBy: 'name',
       sortDirection: SortDirection.desc,
     }).build(TestUserModel.query());
@@ -122,7 +127,8 @@ describe('QueryBuilder', () => {
     await TestPostModel.query().insert({ title: 'test1', userId: user.id });
 
     const res = await new QueryBuilder<
-      TestPostModel & { author?: TestUserModel }
+      TestPostModel & { author?: TestUserModel },
+      TestUserDTO
     >({ extend: ['author'] }).build(TestPostModel.query());
 
     expect(res.results).to.have.lengthOf(1);

--- a/packages/lib-gameserver/src/TakaroEmitter.unit.test.ts
+++ b/packages/lib-gameserver/src/TakaroEmitter.unit.test.ts
@@ -100,6 +100,7 @@ describe('TakaroEmitter', () => {
       GameEvents.LOG_LINE,
       new EventLogLine({
         msg: 'test',
+        // @ts-expect-error - testing validation
         unknownProperty: 'this should trip validation',
       })
     );

--- a/packages/test/src/integrationTest.ts
+++ b/packages/test/src/integrationTest.ts
@@ -12,6 +12,9 @@ import {
   RoleCreateInputDTOCapabilitiesEnum,
 } from '@takaro/apiclient';
 
+/**
+ * blabla doesthisshowupanywhere
+ */
 export class IIntegrationTest<SetupData> {
   snapshot!: boolean;
   group!: string;

--- a/packages/web-docs/docs/development/packages/_category_.yml
+++ b/packages/web-docs/docs/development/packages/_category_.yml
@@ -1,0 +1,1 @@
+label: "Packages API"

--- a/packages/web-docs/docs/development/packages/classes/_category_.yml
+++ b/packages/web-docs/docs/development/packages/classes/_category_.yml
@@ -1,0 +1,2 @@
+label: "Classes"
+position: 3

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.AdminClient.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.AdminClient.md
@@ -1,0 +1,158 @@
+---
+id: "takaro_apiclient.AdminClient"
+title: "Class: AdminClient"
+sidebar_label: "@takaro/apiclient.AdminClient"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).AdminClient
+
+## Hierarchy
+
+- `BaseApiClient`
+
+  ↳ **`AdminClient`**
+
+## Constructors
+
+### constructor
+
+• **new AdminClient**(`config`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | `IApiClientConfig` |
+
+#### Overrides
+
+BaseApiClient.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/adminClient.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/adminClient.ts#L5)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance`
+
+#### Inherited from
+
+BaseApiClient.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:26](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L26)
+
+___
+
+### config
+
+• `Protected` `Readonly` **config**: `IApiClientConfig`
+
+#### Inherited from
+
+BaseApiClient.config
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:34](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L34)
+
+___
+
+### log
+
+• `Protected` **log**: `Logger`
+
+#### Inherited from
+
+BaseApiClient.log
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:27](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L27)
+
+## Accessors
+
+### domain
+
+• `get` **domain**(): [`DomainApi`](takaro_apiclient.DomainApi.md)
+
+#### Returns
+
+[`DomainApi`](takaro_apiclient.DomainApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/adminClient.ts:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/adminClient.ts#L9)
+
+___
+
+### meta
+
+• `get` **meta**(): [`MetaApi`](takaro_apiclient.MetaApi.md)
+
+#### Returns
+
+[`MetaApi`](takaro_apiclient.MetaApi.md)
+
+#### Inherited from
+
+BaseApiClient.meta
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:143](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L143)
+
+## Methods
+
+### isJsonMime
+
+▸ **isJsonMime**(`mime`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `mime` | `string` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+BaseApiClient.isJsonMime
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:50](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L50)
+
+___
+
+### waitUntilHealthy
+
+▸ **waitUntilHealthy**(`timeout?`): `Promise`<`void`\>
+
+Wait until the API reports that it is healthy
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `timeout` | `number` | `600000` | in milliseconds |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+BaseApiClient.waitUntilHealthy
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:123](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L123)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.Client.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.Client.md
@@ -1,0 +1,372 @@
+---
+id: "takaro_apiclient.Client"
+title: "Class: Client"
+sidebar_label: "@takaro/apiclient.Client"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).Client
+
+## Hierarchy
+
+- `BaseApiClient`
+
+  ↳ **`Client`**
+
+## Constructors
+
+### constructor
+
+• **new Client**(`config`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | `IApiClientConfig` |
+
+#### Overrides
+
+BaseApiClient.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L16)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance`
+
+#### Inherited from
+
+BaseApiClient.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:26](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L26)
+
+___
+
+### config
+
+• `Protected` `Readonly` **config**: `IApiClientConfig`
+
+#### Inherited from
+
+BaseApiClient.config
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:34](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L34)
+
+___
+
+### log
+
+• `Protected` **log**: `Logger`
+
+#### Inherited from
+
+BaseApiClient.log
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:27](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L27)
+
+## Accessors
+
+### command
+
+• `get` **command**(): [`CommandApi`](takaro_apiclient.CommandApi.md)
+
+#### Returns
+
+[`CommandApi`](takaro_apiclient.CommandApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:121](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L121)
+
+___
+
+### cronjob
+
+• `get` **cronjob**(): [`CronJobApi`](takaro_apiclient.CronJobApi.md)
+
+#### Returns
+
+[`CronJobApi`](takaro_apiclient.CronJobApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:81](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L81)
+
+___
+
+### function
+
+• `get` **function**(): [`FunctionApi`](takaro_apiclient.FunctionApi.md)
+
+#### Returns
+
+[`FunctionApi`](takaro_apiclient.FunctionApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:91](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L91)
+
+___
+
+### gameserver
+
+• `get` **gameserver**(): [`GameServerApi`](takaro_apiclient.GameServerApi.md)
+
+#### Returns
+
+[`GameServerApi`](takaro_apiclient.GameServerApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:71](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L71)
+
+___
+
+### hook
+
+• `get` **hook**(): [`HookApi`](takaro_apiclient.HookApi.md)
+
+#### Returns
+
+[`HookApi`](takaro_apiclient.HookApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:111](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L111)
+
+___
+
+### meta
+
+• `get` **meta**(): [`MetaApi`](takaro_apiclient.MetaApi.md)
+
+#### Returns
+
+[`MetaApi`](takaro_apiclient.MetaApi.md)
+
+#### Inherited from
+
+BaseApiClient.meta
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:143](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L143)
+
+___
+
+### module
+
+• `get` **module**(): [`ModuleApi`](takaro_apiclient.ModuleApi.md)
+
+#### Returns
+
+[`ModuleApi`](takaro_apiclient.ModuleApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:101](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L101)
+
+___
+
+### password
+
+• `set` **password**(`password`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `password` | `string` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:24](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L24)
+
+___
+
+### player
+
+• `get` **player**(): [`PlayerApi`](takaro_apiclient.PlayerApi.md)
+
+#### Returns
+
+[`PlayerApi`](takaro_apiclient.PlayerApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:131](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L131)
+
+___
+
+### role
+
+• `get` **role**(): [`RoleApi`](takaro_apiclient.RoleApi.md)
+
+#### Returns
+
+[`RoleApi`](takaro_apiclient.RoleApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:61](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L61)
+
+___
+
+### settings
+
+• `get` **settings**(): [`SettingsApi`](takaro_apiclient.SettingsApi.md)
+
+#### Returns
+
+[`SettingsApi`](takaro_apiclient.SettingsApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:141](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L141)
+
+___
+
+### token
+
+• `set` **token**(`token`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `token` | `string` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:28](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L28)
+
+___
+
+### user
+
+• `get` **user**(): [`UserApi`](takaro_apiclient.UserApi.md)
+
+#### Returns
+
+[`UserApi`](takaro_apiclient.UserApi.md)
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:51](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L51)
+
+___
+
+### username
+
+• `set` **username**(`username`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `username` | `string` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L20)
+
+## Methods
+
+### isJsonMime
+
+▸ **isJsonMime**(`mime`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `mime` | `string` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+BaseApiClient.isJsonMime
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:50](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L50)
+
+___
+
+### login
+
+▸ **login**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:32](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L32)
+
+___
+
+### logout
+
+▸ **logout**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/client.ts:47](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/client.ts#L47)
+
+___
+
+### waitUntilHealthy
+
+▸ **waitUntilHealthy**(`timeout?`): `Promise`<`void`\>
+
+Wait until the API reports that it is healthy
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `timeout` | `number` | `600000` | in milliseconds |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+BaseApiClient.waitUntilHealthy
+
+#### Defined in
+
+[packages/lib-apiclient/src/lib/baseClient.ts:123](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/lib/baseClient.ts#L123)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.CommandApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.CommandApi.md
@@ -1,0 +1,238 @@
+---
+id: "takaro_apiclient.CommandApi"
+title: "Class: CommandApi"
+sidebar_label: "@takaro/apiclient.CommandApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CommandApi
+
+CommandApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`CommandApi`**
+
+## Constructors
+
+### constructor
+
+• **new CommandApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### commandControllerCreate
+
+▸ **commandControllerCreate**(`commandCreateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Create
+
+**`Throws`**
+
+**`Memberof`**
+
+CommandApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `commandCreateDTO?` | [`CommandCreateDTO`](../interfaces/takaro_apiclient.CommandCreateDTO.md) | CommandCreateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3546](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3546)
+
+___
+
+### commandControllerGetOne
+
+▸ **commandControllerGetOne**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+CommandApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3563](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3563)
+
+___
+
+### commandControllerRemove
+
+▸ **commandControllerRemove**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Remove
+
+**`Throws`**
+
+**`Memberof`**
+
+CommandApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3577](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3577)
+
+___
+
+### commandControllerSearch
+
+▸ **commandControllerSearch**(`commandSearchInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CommandOutputArrayDTOAPI`](../interfaces/takaro_apiclient.CommandOutputArrayDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Search
+
+**`Throws`**
+
+**`Memberof`**
+
+CommandApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `commandSearchInputDTO?` | [`CommandSearchInputDTO`](../interfaces/takaro_apiclient.CommandSearchInputDTO.md) | CommandSearchInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CommandOutputArrayDTOAPI`](../interfaces/takaro_apiclient.CommandOutputArrayDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3591](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3591)
+
+___
+
+### commandControllerUpdate
+
+▸ **commandControllerUpdate**(`id`, `commandUpdateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Update
+
+**`Throws`**
+
+**`Memberof`**
+
+CommandApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `commandUpdateDTO?` | [`CommandUpdateDTO`](../interfaces/takaro_apiclient.CommandUpdateDTO.md) | CommandUpdateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3609](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3609)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.CronJobApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.CronJobApi.md
@@ -1,0 +1,238 @@
+---
+id: "takaro_apiclient.CronJobApi"
+title: "Class: CronJobApi"
+sidebar_label: "@takaro/apiclient.CronJobApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CronJobApi
+
+CronJobApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`CronJobApi`**
+
+## Constructors
+
+### constructor
+
+• **new CronJobApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### cronJobControllerCreate
+
+▸ **cronJobControllerCreate**(`cronJobCreateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Create
+
+**`Throws`**
+
+**`Memberof`**
+
+CronJobApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `cronJobCreateDTO?` | [`CronJobCreateDTO`](../interfaces/takaro_apiclient.CronJobCreateDTO.md) | CronJobCreateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4134](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4134)
+
+___
+
+### cronJobControllerGetOne
+
+▸ **cronJobControllerGetOne**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+CronJobApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4151](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4151)
+
+___
+
+### cronJobControllerRemove
+
+▸ **cronJobControllerRemove**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Remove
+
+**`Throws`**
+
+**`Memberof`**
+
+CronJobApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4165](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4165)
+
+___
+
+### cronJobControllerSearch
+
+▸ **cronJobControllerSearch**(`cronJobSearchInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CronJobOutputArrayDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputArrayDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Search
+
+**`Throws`**
+
+**`Memberof`**
+
+CronJobApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `cronJobSearchInputDTO?` | [`CronJobSearchInputDTO`](../interfaces/takaro_apiclient.CronJobSearchInputDTO.md) | CronJobSearchInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CronJobOutputArrayDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputArrayDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4179](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4179)
+
+___
+
+### cronJobControllerUpdate
+
+▸ **cronJobControllerUpdate**(`id`, `cronJobUpdateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Update
+
+**`Throws`**
+
+**`Memberof`**
+
+CronJobApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `cronJobUpdateDTO?` | [`CronJobUpdateDTO`](../interfaces/takaro_apiclient.CronJobUpdateDTO.md) | CronJobUpdateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4197](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4197)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.DomainApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.DomainApi.md
@@ -1,0 +1,238 @@
+---
+id: "takaro_apiclient.DomainApi"
+title: "Class: DomainApi"
+sidebar_label: "@takaro/apiclient.DomainApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).DomainApi
+
+DomainApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`DomainApi`**
+
+## Constructors
+
+### constructor
+
+• **new DomainApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### domainControllerCreate
+
+▸ **domainControllerCreate**(`body?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`DomainCreateOutputDTOAPI`](../interfaces/takaro_apiclient.DomainCreateOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Create
+
+**`Throws`**
+
+**`Memberof`**
+
+DomainApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `body?` | `any` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`DomainCreateOutputDTOAPI`](../interfaces/takaro_apiclient.DomainCreateOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4726](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4726)
+
+___
+
+### domainControllerGetOne
+
+▸ **domainControllerGetOne**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`DomainOutputDTOAPI`](../interfaces/takaro_apiclient.DomainOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+DomainApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`DomainOutputDTOAPI`](../interfaces/takaro_apiclient.DomainOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4740](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4740)
+
+___
+
+### domainControllerRemove
+
+▸ **domainControllerRemove**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Remove
+
+**`Throws`**
+
+**`Memberof`**
+
+DomainApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4754](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4754)
+
+___
+
+### domainControllerSearch
+
+▸ **domainControllerSearch**(`domainSearchInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`DomainOutputArrayDTOAPI`](../interfaces/takaro_apiclient.DomainOutputArrayDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Search
+
+**`Throws`**
+
+**`Memberof`**
+
+DomainApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `domainSearchInputDTO?` | [`DomainSearchInputDTO`](../interfaces/takaro_apiclient.DomainSearchInputDTO.md) | DomainSearchInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`DomainOutputArrayDTOAPI`](../interfaces/takaro_apiclient.DomainOutputArrayDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4768](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4768)
+
+___
+
+### domainControllerUpdate
+
+▸ **domainControllerUpdate**(`id`, `domainUpdateInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`DomainOutputDTOAPI`](../interfaces/takaro_apiclient.DomainOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Update
+
+**`Throws`**
+
+**`Memberof`**
+
+DomainApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `domainUpdateInputDTO?` | [`DomainUpdateInputDTO`](../interfaces/takaro_apiclient.DomainUpdateInputDTO.md) | DomainUpdateInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`DomainOutputDTOAPI`](../interfaces/takaro_apiclient.DomainOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4786](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4786)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.FunctionApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.FunctionApi.md
@@ -1,0 +1,238 @@
+---
+id: "takaro_apiclient.FunctionApi"
+title: "Class: FunctionApi"
+sidebar_label: "@takaro/apiclient.FunctionApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).FunctionApi
+
+FunctionApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`FunctionApi`**
+
+## Constructors
+
+### constructor
+
+• **new FunctionApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### functionControllerCreate
+
+▸ **functionControllerCreate**(`functionCreateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Create
+
+**`Throws`**
+
+**`Memberof`**
+
+FunctionApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `functionCreateDTO?` | [`FunctionCreateDTO`](../interfaces/takaro_apiclient.FunctionCreateDTO.md) | FunctionCreateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:5311](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L5311)
+
+___
+
+### functionControllerGetOne
+
+▸ **functionControllerGetOne**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+FunctionApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:5328](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L5328)
+
+___
+
+### functionControllerRemove
+
+▸ **functionControllerRemove**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Remove
+
+**`Throws`**
+
+**`Memberof`**
+
+FunctionApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:5342](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L5342)
+
+___
+
+### functionControllerSearch
+
+▸ **functionControllerSearch**(`functionSearchInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`FunctionOutputArrayDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputArrayDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Search
+
+**`Throws`**
+
+**`Memberof`**
+
+FunctionApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `functionSearchInputDTO?` | [`FunctionSearchInputDTO`](../interfaces/takaro_apiclient.FunctionSearchInputDTO.md) | FunctionSearchInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`FunctionOutputArrayDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputArrayDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:5356](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L5356)
+
+___
+
+### functionControllerUpdate
+
+▸ **functionControllerUpdate**(`id`, `functionUpdateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Update
+
+**`Throws`**
+
+**`Memberof`**
+
+FunctionApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `functionUpdateDTO?` | [`FunctionUpdateDTO`](../interfaces/takaro_apiclient.FunctionUpdateDTO.md) | FunctionUpdateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:5374](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L5374)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.GameServerApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.GameServerApi.md
@@ -1,0 +1,300 @@
+---
+id: "takaro_apiclient.GameServerApi"
+title: "Class: GameServerApi"
+sidebar_label: "@takaro/apiclient.GameServerApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GameServerApi
+
+GameServerApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`GameServerApi`**
+
+## Constructors
+
+### constructor
+
+• **new GameServerApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### gameServerControllerCreate
+
+▸ **gameServerControllerCreate**(`gameServerCreateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Create
+
+**`Throws`**
+
+**`Memberof`**
+
+GameServerApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `gameServerCreateDTO?` | [`GameServerCreateDTO`](../interfaces/takaro_apiclient.GameServerCreateDTO.md) | GameServerCreateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6087](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6087)
+
+___
+
+### gameServerControllerGetOne
+
+▸ **gameServerControllerGetOne**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+GameServerApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6104](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6104)
+
+___
+
+### gameServerControllerRemove
+
+▸ **gameServerControllerRemove**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Remove
+
+**`Throws`**
+
+**`Memberof`**
+
+GameServerApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6118](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6118)
+
+___
+
+### gameServerControllerSearch
+
+▸ **gameServerControllerSearch**(`gameServerSearchInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerOutputArrayDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputArrayDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Search
+
+**`Throws`**
+
+**`Memberof`**
+
+GameServerApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `gameServerSearchInputDTO?` | [`GameServerSearchInputDTO`](../interfaces/takaro_apiclient.GameServerSearchInputDTO.md) | GameServerSearchInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerOutputArrayDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputArrayDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6132](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6132)
+
+___
+
+### gameServerControllerTestReachability
+
+▸ **gameServerControllerTestReachability**(`gameServerTestReachabilityInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerTestReachabilityDTOAPI`](../interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Test reachability
+
+**`Throws`**
+
+**`Memberof`**
+
+GameServerApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `gameServerTestReachabilityInputDTO?` | [`GameServerTestReachabilityInputDTO`](../interfaces/takaro_apiclient.GameServerTestReachabilityInputDTO.md) | GameServerTestReachabilityInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerTestReachabilityDTOAPI`](../interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6149](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6149)
+
+___
+
+### gameServerControllerTestReachabilityForId
+
+▸ **gameServerControllerTestReachabilityForId**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerTestReachabilityDTOAPI`](../interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Test reachability for id
+
+**`Throws`**
+
+**`Memberof`**
+
+GameServerApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerTestReachabilityDTOAPI`](../interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6169](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6169)
+
+___
+
+### gameServerControllerUpdate
+
+▸ **gameServerControllerUpdate**(`id`, `gameServerUpdateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Update
+
+**`Throws`**
+
+**`Memberof`**
+
+GameServerApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `gameServerUpdateDTO?` | [`GameServerUpdateDTO`](../interfaces/takaro_apiclient.GameServerUpdateDTO.md) | GameServerUpdateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6187](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6187)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.HookApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.HookApi.md
@@ -1,0 +1,238 @@
+---
+id: "takaro_apiclient.HookApi"
+title: "Class: HookApi"
+sidebar_label: "@takaro/apiclient.HookApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).HookApi
+
+HookApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`HookApi`**
+
+## Constructors
+
+### constructor
+
+• **new HookApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### hookControllerCreate
+
+▸ **hookControllerCreate**(`hookCreateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Create
+
+**`Throws`**
+
+**`Memberof`**
+
+HookApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `hookCreateDTO?` | [`HookCreateDTO`](../interfaces/takaro_apiclient.HookCreateDTO.md) | HookCreateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6709](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6709)
+
+___
+
+### hookControllerGetOne
+
+▸ **hookControllerGetOne**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+HookApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6726](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6726)
+
+___
+
+### hookControllerRemove
+
+▸ **hookControllerRemove**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Remove
+
+**`Throws`**
+
+**`Memberof`**
+
+HookApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6740](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6740)
+
+___
+
+### hookControllerSearch
+
+▸ **hookControllerSearch**(`hookSearchInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`HookOutputArrayDTOAPI`](../interfaces/takaro_apiclient.HookOutputArrayDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Search
+
+**`Throws`**
+
+**`Memberof`**
+
+HookApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `hookSearchInputDTO?` | [`HookSearchInputDTO`](../interfaces/takaro_apiclient.HookSearchInputDTO.md) | HookSearchInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`HookOutputArrayDTOAPI`](../interfaces/takaro_apiclient.HookOutputArrayDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6754](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6754)
+
+___
+
+### hookControllerUpdate
+
+▸ **hookControllerUpdate**(`id`, `hookUpdateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Update
+
+**`Throws`**
+
+**`Memberof`**
+
+HookApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `hookUpdateDTO?` | [`HookUpdateDTO`](../interfaces/takaro_apiclient.HookUpdateDTO.md) | HookUpdateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6772](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6772)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.MetaApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.MetaApi.md
@@ -1,0 +1,172 @@
+---
+id: "takaro_apiclient.MetaApi"
+title: "Class: MetaApi"
+sidebar_label: "@takaro/apiclient.MetaApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).MetaApi
+
+MetaApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`MetaApi`**
+
+## Constructors
+
+### constructor
+
+• **new MetaApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### metaGetHealth
+
+▸ **metaGetHealth**(`options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`HealthOutputDTO`](../interfaces/takaro_apiclient.HealthOutputDTO.md), `any`\>\>
+
+**`Summary`**
+
+Get health
+
+**`Throws`**
+
+**`Memberof`**
+
+MetaApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`HealthOutputDTO`](../interfaces/takaro_apiclient.HealthOutputDTO.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7047](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7047)
+
+___
+
+### metaGetOpenApi
+
+▸ **metaGetOpenApi**(`options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<`void`, `any`\>\>
+
+**`Summary`**
+
+Get open api
+
+**`Throws`**
+
+**`Memberof`**
+
+MetaApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<`void`, `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7060](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7060)
+
+___
+
+### metaGetOpenApiHtml
+
+▸ **metaGetOpenApiHtml**(`options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<`void`, `any`\>\>
+
+**`Summary`**
+
+Get open api html
+
+**`Throws`**
+
+**`Memberof`**
+
+MetaApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<`void`, `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7073](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7073)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.ModuleApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.ModuleApi.md
@@ -1,0 +1,238 @@
+---
+id: "takaro_apiclient.ModuleApi"
+title: "Class: ModuleApi"
+sidebar_label: "@takaro/apiclient.ModuleApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ModuleApi
+
+ModuleApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`ModuleApi`**
+
+## Constructors
+
+### constructor
+
+• **new ModuleApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### moduleControllerCreate
+
+▸ **moduleControllerCreate**(`moduleCreateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Create
+
+**`Throws`**
+
+**`Memberof`**
+
+ModuleApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `moduleCreateDTO?` | [`ModuleCreateDTO`](../interfaces/takaro_apiclient.ModuleCreateDTO.md) | ModuleCreateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7591](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7591)
+
+___
+
+### moduleControllerGetOne
+
+▸ **moduleControllerGetOne**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+ModuleApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7608](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7608)
+
+___
+
+### moduleControllerRemove
+
+▸ **moduleControllerRemove**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Remove
+
+**`Throws`**
+
+**`Memberof`**
+
+ModuleApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7622](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7622)
+
+___
+
+### moduleControllerSearch
+
+▸ **moduleControllerSearch**(`moduleSearchInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`ModuleOutputArrayDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputArrayDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Search
+
+**`Throws`**
+
+**`Memberof`**
+
+ModuleApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `moduleSearchInputDTO?` | [`ModuleSearchInputDTO`](../interfaces/takaro_apiclient.ModuleSearchInputDTO.md) | ModuleSearchInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`ModuleOutputArrayDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputArrayDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7636](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7636)
+
+___
+
+### moduleControllerUpdate
+
+▸ **moduleControllerUpdate**(`id`, `moduleUpdateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Update
+
+**`Throws`**
+
+**`Memberof`**
+
+ModuleApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `moduleUpdateDTO?` | [`ModuleUpdateDTO`](../interfaces/takaro_apiclient.ModuleUpdateDTO.md) | ModuleUpdateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7654](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7654)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.PlayerApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.PlayerApi.md
@@ -1,0 +1,144 @@
+---
+id: "takaro_apiclient.PlayerApi"
+title: "Class: PlayerApi"
+sidebar_label: "@takaro/apiclient.PlayerApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).PlayerApi
+
+PlayerApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`PlayerApi`**
+
+## Constructors
+
+### constructor
+
+• **new PlayerApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### playerControllerGetOne
+
+▸ **playerControllerGetOne**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`PlayerOutputDTOAPI`](../interfaces/takaro_apiclient.PlayerOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+PlayerApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`PlayerOutputDTOAPI`](../interfaces/takaro_apiclient.PlayerOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7896](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7896)
+
+___
+
+### playerControllerSearch
+
+▸ **playerControllerSearch**(`playerSearchInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`PlayerOutputArrayDTOAPI`](../interfaces/takaro_apiclient.PlayerOutputArrayDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Search
+
+**`Throws`**
+
+**`Memberof`**
+
+PlayerApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `playerSearchInputDTO?` | [`PlayerSearchInputDTO`](../interfaces/takaro_apiclient.PlayerSearchInputDTO.md) | PlayerSearchInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`PlayerOutputArrayDTOAPI`](../interfaces/takaro_apiclient.PlayerOutputArrayDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7910](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7910)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.RoleApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.RoleApi.md
@@ -1,0 +1,238 @@
+---
+id: "takaro_apiclient.RoleApi"
+title: "Class: RoleApi"
+sidebar_label: "@takaro/apiclient.RoleApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).RoleApi
+
+RoleApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`RoleApi`**
+
+## Constructors
+
+### constructor
+
+• **new RoleApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### roleControllerCreate
+
+▸ **roleControllerCreate**(`roleCreateInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Create
+
+**`Throws`**
+
+**`Memberof`**
+
+RoleApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `roleCreateInputDTO?` | [`RoleCreateInputDTO`](../interfaces/takaro_apiclient.RoleCreateInputDTO.md) | RoleCreateInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8431](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8431)
+
+___
+
+### roleControllerGetOne
+
+▸ **roleControllerGetOne**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+RoleApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8448](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8448)
+
+___
+
+### roleControllerRemove
+
+▸ **roleControllerRemove**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Remove
+
+**`Throws`**
+
+**`Memberof`**
+
+RoleApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8462](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8462)
+
+___
+
+### roleControllerSearch
+
+▸ **roleControllerSearch**(`roleSearchInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`RoleOutputArrayDTOAPI`](../interfaces/takaro_apiclient.RoleOutputArrayDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Search
+
+**`Throws`**
+
+**`Memberof`**
+
+RoleApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `roleSearchInputDTO?` | [`RoleSearchInputDTO`](../interfaces/takaro_apiclient.RoleSearchInputDTO.md) | RoleSearchInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`RoleOutputArrayDTOAPI`](../interfaces/takaro_apiclient.RoleOutputArrayDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8476](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8476)
+
+___
+
+### roleControllerUpdate
+
+▸ **roleControllerUpdate**(`id`, `roleUpdateInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Update
+
+**`Throws`**
+
+**`Memberof`**
+
+RoleApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `roleUpdateInputDTO?` | [`RoleUpdateInputDTO`](../interfaces/takaro_apiclient.RoleUpdateInputDTO.md) | RoleUpdateInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8494](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8494)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.SettingsApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.SettingsApi.md
@@ -1,0 +1,178 @@
+---
+id: "takaro_apiclient.SettingsApi"
+title: "Class: SettingsApi"
+sidebar_label: "@takaro/apiclient.SettingsApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).SettingsApi
+
+SettingsApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`SettingsApi`**
+
+## Constructors
+
+### constructor
+
+• **new SettingsApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### settingsControllerGet
+
+▸ **settingsControllerGet**(`keys?`, `gameServerId?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`SettingsOutputObjectDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputObjectDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get
+
+**`Throws`**
+
+**`Memberof`**
+
+SettingsApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `keys?` | (``"commandPrefix"`` \| ``"serverChatName"``)[] |  |
+| `gameServerId?` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`SettingsOutputObjectDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputObjectDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8864](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8864)
+
+___
+
+### settingsControllerGetOne
+
+▸ **settingsControllerGetOne**(`key`, `gameServerId?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`SettingsOutputDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+SettingsApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `key` | `string` |  |
+| `gameServerId?` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`SettingsOutputDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8883](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8883)
+
+___
+
+### settingsControllerSet
+
+▸ **settingsControllerSet**(`key`, `settingsSetDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`SettingsOutputDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Set
+
+**`Throws`**
+
+**`Memberof`**
+
+SettingsApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `key` | `string` |  |
+| `settingsSetDTO?` | [`SettingsSetDTO`](../interfaces/takaro_apiclient.SettingsSetDTO.md) | SettingsSetDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`SettingsOutputDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8902](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8902)

--- a/packages/web-docs/docs/development/packages/classes/takaro_apiclient.UserApi.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_apiclient.UserApi.md
@@ -1,0 +1,393 @@
+---
+id: "takaro_apiclient.UserApi"
+title: "Class: UserApi"
+sidebar_label: "@takaro/apiclient.UserApi"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).UserApi
+
+UserApi - object-oriented interface
+
+**`Export`**
+
+## Hierarchy
+
+- `BaseAPI`
+
+  ↳ **`UserApi`**
+
+## Constructors
+
+### constructor
+
+• **new UserApi**(`configuration?`, `basePath?`, `axios?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `configuration?` | `Configuration` | `undefined` |
+| `basePath` | `string` | `BASE_PATH` |
+| `axios` | `AxiosInstance` | `globalAxios` |
+
+#### Inherited from
+
+BaseAPI.constructor
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L55)
+
+## Properties
+
+### axios
+
+• `Protected` **axios**: `AxiosInstance` = `globalAxios`
+
+#### Inherited from
+
+BaseAPI.axios
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L58)
+
+___
+
+### basePath
+
+• `Protected` **basePath**: `string` = `BASE_PATH`
+
+#### Inherited from
+
+BaseAPI.basePath
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L57)
+
+___
+
+### configuration
+
+• `Protected` **configuration**: `undefined` \| `Configuration`
+
+#### Inherited from
+
+BaseAPI.configuration
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/base.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/base.ts#L53)
+
+## Methods
+
+### userControllerAssignRole
+
+▸ **userControllerAssignRole**(`id`, `roleId`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Assign role
+
+**`Throws`**
+
+**`Memberof`**
+
+UserApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `roleId` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9854](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9854)
+
+___
+
+### userControllerCreate
+
+▸ **userControllerCreate**(`userCreateInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Create
+
+**`Throws`**
+
+**`Memberof`**
+
+UserApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `userCreateInputDTO?` | [`UserCreateInputDTO`](../interfaces/takaro_apiclient.UserCreateInputDTO.md) | UserCreateInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9872](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9872)
+
+___
+
+### userControllerGetOne
+
+▸ **userControllerGetOne**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Get one
+
+**`Throws`**
+
+**`Memberof`**
+
+UserApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9889](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9889)
+
+___
+
+### userControllerLogin
+
+▸ **userControllerLogin**(`loginDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`LoginOutputDTOAPI`](../interfaces/takaro_apiclient.LoginOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Login
+
+**`Throws`**
+
+**`Memberof`**
+
+UserApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `loginDTO?` | [`LoginDTO`](../interfaces/takaro_apiclient.LoginDTO.md) | LoginDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`LoginOutputDTOAPI`](../interfaces/takaro_apiclient.LoginOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9903](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9903)
+
+___
+
+### userControllerLogout
+
+▸ **userControllerLogout**(`options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Logout
+
+**`Throws`**
+
+**`Memberof`**
+
+UserApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9919](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9919)
+
+___
+
+### userControllerMe
+
+▸ **userControllerMe**(`options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Me
+
+**`Throws`**
+
+**`Memberof`**
+
+UserApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9932](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9932)
+
+___
+
+### userControllerRemove
+
+▸ **userControllerRemove**(`id`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Remove
+
+**`Throws`**
+
+**`Memberof`**
+
+UserApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9946](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9946)
+
+___
+
+### userControllerRemoveRole
+
+▸ **userControllerRemoveRole**(`id`, `roleId`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+**`Summary`**
+
+Remove role
+
+**`Throws`**
+
+**`Memberof`**
+
+UserApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `roleId` | `string` |  |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9961](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9961)
+
+___
+
+### userControllerSearch
+
+▸ **userControllerSearch**(`userSearchInputDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`UserOutputArrayDTOAPI`](../interfaces/takaro_apiclient.UserOutputArrayDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Search
+
+**`Throws`**
+
+**`Memberof`**
+
+UserApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `userSearchInputDTO?` | [`UserSearchInputDTO`](../interfaces/takaro_apiclient.UserSearchInputDTO.md) | UserSearchInputDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`UserOutputArrayDTOAPI`](../interfaces/takaro_apiclient.UserOutputArrayDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9979](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9979)
+
+___
+
+### userControllerUpdate
+
+▸ **userControllerUpdate**(`id`, `userUpdateDTO?`, `options?`): `Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md), `any`\>\>
+
+**`Summary`**
+
+Update
+
+**`Throws`**
+
+**`Memberof`**
+
+UserApi
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `id` | `string` |  |
+| `userUpdateDTO?` | [`UserUpdateDTO`](../interfaces/takaro_apiclient.UserUpdateDTO.md) | UserUpdateDTO |
+| `options?` | `AxiosRequestConfig`<`any`\> | Override http request option. |
+
+#### Returns
+
+`Promise`<[`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md), `any`\>\>
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9997](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9997)

--- a/packages/web-docs/docs/development/packages/classes/takaro_config.Config.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_config.Config.md
@@ -1,0 +1,106 @@
+---
+id: "takaro_config.Config"
+title: "Class: Config<T>"
+sidebar_label: "@takaro/config.Config"
+custom_edit_url: null
+---
+
+[@takaro/config](../modules/takaro_config.md).Config
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends [`IBaseConfig`](../interfaces/takaro_config.IBaseConfig.md) |
+
+## Constructors
+
+### constructor
+
+• **new Config**<`T`\>(`valuesArray?`)
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends [`IBaseConfig`](../interfaces/takaro_config.IBaseConfig.md) |
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `valuesArray` | `Schema`<`Partial`<`T`\>\>[] | `[]` |
+
+#### Defined in
+
+[packages/lib-config/src/main.ts:30](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-config/src/main.ts#L30)
+
+## Properties
+
+### \_config
+
+• **\_config**: `Config`<`T`\>
+
+#### Defined in
+
+[packages/lib-config/src/main.ts:28](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-config/src/main.ts#L28)
+
+## Methods
+
+### get
+
+▸ **get**<`K`\>(`arg`): `K` extends `undefined` \| ``null`` ? `T` : `K` extends `Path`<`T`\> ? `PathValue`<`T`, `K`\> : `never`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `K` | extends `string` \| `number` \| `symbol` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `arg` | `K` |
+
+#### Returns
+
+`K` extends `undefined` \| ``null`` ? `T` : `K` extends `Path`<`T`\> ? `PathValue`<`T`, `K`\> : `never`
+
+#### Defined in
+
+[packages/lib-config/src/main.ts:39](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-config/src/main.ts#L39)
+
+___
+
+### load
+
+▸ **load**(`data`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Partial`<`T`\> |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-config/src/main.ts:49](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-config/src/main.ts#L49)
+
+___
+
+### validate
+
+▸ **validate**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-config/src/main.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-config/src/main.ts#L53)

--- a/packages/web-docs/docs/development/packages/classes/takaro_db.ITakaroQuery.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_db.ITakaroQuery.md
@@ -1,0 +1,86 @@
+---
+id: "takaro_db.ITakaroQuery"
+title: "Class: ITakaroQuery<T>"
+sidebar_label: "@takaro/db.ITakaroQuery"
+custom_edit_url: null
+---
+
+[@takaro/db](../modules/takaro_db.md).ITakaroQuery
+
+## Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+## Constructors
+
+### constructor
+
+• **new ITakaroQuery**<`T`\>()
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:33](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L33)
+
+___
+
+### filters
+
+• `Optional` **filters**: { [key in string \| number \| symbol]?: unknown }
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L10)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L20)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L16)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `Extract`<keyof `T`, `string`\>
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:24](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L24)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: `SortDirection`
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:29](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L29)

--- a/packages/web-docs/docs/development/packages/classes/takaro_db.QueryBuilder.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_db.QueryBuilder.md
@@ -1,0 +1,126 @@
+---
+id: "takaro_db.QueryBuilder"
+title: "Class: QueryBuilder<Model, OutputDTO>"
+sidebar_label: "@takaro/db.QueryBuilder"
+custom_edit_url: null
+---
+
+[@takaro/db](../modules/takaro_db.md).QueryBuilder
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Model` | extends `ObjectionModel` |
+| `OutputDTO` | `OutputDTO` |
+
+## Constructors
+
+### constructor
+
+• **new QueryBuilder**<`Model`, `OutputDTO`\>(`query?`)
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Model` | extends `Model`<`Model`\> |
+| `OutputDTO` | `OutputDTO` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `query` | [`ITakaroQuery`](takaro_db.ITakaroQuery.md)<`OutputDTO`\> |
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:42](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L42)
+
+## Properties
+
+### query
+
+• `Private` `Readonly` **query**: [`ITakaroQuery`](takaro_db.ITakaroQuery.md)<`OutputDTO`\>
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:43](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L43)
+
+## Methods
+
+### build
+
+▸ **build**(`query`): `QueryBuilder`<`Model`, `Page`<`Model`\>\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `query` | `QueryBuilder`<`Model`, `Model`[]\> |
+
+#### Returns
+
+`QueryBuilder`<`Model`, `Page`<`Model`\>\>
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:46](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L46)
+
+___
+
+### filters
+
+▸ `Private` **filters**(`tableName`): `Record`<`string`, `unknown`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `tableName` | `string` |
+
+#### Returns
+
+`Record`<`string`, `unknown`\>
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:67](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L67)
+
+___
+
+### pagination
+
+▸ `Private` **pagination**(): `Object`
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `limit` | `number` |
+| `page` | `number` |
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:95](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L95)
+
+___
+
+### sorting
+
+▸ `Private` **sorting**(): `Object`
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `sortBy` | `string` |
+| `sortDirection` | `SortDirection` |
+
+#### Defined in
+
+[packages/lib-db/src/queryBuilder.ts:82](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/queryBuilder.ts#L82)

--- a/packages/web-docs/docs/development/packages/classes/takaro_db.TakaroModel.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_db.TakaroModel.md
@@ -1,0 +1,2206 @@
+---
+id: "takaro_db.TakaroModel"
+title: "Class: TakaroModel"
+sidebar_label: "@takaro/db.TakaroModel"
+custom_edit_url: null
+---
+
+[@takaro/db](../modules/takaro_db.md).TakaroModel
+
+## Hierarchy
+
+- `Model`
+
+  ↳ **`TakaroModel`**
+
+## Constructors
+
+### constructor
+
+• **new TakaroModel**()
+
+#### Inherited from
+
+Model.constructor
+
+## Properties
+
+### $modelClass
+
+• **$modelClass**: `ModelClass`<[`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Inherited from
+
+Model.$modelClass
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1533
+
+___
+
+### QueryBuilderType
+
+• **QueryBuilderType**: `QueryBuilder`<[`TakaroModel`](takaro_db.TakaroModel.md), [`TakaroModel`](takaro_db.TakaroModel.md)[]\>
+
+#### Inherited from
+
+Model.QueryBuilderType
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1603
+
+___
+
+### createdAt
+
+• **createdAt**: `string`
+
+#### Defined in
+
+[packages/lib-db/src/TakaroModel.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/TakaroModel.ts#L5)
+
+___
+
+### id
+
+• **id**: `string`
+
+#### Defined in
+
+[packages/lib-db/src/TakaroModel.ts:4](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/TakaroModel.ts#L4)
+
+___
+
+### updatedAt
+
+• **updatedAt**: `string`
+
+#### Defined in
+
+[packages/lib-db/src/TakaroModel.ts:6](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/TakaroModel.ts#L6)
+
+___
+
+### BelongsToOneRelation
+
+▪ `Static` **BelongsToOneRelation**: `RelationType`
+
+#### Inherited from
+
+Model.BelongsToOneRelation
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1447
+
+___
+
+### HasManyRelation
+
+▪ `Static` **HasManyRelation**: `RelationType`
+
+#### Inherited from
+
+Model.HasManyRelation
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1449
+
+___
+
+### HasOneRelation
+
+▪ `Static` **HasOneRelation**: `RelationType`
+
+#### Inherited from
+
+Model.HasOneRelation
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1448
+
+___
+
+### HasOneThroughRelation
+
+▪ `Static` **HasOneThroughRelation**: `RelationType`
+
+#### Inherited from
+
+Model.HasOneThroughRelation
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1451
+
+___
+
+### ManyToManyRelation
+
+▪ `Static` **ManyToManyRelation**: `RelationType`
+
+#### Inherited from
+
+Model.ManyToManyRelation
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1450
+
+___
+
+### QueryBuilder
+
+▪ `Static` **QueryBuilder**: typeof `QueryBuilder`
+
+#### Inherited from
+
+Model.QueryBuilder
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1423
+
+___
+
+### columnNameMappers
+
+▪ `Static` **columnNameMappers**: `ColumnNameMappers`
+
+#### Inherited from
+
+Model.columnNameMappers
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1441
+
+___
+
+### dbRefProp
+
+▪ `Static` **dbRefProp**: `string`
+
+#### Inherited from
+
+Model.dbRefProp
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1434
+
+___
+
+### defaultGraphOptions
+
+▪ `Static` `Optional` **defaultGraphOptions**: `GraphOptions`
+
+#### Inherited from
+
+Model.defaultGraphOptions
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1453
+
+___
+
+### fn
+
+▪ `Static` **fn**: `FunctionFunction`
+
+#### Inherited from
+
+Model.fn
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1445
+
+___
+
+### jsonAttributes
+
+▪ `Static` **jsonAttributes**: `string`[]
+
+#### Inherited from
+
+Model.jsonAttributes
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1430
+
+___
+
+### jsonSchema
+
+▪ `Static` **jsonSchema**: `JSONSchema`
+
+#### Inherited from
+
+Model.jsonSchema
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1427
+
+___
+
+### modelPaths
+
+▪ `Static` **modelPaths**: `string`[]
+
+#### Inherited from
+
+Model.modelPaths
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1429
+
+___
+
+### modifiers
+
+▪ `Static` **modifiers**: `Modifiers`<`AnyQueryBuilder`\>
+
+#### Inherited from
+
+Model.modifiers
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1440
+
+___
+
+### pickJsonSchemaProperties
+
+▪ `Static` **pickJsonSchemaProperties**: `boolean`
+
+#### Inherited from
+
+Model.pickJsonSchemaProperties
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1436
+
+___
+
+### propRefRegex
+
+▪ `Static` **propRefRegex**: `RegExp`
+
+#### Inherited from
+
+Model.propRefRegex
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1435
+
+___
+
+### raw
+
+▪ `Static` **raw**: `RawFunction`
+
+#### Inherited from
+
+Model.raw
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1443
+
+___
+
+### ref
+
+▪ `Static` **ref**: `ReferenceFunction`
+
+#### Inherited from
+
+Model.ref
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1444
+
+___
+
+### relatedFindQueryMutates
+
+▪ `Static` **relatedFindQueryMutates**: `boolean`
+
+#### Inherited from
+
+Model.relatedFindQueryMutates
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1437
+
+___
+
+### relatedInsertQueryMutates
+
+▪ `Static` **relatedInsertQueryMutates**: `boolean`
+
+#### Inherited from
+
+Model.relatedInsertQueryMutates
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1438
+
+___
+
+### relationMappings
+
+▪ `Static` **relationMappings**: `RelationMappings` \| `RelationMappingsThunk`
+
+#### Inherited from
+
+Model.relationMappings
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1428
+
+___
+
+### tableName
+
+▪ `Static` **tableName**: `string`
+
+#### Inherited from
+
+Model.tableName
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1425
+
+___
+
+### uidProp
+
+▪ `Static` **uidProp**: `string`
+
+#### Inherited from
+
+Model.uidProp
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1432
+
+___
+
+### uidRefProp
+
+▪ `Static` **uidRefProp**: `string`
+
+#### Inherited from
+
+Model.uidRefProp
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1433
+
+___
+
+### useLimitInFirst
+
+▪ `Static` **useLimitInFirst**: `boolean`
+
+#### Inherited from
+
+Model.useLimitInFirst
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1439
+
+___
+
+### virtualAttributes
+
+▪ `Static` **virtualAttributes**: `string`[]
+
+#### Inherited from
+
+Model.virtualAttributes
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1431
+
+## Accessors
+
+### idColumn
+
+• `Static` `get` **idColumn**(): `string`
+
+#### Returns
+
+`string`
+
+#### Overrides
+
+Model.idColumn
+
+#### Defined in
+
+[packages/lib-db/src/TakaroModel.ts:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/TakaroModel.ts#L8)
+
+## Methods
+
+### $afterDelete
+
+▸ **$afterDelete**(`queryContext`): `void` \| `Promise`<`any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `queryContext` | `QueryContext` |
+
+#### Returns
+
+`void` \| `Promise`<`any`\>
+
+#### Inherited from
+
+Model.$afterDelete
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1572
+
+___
+
+### $afterFind
+
+▸ **$afterFind**(`queryContext`): `void` \| `Promise`<`any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `queryContext` | `QueryContext` |
+
+#### Returns
+
+`void` \| `Promise`<`any`\>
+
+#### Inherited from
+
+Model.$afterFind
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1570
+
+___
+
+### $afterGet
+
+▸ **$afterGet**(`queryContext`): `void` \| `Promise`<`any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `queryContext` | `QueryContext` |
+
+#### Returns
+
+`void` \| `Promise`<`any`\>
+
+#### Inherited from
+
+Model.$afterGet
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1569
+
+___
+
+### $afterInsert
+
+▸ **$afterInsert**(`queryContext`): `void` \| `Promise`<`any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `queryContext` | `QueryContext` |
+
+#### Returns
+
+`void` \| `Promise`<`any`\>
+
+#### Inherited from
+
+Model.$afterInsert
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1566
+
+___
+
+### $afterUpdate
+
+▸ **$afterUpdate**(`opt`, `queryContext`): `void` \| `Promise`<`any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opt` | `ModelOptions` |
+| `queryContext` | `QueryContext` |
+
+#### Returns
+
+`void` \| `Promise`<`any`\>
+
+#### Inherited from
+
+Model.$afterUpdate
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1567
+
+___
+
+### $afterValidate
+
+▸ **$afterValidate**(`json`, `opt`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `json` | `Pojo` |
+| `opt` | `ModelOptions` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Model.$afterValidate
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1563
+
+___
+
+### $appendRelated
+
+▸ **$appendRelated**<`RM`\>(`relation`, `related`): [`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `RM` | extends `Model`<`RM`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `relation` | `String` \| `Relation` |
+| `related` | `undefined` \| ``null`` \| `RM` \| `RM`[] |
+
+#### Returns
+
+[`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Inherited from
+
+Model.$appendRelated
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1586
+
+___
+
+### $beforeDelete
+
+▸ **$beforeDelete**(`queryContext`): `void` \| `Promise`<`any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `queryContext` | `QueryContext` |
+
+#### Returns
+
+`void` \| `Promise`<`any`\>
+
+#### Inherited from
+
+Model.$beforeDelete
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1571
+
+___
+
+### $beforeInsert
+
+▸ **$beforeInsert**(): `void`
+
+#### Returns
+
+`void`
+
+#### Overrides
+
+Model.$beforeInsert
+
+#### Defined in
+
+[packages/lib-db/src/TakaroModel.ts:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/TakaroModel.ts#L12)
+
+___
+
+### $beforeUpdate
+
+▸ **$beforeUpdate**(): `void`
+
+#### Returns
+
+`void`
+
+#### Overrides
+
+Model.$beforeUpdate
+
+#### Defined in
+
+[packages/lib-db/src/TakaroModel.ts:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/TakaroModel.ts#L16)
+
+___
+
+### $beforeValidate
+
+▸ **$beforeValidate**(`jsonSchema`, `json`, `opt`): `JSONSchema`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `jsonSchema` | `JSONSchema` |
+| `json` | `Pojo` |
+| `opt` | `ModelOptions` |
+
+#### Returns
+
+`JSONSchema`
+
+#### Inherited from
+
+Model.$beforeValidate
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1561
+
+___
+
+### $clone
+
+▸ **$clone**(`opt?`): [`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opt?` | `CloneOptions` |
+
+#### Returns
+
+[`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Inherited from
+
+Model.$clone
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1594
+
+___
+
+### $fetchGraph
+
+▸ **$fetchGraph**(`expression`, `options?`): `QueryBuilder`<[`TakaroModel`](takaro_db.TakaroModel.md), [`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `expression` | `RelationExpression`<`M`\> |
+| `options?` | `FetchGraphOptions` |
+
+#### Returns
+
+`QueryBuilder`<[`TakaroModel`](takaro_db.TakaroModel.md), [`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Inherited from
+
+Model.$fetchGraph
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1550
+
+___
+
+### $formatDatabaseJson
+
+▸ **$formatDatabaseJson**(`json`): `Pojo`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `json` | `Pojo` |
+
+#### Returns
+
+`Pojo`
+
+#### Inherited from
+
+Model.$formatDatabaseJson
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1555
+
+___
+
+### $formatJson
+
+▸ **$formatJson**(`json`): `Pojo`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `json` | `Pojo` |
+
+#### Returns
+
+`Pojo`
+
+#### Inherited from
+
+Model.$formatJson
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1558
+
+___
+
+### $id
+
+▸ **$id**(`id`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `any` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Model.$id
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1547
+
+▸ **$id**(): `any`
+
+#### Returns
+
+`any`
+
+#### Inherited from
+
+Model.$id
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1548
+
+___
+
+### $knex
+
+▸ **$knex**(): `Knex`<`any`, `any`[]\>
+
+#### Returns
+
+`Knex`<`any`, `any`[]\>
+
+#### Inherited from
+
+Model.$knex
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1600
+
+___
+
+### $omit
+
+▸ **$omit**(`keys`): [`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `keys` | `string` \| `string`[] \| { `[key: string]`: `boolean`;  } |
+
+#### Returns
+
+[`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Inherited from
+
+Model.$omit
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1592
+
+___
+
+### $parseDatabaseJson
+
+▸ **$parseDatabaseJson**(`json`): `Pojo`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `json` | `Pojo` |
+
+#### Returns
+
+`Pojo`
+
+#### Inherited from
+
+Model.$parseDatabaseJson
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1556
+
+___
+
+### $parseJson
+
+▸ **$parseJson**(`json`, `opt?`): `Pojo`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `json` | `Pojo` |
+| `opt?` | `ModelOptions` |
+
+#### Returns
+
+`Pojo`
+
+#### Inherited from
+
+Model.$parseJson
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1559
+
+___
+
+### $pick
+
+▸ **$pick**(`keys`): [`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `keys` | `string` \| `string`[] \| { `[key: string]`: `boolean`;  } |
+
+#### Returns
+
+[`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Inherited from
+
+Model.$pick
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1593
+
+___
+
+### $query
+
+▸ **$query**(`trxOrKnex?`): `QueryBuilder`<[`TakaroModel`](takaro_db.TakaroModel.md), [`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `trxOrKnex?` | `TransactionOrKnex` |
+
+#### Returns
+
+`QueryBuilder`<[`TakaroModel`](takaro_db.TakaroModel.md), [`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Inherited from
+
+Model.$query
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1545
+
+___
+
+### $relatedQuery
+
+▸ **$relatedQuery**<`K`\>(`relationName`, `trxOrKnex?`): `RelatedQueryBuilder`<[`TakaroModel`](takaro_db.TakaroModel.md)[`K`]\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `K` | extends keyof [`TakaroModel`](takaro_db.TakaroModel.md) |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `relationName` | `K` |
+| `trxOrKnex?` | `TransactionOrKnex` |
+
+#### Returns
+
+`RelatedQueryBuilder`<[`TakaroModel`](takaro_db.TakaroModel.md)[`K`]\>
+
+#### Inherited from
+
+Model.$relatedQuery
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1535
+
+▸ **$relatedQuery**<`RM`\>(`relationName`, `trxOrKnex?`): `QueryBuilderType`<`RM`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `RM` | extends `Model`<`RM`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `relationName` | `string` |
+| `trxOrKnex?` | `TransactionOrKnex` |
+
+#### Returns
+
+`QueryBuilderType`<`RM`\>
+
+#### Inherited from
+
+Model.$relatedQuery
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1540
+
+___
+
+### $set
+
+▸ **$set**(`obj`): [`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `obj` | `Pojo` |
+
+#### Returns
+
+[`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Inherited from
+
+Model.$set
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1591
+
+___
+
+### $setDatabaseJson
+
+▸ **$setDatabaseJson**(`json`): [`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `json` | `object` |
+
+#### Returns
+
+[`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Inherited from
+
+Model.$setDatabaseJson
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1579
+
+___
+
+### $setJson
+
+▸ **$setJson**(`json`, `opt?`): [`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `json` | `object` |
+| `opt?` | `ModelOptions` |
+
+#### Returns
+
+[`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Inherited from
+
+Model.$setJson
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1578
+
+___
+
+### $setRelated
+
+▸ **$setRelated**<`RM`\>(`relation`, `related`): [`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `RM` | extends `Model`<`RM`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `relation` | `String` \| `Relation` |
+| `related` | `undefined` \| ``null`` \| `RM` \| `RM`[] |
+
+#### Returns
+
+[`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Inherited from
+
+Model.$setRelated
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1581
+
+___
+
+### $toDatabaseJson
+
+▸ **$toDatabaseJson**(): `Pojo`
+
+#### Returns
+
+`Pojo`
+
+#### Inherited from
+
+Model.$toDatabaseJson
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1574
+
+___
+
+### $toJson
+
+▸ **$toJson**(`opt?`): `ModelObject`<[`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opt?` | `ToJsonOptions` |
+
+#### Returns
+
+`ModelObject`<[`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Inherited from
+
+Model.$toJson
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1575
+
+___
+
+### $transaction
+
+▸ **$transaction**(): `Knex`<`any`, `any`[]\>
+
+#### Returns
+
+`Knex`<`any`, `any`[]\>
+
+#### Inherited from
+
+Model.$transaction
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1601
+
+___
+
+### $traverse
+
+▸ **$traverse**(`filterConstructor`, `traverser`): [`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `filterConstructor` | typeof `Model` |
+| `traverser` | `TraverserFunction` |
+
+#### Returns
+
+[`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Inherited from
+
+Model.$traverse
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1595
+
+▸ **$traverse**(`traverser`): [`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `traverser` | `TraverserFunction` |
+
+#### Returns
+
+[`TakaroModel`](takaro_db.TakaroModel.md)
+
+#### Inherited from
+
+Model.$traverse
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1596
+
+___
+
+### $traverseAsync
+
+▸ **$traverseAsync**(`filterConstructor`, `traverser`): `Promise`<[`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `filterConstructor` | typeof `Model` |
+| `traverser` | `TraverserFunction` |
+
+#### Returns
+
+`Promise`<[`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Inherited from
+
+Model.$traverseAsync
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1597
+
+▸ **$traverseAsync**(`traverser`): `Promise`<[`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `traverser` | `TraverserFunction` |
+
+#### Returns
+
+`Promise`<[`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Inherited from
+
+Model.$traverseAsync
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1598
+
+___
+
+### $validate
+
+▸ **$validate**(`json?`, `opt?`): `Pojo`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `json?` | `Pojo` |
+| `opt?` | `ModelOptions` |
+
+#### Returns
+
+`Pojo`
+
+#### Inherited from
+
+Model.$validate
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1562
+
+___
+
+### toJSON
+
+▸ **toJSON**(`opt?`): `ModelObject`<[`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opt?` | `ToJsonOptions` |
+
+#### Returns
+
+`ModelObject`<[`TakaroModel`](takaro_db.TakaroModel.md)\>
+
+#### Inherited from
+
+Model.toJSON
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1576
+
+___
+
+### afterDelete
+
+▸ `Static` **afterDelete**(`args`): `any`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `StaticHookArguments`<`any`, `any`\> |
+
+#### Returns
+
+`any`
+
+#### Inherited from
+
+Model.afterDelete
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1531
+
+___
+
+### afterFind
+
+▸ `Static` **afterFind**(`args`): `any`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `StaticHookArguments`<`any`, `any`\> |
+
+#### Returns
+
+`any`
+
+#### Inherited from
+
+Model.afterFind
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1525
+
+___
+
+### afterInsert
+
+▸ `Static` **afterInsert**(`args`): `any`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `StaticHookArguments`<`any`, `any`\> |
+
+#### Returns
+
+`any`
+
+#### Inherited from
+
+Model.afterInsert
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1527
+
+___
+
+### afterUpdate
+
+▸ `Static` **afterUpdate**(`args`): `any`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `StaticHookArguments`<`any`, `any`\> |
+
+#### Returns
+
+`any`
+
+#### Inherited from
+
+Model.afterUpdate
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1529
+
+___
+
+### beforeDelete
+
+▸ `Static` **beforeDelete**(`args`): `any`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `StaticHookArguments`<`any`, `any`\> |
+
+#### Returns
+
+`any`
+
+#### Inherited from
+
+Model.beforeDelete
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1530
+
+___
+
+### beforeFind
+
+▸ `Static` **beforeFind**(`args`): `any`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `StaticHookArguments`<`any`, `any`\> |
+
+#### Returns
+
+`any`
+
+#### Inherited from
+
+Model.beforeFind
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1524
+
+___
+
+### beforeInsert
+
+▸ `Static` **beforeInsert**(`args`): `any`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `StaticHookArguments`<`any`, `any`\> |
+
+#### Returns
+
+`any`
+
+#### Inherited from
+
+Model.beforeInsert
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1526
+
+___
+
+### beforeUpdate
+
+▸ `Static` **beforeUpdate**(`args`): `any`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `StaticHookArguments`<`any`, `any`\> |
+
+#### Returns
+
+`any`
+
+#### Inherited from
+
+Model.beforeUpdate
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1528
+
+___
+
+### bindKnex
+
+▸ `Static` **bindKnex**<`M`\>(`this`, `trxOrKnex`): `M`
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `M` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | `M` |
+| `trxOrKnex` | `TransactionOrKnex` |
+
+#### Returns
+
+`M`
+
+#### Inherited from
+
+Model.bindKnex
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1491
+
+___
+
+### bindTransaction
+
+▸ `Static` **bindTransaction**<`M`\>(`this`, `trxOrKnex`): `M`
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `M` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | `M` |
+| `trxOrKnex` | `TransactionOrKnex` |
+
+#### Returns
+
+`M`
+
+#### Inherited from
+
+Model.bindTransaction
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1492
+
+___
+
+### createNotFoundError
+
+▸ `Static` **createNotFoundError**(`queryContext`, `args`): `Error`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `queryContext` | `QueryContext` |
+| `args` | `CreateNotFoundErrorArgs` |
+
+#### Returns
+
+`Error`
+
+#### Inherited from
+
+Model.createNotFoundError
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1476
+
+___
+
+### createValidationError
+
+▸ `Static` **createValidationError**(`args`): `Error`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `args` | `CreateValidationErrorArgs` |
+
+#### Returns
+
+`Error`
+
+#### Inherited from
+
+Model.createValidationError
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1475
+
+___
+
+### createValidator
+
+▸ `Static` **createValidator**(): `Validator`
+
+#### Returns
+
+`Validator`
+
+#### Inherited from
+
+Model.createValidator
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1474
+
+___
+
+### fetchGraph
+
+▸ `Static` **fetchGraph**<`M`\>(`this`, `modelOrObject`, `expression`, `options?`): `SingleQueryBuilder`<`QueryBuilderType`<`M`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `M` | extends `Model`<`M`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | `Constructor`<`M`\> |
+| `modelOrObject` | `PartialModelObject`<`M`\> |
+| `expression` | `RelationExpression`<`M`\> |
+| `options?` | `FetchGraphOptions` |
+
+#### Returns
+
+`SingleQueryBuilder`<`QueryBuilderType`<`M`\>\>
+
+#### Inherited from
+
+Model.fetchGraph
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1494
+
+▸ `Static` **fetchGraph**<`M`\>(`this`, `modelOrObject`, `expression`, `options?`): `QueryBuilderType`<`M`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `M` | extends `Model`<`M`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | `Constructor`<`M`\> |
+| `modelOrObject` | `PartialModelObject`<`M`\>[] |
+| `expression` | `RelationExpression`<`M`\> |
+| `options?` | `FetchGraphOptions` |
+
+#### Returns
+
+`QueryBuilderType`<`M`\>
+
+#### Inherited from
+
+Model.fetchGraph
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1501
+
+___
+
+### fetchTableMetadata
+
+▸ `Static` **fetchTableMetadata**(`opt?`): `Promise`<`TableMetadata`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opt?` | `FetchTableMetadataOptions` |
+
+#### Returns
+
+`Promise`<`TableMetadata`\>
+
+#### Inherited from
+
+Model.fetchTableMetadata
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1479
+
+___
+
+### fromDatabaseJson
+
+▸ `Static` **fromDatabaseJson**<`M`\>(`this`, `json`): `M`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `M` | extends `Model`<`M`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | `Constructor`<`M`\> |
+| `json` | `object` |
+
+#### Returns
+
+`M`
+
+#### Inherited from
+
+Model.fromDatabaseJson
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1472
+
+___
+
+### fromJson
+
+▸ `Static` **fromJson**<`M`\>(`this`, `json`, `opt?`): `M`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `M` | extends `Model`<`M`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | `Constructor`<`M`\> |
+| `json` | `object` |
+| `opt?` | `ModelOptions` |
+
+#### Returns
+
+`M`
+
+#### Inherited from
+
+Model.fromJson
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1471
+
+___
+
+### getRelation
+
+▸ `Static` **getRelation**(`name`): `Relation`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+
+#### Returns
+
+`Relation`
+
+#### Inherited from
+
+Model.getRelation
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1509
+
+___
+
+### getRelations
+
+▸ `Static` **getRelations**(): `Relations`
+
+#### Returns
+
+`Relations`
+
+#### Inherited from
+
+Model.getRelations
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1508
+
+___
+
+### knex
+
+▸ `Static` **knex**(`knex?`): `Knex`<`any`, `any`[]\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `knex?` | `Knex`<`any`, `any`[]\> |
+
+#### Returns
+
+`Knex`<`any`, `any`[]\>
+
+#### Inherited from
+
+Model.knex
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1481
+
+___
+
+### knexQuery
+
+▸ `Static` **knexQuery**(): `QueryBuilder`<`any`, `any`\>
+
+#### Returns
+
+`QueryBuilder`<`any`, `any`\>
+
+#### Inherited from
+
+Model.knexQuery
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1482
+
+___
+
+### query
+
+▸ `Static` **query**<`M`\>(`this`, `trxOrKnex?`): `QueryBuilderType`<`M`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `M` | extends `Model`<`M`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | `Constructor`<`M`\> |
+| `trxOrKnex?` | `TransactionOrKnex` |
+
+#### Returns
+
+`QueryBuilderType`<`M`\>
+
+#### Inherited from
+
+Model.query
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1455
+
+___
+
+### relatedQuery
+
+▸ `Static` **relatedQuery**<`M`, `K`\>(`this`, `relationName`, `trxOrKnex?`): `ArrayRelatedQueryBuilder`<`M`[`K`]\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `M` | extends `Model`<`M`\> |
+| `K` | extends `string` \| `number` \| `symbol` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | `Constructor`<`M`\> |
+| `relationName` | `K` |
+| `trxOrKnex?` | `TransactionOrKnex` |
+
+#### Returns
+
+`ArrayRelatedQueryBuilder`<`M`[`K`]\>
+
+#### Inherited from
+
+Model.relatedQuery
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1460
+
+▸ `Static` **relatedQuery**<`RM`\>(`relationName`, `trxOrKnex?`): `QueryBuilderType`<`RM`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `RM` | extends `Model`<`RM`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `relationName` | `string` |
+| `trxOrKnex?` | `TransactionOrKnex` |
+
+#### Returns
+
+`QueryBuilderType`<`RM`\>
+
+#### Inherited from
+
+Model.relatedQuery
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1466
+
+___
+
+### startTransaction
+
+▸ `Static` **startTransaction**(`knexOrTransaction?`): `Promise`<`Transaction`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `knexOrTransaction?` | `TransactionOrKnex` |
+
+#### Returns
+
+`Promise`<`Transaction`\>
+
+#### Inherited from
+
+Model.startTransaction
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1483
+
+___
+
+### tableMetadata
+
+▸ `Static` **tableMetadata**(`opt?`): `TableMetadata`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `opt?` | `TableMetadataOptions` |
+
+#### Returns
+
+`TableMetadata`
+
+#### Inherited from
+
+Model.tableMetadata
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1478
+
+___
+
+### transaction
+
+▸ `Static` **transaction**<`T`\>(`callback`): `Promise`<`T`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | (`trx`: `Transaction`) => `Promise`<`T`\> |
+
+#### Returns
+
+`Promise`<`T`\>
+
+#### Inherited from
+
+Model.transaction
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1485
+
+▸ `Static` **transaction**<`T`\>(`trxOrKnex`, `callback`): `Promise`<`T`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `trxOrKnex` | `TransactionOrKnex` |
+| `callback` | (`trx`: `Transaction`) => `Promise`<`T`\> |
+
+#### Returns
+
+`Promise`<`T`\>
+
+#### Inherited from
+
+Model.transaction
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1486
+
+___
+
+### traverse
+
+▸ `Static` **traverse**(`models`, `traverser`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `models` | `Model` \| `Model`[] |
+| `traverser` | `TraverserFunction` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Model.traverse
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1511
+
+▸ `Static` **traverse**(`filterConstructor`, `models`, `traverser`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `filterConstructor` | typeof `Model` |
+| `models` | `Model` \| `Model`[] |
+| `traverser` | `TraverserFunction` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Model.traverse
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1512
+
+___
+
+### traverseAsync
+
+▸ `Static` **traverseAsync**(`models`, `traverser`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `models` | `Model` \| `Model`[] |
+| `traverser` | `TraverserFunction` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Model.traverseAsync
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1517
+
+▸ `Static` **traverseAsync**(`filterConstructor`, `models`, `traverser`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `filterConstructor` | typeof `Model` |
+| `models` | `Model` \| `Model`[] |
+| `traverser` | `TraverserFunction` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Model.traverseAsync
+
+#### Defined in
+
+node_modules/objection/typings/objection/index.d.ts:1518

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.BaseEvent.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.BaseEvent.md
@@ -1,0 +1,120 @@
+---
+id: "takaro_gameserver.BaseEvent"
+title: "Class: BaseEvent<T>"
+sidebar_label: "@takaro/gameserver.BaseEvent"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).BaseEvent
+
+## Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+## Hierarchy
+
+- `TakaroDTO`<[`BaseEvent`](takaro_gameserver.BaseEvent.md)<`T`\>\>
+
+  ↳ **`BaseEvent`**
+
+  ↳↳ [`EventLogLine`](takaro_gameserver.EventLogLine.md)
+
+  ↳↳ [`EventPlayerConnected`](takaro_gameserver.EventPlayerConnected.md)
+
+  ↳↳ [`EventPlayerDisconnected`](takaro_gameserver.EventPlayerDisconnected.md)
+
+  ↳↳ [`EventChatMessage`](takaro_gameserver.EventChatMessage.md)
+
+## Constructors
+
+### constructor
+
+• **new BaseEvent**<`T`\>(`data`)
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Partial`<`T`\> |
+
+#### Overrides
+
+TakaroDTO&lt;BaseEvent&lt;T\&gt;\&gt;.constructor
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:30](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L30)
+
+## Properties
+
+### msg
+
+• **msg**: `string`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:28](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L28)
+
+___
+
+### timestamp
+
+• **timestamp**: `string`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L22)
+
+___
+
+### type
+
+• **type**: `string`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:25](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L25)
+
+## Methods
+
+### toJSON
+
+▸ **toJSON**(): `Record`<`string`, `any`\>
+
+#### Returns
+
+`Record`<`string`, `any`\>
+
+#### Inherited from
+
+TakaroDTO.toJSON
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:8
+
+___
+
+### validate
+
+▸ **validate**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+TakaroDTO.validate
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:7

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.EventChatMessage.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.EventChatMessage.md
@@ -1,0 +1,122 @@
+---
+id: "takaro_gameserver.EventChatMessage"
+title: "Class: EventChatMessage"
+sidebar_label: "@takaro/gameserver.EventChatMessage"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).EventChatMessage
+
+## Hierarchy
+
+- [`BaseEvent`](takaro_gameserver.BaseEvent.md)<[`EventChatMessage`](takaro_gameserver.EventChatMessage.md)\>
+
+  ↳ **`EventChatMessage`**
+
+## Constructors
+
+### constructor
+
+• **new EventChatMessage**(`data`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Partial`<[`EventChatMessage`](takaro_gameserver.EventChatMessage.md)\> |
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[constructor](takaro_gameserver.BaseEvent.md#constructor)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:30](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L30)
+
+## Properties
+
+### msg
+
+• **msg**: `string`
+
+#### Overrides
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[msg](takaro_gameserver.BaseEvent.md#msg)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:59](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L59)
+
+___
+
+### player
+
+• `Optional` **player**: [`IGamePlayer`](takaro_gameserver.IGamePlayer.md)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L57)
+
+___
+
+### timestamp
+
+• **timestamp**: `string`
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[timestamp](takaro_gameserver.BaseEvent.md#timestamp)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L22)
+
+___
+
+### type
+
+• **type**: [`GameEvents`](../enums/takaro_gameserver.GameEvents.md) = `GameEvents.CHAT_MESSAGE`
+
+#### Overrides
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[type](takaro_gameserver.BaseEvent.md#type)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:54](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L54)
+
+## Methods
+
+### toJSON
+
+▸ **toJSON**(): `Record`<`string`, `any`\>
+
+#### Returns
+
+`Record`<`string`, `any`\>
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[toJSON](takaro_gameserver.BaseEvent.md#tojson)
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:8
+
+___
+
+### validate
+
+▸ **validate**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[validate](takaro_gameserver.BaseEvent.md#validate)
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:7

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.EventLogLine.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.EventLogLine.md
@@ -1,0 +1,112 @@
+---
+id: "takaro_gameserver.EventLogLine"
+title: "Class: EventLogLine"
+sidebar_label: "@takaro/gameserver.EventLogLine"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).EventLogLine
+
+## Hierarchy
+
+- [`BaseEvent`](takaro_gameserver.BaseEvent.md)<[`EventLogLine`](takaro_gameserver.EventLogLine.md)\>
+
+  ↳ **`EventLogLine`**
+
+## Constructors
+
+### constructor
+
+• **new EventLogLine**(`data`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Partial`<[`EventLogLine`](takaro_gameserver.EventLogLine.md)\> |
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[constructor](takaro_gameserver.BaseEvent.md#constructor)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:30](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L30)
+
+## Properties
+
+### msg
+
+• **msg**: `string`
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[msg](takaro_gameserver.BaseEvent.md#msg)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:28](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L28)
+
+___
+
+### timestamp
+
+• **timestamp**: `string`
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[timestamp](takaro_gameserver.BaseEvent.md#timestamp)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L22)
+
+___
+
+### type
+
+• **type**: [`GameEvents`](../enums/takaro_gameserver.GameEvents.md) = `GameEvents.LOG_LINE`
+
+#### Overrides
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[type](takaro_gameserver.BaseEvent.md#type)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:36](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L36)
+
+## Methods
+
+### toJSON
+
+▸ **toJSON**(): `Record`<`string`, `any`\>
+
+#### Returns
+
+`Record`<`string`, `any`\>
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[toJSON](takaro_gameserver.BaseEvent.md#tojson)
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:8
+
+___
+
+### validate
+
+▸ **validate**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[validate](takaro_gameserver.BaseEvent.md#validate)
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:7

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.EventPlayerConnected.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.EventPlayerConnected.md
@@ -1,0 +1,122 @@
+---
+id: "takaro_gameserver.EventPlayerConnected"
+title: "Class: EventPlayerConnected"
+sidebar_label: "@takaro/gameserver.EventPlayerConnected"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).EventPlayerConnected
+
+## Hierarchy
+
+- [`BaseEvent`](takaro_gameserver.BaseEvent.md)<[`EventPlayerConnected`](takaro_gameserver.EventPlayerConnected.md)\>
+
+  ↳ **`EventPlayerConnected`**
+
+## Constructors
+
+### constructor
+
+• **new EventPlayerConnected**(`data`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Partial`<[`EventPlayerConnected`](takaro_gameserver.EventPlayerConnected.md)\> |
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[constructor](takaro_gameserver.BaseEvent.md#constructor)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:30](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L30)
+
+## Properties
+
+### msg
+
+• **msg**: `string`
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[msg](takaro_gameserver.BaseEvent.md#msg)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:28](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L28)
+
+___
+
+### player
+
+• **player**: [`IGamePlayer`](takaro_gameserver.IGamePlayer.md)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:43](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L43)
+
+___
+
+### timestamp
+
+• **timestamp**: `string`
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[timestamp](takaro_gameserver.BaseEvent.md#timestamp)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L22)
+
+___
+
+### type
+
+• **type**: [`GameEvents`](../enums/takaro_gameserver.GameEvents.md) = `GameEvents.PLAYER_CONNECTED`
+
+#### Overrides
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[type](takaro_gameserver.BaseEvent.md#type)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:40](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L40)
+
+## Methods
+
+### toJSON
+
+▸ **toJSON**(): `Record`<`string`, `any`\>
+
+#### Returns
+
+`Record`<`string`, `any`\>
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[toJSON](takaro_gameserver.BaseEvent.md#tojson)
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:8
+
+___
+
+### validate
+
+▸ **validate**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[validate](takaro_gameserver.BaseEvent.md#validate)
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:7

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.EventPlayerDisconnected.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.EventPlayerDisconnected.md
@@ -1,0 +1,122 @@
+---
+id: "takaro_gameserver.EventPlayerDisconnected"
+title: "Class: EventPlayerDisconnected"
+sidebar_label: "@takaro/gameserver.EventPlayerDisconnected"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).EventPlayerDisconnected
+
+## Hierarchy
+
+- [`BaseEvent`](takaro_gameserver.BaseEvent.md)<[`EventPlayerDisconnected`](takaro_gameserver.EventPlayerDisconnected.md)\>
+
+  ↳ **`EventPlayerDisconnected`**
+
+## Constructors
+
+### constructor
+
+• **new EventPlayerDisconnected**(`data`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Partial`<[`EventPlayerDisconnected`](takaro_gameserver.EventPlayerDisconnected.md)\> |
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[constructor](takaro_gameserver.BaseEvent.md#constructor)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:30](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L30)
+
+## Properties
+
+### msg
+
+• **msg**: `string`
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[msg](takaro_gameserver.BaseEvent.md#msg)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:28](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L28)
+
+___
+
+### player
+
+• **player**: [`IGamePlayer`](takaro_gameserver.IGamePlayer.md)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:50](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L50)
+
+___
+
+### timestamp
+
+• **timestamp**: `string`
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[timestamp](takaro_gameserver.BaseEvent.md#timestamp)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L22)
+
+___
+
+### type
+
+• **type**: [`GameEvents`](../enums/takaro_gameserver.GameEvents.md) = `GameEvents.PLAYER_DISCONNECTED`
+
+#### Overrides
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[type](takaro_gameserver.BaseEvent.md#type)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:47](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L47)
+
+## Methods
+
+### toJSON
+
+▸ **toJSON**(): `Record`<`string`, `any`\>
+
+#### Returns
+
+`Record`<`string`, `any`\>
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[toJSON](takaro_gameserver.BaseEvent.md#tojson)
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:8
+
+___
+
+### validate
+
+▸ **validate**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+[BaseEvent](takaro_gameserver.BaseEvent.md).[validate](takaro_gameserver.BaseEvent.md#validate)
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:7

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.IGamePlayer.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.IGamePlayer.md
@@ -1,0 +1,154 @@
+---
+id: "takaro_gameserver.IGamePlayer"
+title: "Class: IGamePlayer"
+sidebar_label: "@takaro/gameserver.IGamePlayer"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).IGamePlayer
+
+## Hierarchy
+
+- `TakaroDTO`<[`IGamePlayer`](takaro_gameserver.IGamePlayer.md)\>
+
+  ↳ **`IGamePlayer`**
+
+## Constructors
+
+### constructor
+
+• **new IGamePlayer**(`data?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data?` | `Partial`<[`IGamePlayer`](takaro_gameserver.IGamePlayer.md)\> |
+
+#### Inherited from
+
+TakaroDTO<IGamePlayer\>.constructor
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:6
+
+## Properties
+
+### device
+
+• `Optional` **device**: `string`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GamePlayer.ts:34](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GamePlayer.ts#L34)
+
+___
+
+### epicOnlineServicesId
+
+• `Optional` **epicOnlineServicesId**: `string`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GamePlayer.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GamePlayer.ts#L22)
+
+___
+
+### gameId
+
+• **gameId**: `string`
+
+Unique identifier for this player, as used by the game
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GamePlayer.ts:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GamePlayer.ts#L9)
+
+___
+
+### ip
+
+• `Optional` **ip**: `string`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GamePlayer.ts:38](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GamePlayer.ts#L38)
+
+___
+
+### name
+
+• **name**: `string`
+
+The players username
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GamePlayer.ts:14](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GamePlayer.ts#L14)
+
+___
+
+### platformId
+
+• `Optional` **platformId**: `string`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GamePlayer.ts:30](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GamePlayer.ts#L30)
+
+___
+
+### steamId
+
+• `Optional` **steamId**: `string`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GamePlayer.ts:18](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GamePlayer.ts#L18)
+
+___
+
+### xboxLiveId
+
+• `Optional` **xboxLiveId**: `string`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GamePlayer.ts:26](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GamePlayer.ts#L26)
+
+## Methods
+
+### toJSON
+
+▸ **toJSON**(): `Record`<`string`, `any`\>
+
+#### Returns
+
+`Record`<`string`, `any`\>
+
+#### Inherited from
+
+TakaroDTO.toJSON
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:8
+
+___
+
+### validate
+
+▸ **validate**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+TakaroDTO.validate
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:7

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.Mock.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.Mock.md
@@ -1,0 +1,133 @@
+---
+id: "takaro_gameserver.Mock"
+title: "Class: Mock"
+sidebar_label: "@takaro/gameserver.Mock"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).Mock
+
+## Implements
+
+- [`IGameServer`](../interfaces/takaro_gameserver.IGameServer.md)
+
+## Constructors
+
+### constructor
+
+• **new Mock**(`config`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | `Record`<`string`, `unknown`\> |
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/mock/index.ts:33](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/mock/index.ts#L33)
+
+## Properties
+
+### connectionInfo
+
+• **connectionInfo**: `MockConnectionInfo`
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[connectionInfo](../interfaces/takaro_gameserver.IGameServer.md#connectioninfo)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/mock/index.ts:31](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/mock/index.ts#L31)
+
+___
+
+### logger
+
+• `Private` **logger**: `Logger`
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/mock/index.ts:30](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/mock/index.ts#L30)
+
+## Methods
+
+### getEventEmitter
+
+▸ **getEventEmitter**(): `MockEmitter`
+
+#### Returns
+
+`MockEmitter`
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[getEventEmitter](../interfaces/takaro_gameserver.IGameServer.md#geteventemitter)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/mock/index.ts:46](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/mock/index.ts#L46)
+
+___
+
+### getPlayer
+
+▸ **getPlayer**(`id`): `Promise`<``null`` \| [`IGamePlayer`](takaro_gameserver.IGamePlayer.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `string` |
+
+#### Returns
+
+`Promise`<``null`` \| [`IGamePlayer`](takaro_gameserver.IGamePlayer.md)\>
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[getPlayer](../interfaces/takaro_gameserver.IGameServer.md#getplayer)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/mock/index.ts:37](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/mock/index.ts#L37)
+
+___
+
+### getPlayers
+
+▸ **getPlayers**(): `Promise`<[`IGamePlayer`](takaro_gameserver.IGamePlayer.md)[]\>
+
+#### Returns
+
+`Promise`<[`IGamePlayer`](takaro_gameserver.IGamePlayer.md)[]\>
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[getPlayers](../interfaces/takaro_gameserver.IGameServer.md#getplayers)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/mock/index.ts:42](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/mock/index.ts#L42)
+
+___
+
+### testReachability
+
+▸ **testReachability**(): `Promise`<[`TestReachabilityOutput`](takaro_gameserver.TestReachabilityOutput.md)\>
+
+Try and connect to the gameserver
+If anything goes wrong, this function will report a detailed reason
+
+#### Returns
+
+`Promise`<[`TestReachabilityOutput`](takaro_gameserver.TestReachabilityOutput.md)\>
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[testReachability](../interfaces/takaro_gameserver.IGameServer.md#testreachability)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/mock/index.ts:51](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/mock/index.ts#L51)

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.Rust.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.Rust.md
@@ -1,0 +1,133 @@
+---
+id: "takaro_gameserver.Rust"
+title: "Class: Rust"
+sidebar_label: "@takaro/gameserver.Rust"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).Rust
+
+## Implements
+
+- [`IGameServer`](../interfaces/takaro_gameserver.IGameServer.md)
+
+## Constructors
+
+### constructor
+
+• **new Rust**(`config`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | `Record`<`string`, `unknown`\> |
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/rust/index.ts:23](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/rust/index.ts#L23)
+
+## Properties
+
+### connectionInfo
+
+• **connectionInfo**: `RustConnectionInfo`
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[connectionInfo](../interfaces/takaro_gameserver.IGameServer.md#connectioninfo)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/rust/index.ts:21](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/rust/index.ts#L21)
+
+___
+
+### logger
+
+• `Private` **logger**: `Logger`
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/rust/index.ts:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/rust/index.ts#L20)
+
+## Methods
+
+### getEventEmitter
+
+▸ **getEventEmitter**(): `RustEmitter`
+
+#### Returns
+
+`RustEmitter`
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[getEventEmitter](../interfaces/takaro_gameserver.IGameServer.md#geteventemitter)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/rust/index.ts:36](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/rust/index.ts#L36)
+
+___
+
+### getPlayer
+
+▸ **getPlayer**(`id`): `Promise`<``null`` \| [`IGamePlayer`](takaro_gameserver.IGamePlayer.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `string` |
+
+#### Returns
+
+`Promise`<``null`` \| [`IGamePlayer`](takaro_gameserver.IGamePlayer.md)\>
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[getPlayer](../interfaces/takaro_gameserver.IGameServer.md#getplayer)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/rust/index.ts:27](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/rust/index.ts#L27)
+
+___
+
+### getPlayers
+
+▸ **getPlayers**(): `Promise`<[`IGamePlayer`](takaro_gameserver.IGamePlayer.md)[]\>
+
+#### Returns
+
+`Promise`<[`IGamePlayer`](takaro_gameserver.IGamePlayer.md)[]\>
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[getPlayers](../interfaces/takaro_gameserver.IGameServer.md#getplayers)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/rust/index.ts:32](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/rust/index.ts#L32)
+
+___
+
+### testReachability
+
+▸ **testReachability**(): `Promise`<[`TestReachabilityOutput`](takaro_gameserver.TestReachabilityOutput.md)\>
+
+Try and connect to the gameserver
+If anything goes wrong, this function will report a detailed reason
+
+#### Returns
+
+`Promise`<[`TestReachabilityOutput`](takaro_gameserver.TestReachabilityOutput.md)\>
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[testReachability](../interfaces/takaro_gameserver.IGameServer.md#testreachability)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/rust/index.ts:41](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/rust/index.ts#L41)

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.SevenDaysToDie.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.SevenDaysToDie.md
@@ -1,0 +1,143 @@
+---
+id: "takaro_gameserver.SevenDaysToDie"
+title: "Class: SevenDaysToDie"
+sidebar_label: "@takaro/gameserver.SevenDaysToDie"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).SevenDaysToDie
+
+## Implements
+
+- [`IGameServer`](../interfaces/takaro_gameserver.IGameServer.md)
+
+## Constructors
+
+### constructor
+
+• **new SevenDaysToDie**(`config`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | `Record`<`string`, `unknown`\> |
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/7d2d/index.ts:27](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/7d2d/index.ts#L27)
+
+## Properties
+
+### apiClient
+
+• `Private` **apiClient**: `SdtdApiClient`
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/7d2d/index.ts:24](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/7d2d/index.ts#L24)
+
+___
+
+### connectionInfo
+
+• **connectionInfo**: `SdtdConnectionInfo`
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[connectionInfo](../interfaces/takaro_gameserver.IGameServer.md#connectioninfo)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/7d2d/index.ts:25](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/7d2d/index.ts#L25)
+
+___
+
+### logger
+
+• `Private` **logger**: `Logger`
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/7d2d/index.ts:23](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/7d2d/index.ts#L23)
+
+## Methods
+
+### getEventEmitter
+
+▸ **getEventEmitter**(): `SevenDaysToDieEmitter`
+
+#### Returns
+
+`SevenDaysToDieEmitter`
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[getEventEmitter](../interfaces/takaro_gameserver.IGameServer.md#geteventemitter)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/7d2d/index.ts:41](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/7d2d/index.ts#L41)
+
+___
+
+### getPlayer
+
+▸ **getPlayer**(`id`): `Promise`<``null`` \| [`IGamePlayer`](takaro_gameserver.IGamePlayer.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `string` |
+
+#### Returns
+
+`Promise`<``null`` \| [`IGamePlayer`](takaro_gameserver.IGamePlayer.md)\>
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[getPlayer](../interfaces/takaro_gameserver.IGameServer.md#getplayer)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/7d2d/index.ts:32](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/7d2d/index.ts#L32)
+
+___
+
+### getPlayers
+
+▸ **getPlayers**(): `Promise`<[`IGamePlayer`](takaro_gameserver.IGamePlayer.md)[]\>
+
+#### Returns
+
+`Promise`<[`IGamePlayer`](takaro_gameserver.IGamePlayer.md)[]\>
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[getPlayers](../interfaces/takaro_gameserver.IGameServer.md#getplayers)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/7d2d/index.ts:37](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/7d2d/index.ts#L37)
+
+___
+
+### testReachability
+
+▸ **testReachability**(): `Promise`<[`TestReachabilityOutput`](takaro_gameserver.TestReachabilityOutput.md)\>
+
+Try and connect to the gameserver
+If anything goes wrong, this function will report a detailed reason
+
+#### Returns
+
+`Promise`<[`TestReachabilityOutput`](takaro_gameserver.TestReachabilityOutput.md)\>
+
+#### Implementation of
+
+[IGameServer](../interfaces/takaro_gameserver.IGameServer.md).[testReachability](../interfaces/takaro_gameserver.IGameServer.md#testreachability)
+
+#### Defined in
+
+[packages/lib-gameserver/src/gameservers/7d2d/index.ts:46](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/gameservers/7d2d/index.ts#L46)

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.TakaroEmitter.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.TakaroEmitter.md
@@ -1,0 +1,157 @@
+---
+id: "takaro_gameserver.TakaroEmitter"
+title: "Class: TakaroEmitter"
+sidebar_label: "@takaro/gameserver.TakaroEmitter"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).TakaroEmitter
+
+## Constructors
+
+### constructor
+
+• **new TakaroEmitter**()
+
+#### Defined in
+
+[packages/lib-gameserver/src/TakaroEmitter.ts:36](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/TakaroEmitter.ts#L36)
+
+## Properties
+
+### listenerMap
+
+• `Private` **listenerMap**: `Map`<keyof `IEventMap`, ((`log`: [`EventLogLine`](takaro_gameserver.EventLogLine.md)) => `Promise`<`void`\> \| (`player`: [`EventPlayerConnected`](takaro_gameserver.EventPlayerConnected.md)) => `Promise`<`void`\> \| (`player`: [`EventPlayerDisconnected`](takaro_gameserver.EventPlayerDisconnected.md)) => `Promise`<`void`\> \| (`chatMessage`: [`EventChatMessage`](takaro_gameserver.EventChatMessage.md)) => `Promise`<`void`\> \| (`error`: `TakaroError` \| `Error`) => `void` \| `Promise`<`void`\>)[]\>
+
+#### Defined in
+
+[packages/lib-gameserver/src/TakaroEmitter.ts:30](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/TakaroEmitter.ts#L30)
+
+## Methods
+
+### emit
+
+▸ **emit**<`E`\>(`event`, `data`): `Promise`<`void`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `E` | extends keyof `IEventMap` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `E` |
+| `data` | `Parameters`<`IEventMap`[`E`]\>[``0``] |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-gameserver/src/TakaroEmitter.ts:40](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/TakaroEmitter.ts#L40)
+
+___
+
+### hasErrorListener
+
+▸ **hasErrorListener**(): `boolean`
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[packages/lib-gameserver/src/TakaroEmitter.ts:86](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/TakaroEmitter.ts#L86)
+
+___
+
+### off
+
+▸ **off**<`E`\>(`event`, `listener`): [`TakaroEmitter`](takaro_gameserver.TakaroEmitter.md)
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `E` | extends keyof `IEventMap` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `E` |
+| `listener` | `IEventMap`[`E`] |
+
+#### Returns
+
+[`TakaroEmitter`](takaro_gameserver.TakaroEmitter.md)
+
+#### Defined in
+
+[packages/lib-gameserver/src/TakaroEmitter.ts:73](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/TakaroEmitter.ts#L73)
+
+___
+
+### on
+
+▸ **on**<`E`\>(`event`, `listener`): [`TakaroEmitter`](takaro_gameserver.TakaroEmitter.md)
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `E` | extends keyof `IEventMap` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `E` |
+| `listener` | `IEventMap`[`E`] |
+
+#### Returns
+
+[`TakaroEmitter`](takaro_gameserver.TakaroEmitter.md)
+
+#### Defined in
+
+[packages/lib-gameserver/src/TakaroEmitter.ts:68](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/TakaroEmitter.ts#L68)
+
+___
+
+### start
+
+▸ `Abstract` **start**(`config`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `config` | `Record`<`string`, `unknown`\> |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-gameserver/src/TakaroEmitter.ts:34](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/TakaroEmitter.ts#L34)
+
+___
+
+### stop
+
+▸ `Abstract` **stop**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-gameserver/src/TakaroEmitter.ts:33](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/TakaroEmitter.ts#L33)

--- a/packages/web-docs/docs/development/packages/classes/takaro_gameserver.TestReachabilityOutput.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_gameserver.TestReachabilityOutput.md
@@ -1,0 +1,90 @@
+---
+id: "takaro_gameserver.TestReachabilityOutput"
+title: "Class: TestReachabilityOutput"
+sidebar_label: "@takaro/gameserver.TestReachabilityOutput"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).TestReachabilityOutput
+
+## Hierarchy
+
+- `TakaroDTO`<[`TestReachabilityOutput`](takaro_gameserver.TestReachabilityOutput.md)\>
+
+  ↳ **`TestReachabilityOutput`**
+
+## Constructors
+
+### constructor
+
+• **new TestReachabilityOutput**(`data?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data?` | `Partial`<[`TestReachabilityOutput`](takaro_gameserver.TestReachabilityOutput.md)\> |
+
+#### Inherited from
+
+TakaroDTO<TestReachabilityOutput\>.constructor
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:6
+
+## Properties
+
+### connectable
+
+• **connectable**: `boolean`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GameServer.ts:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GameServer.ts#L8)
+
+___
+
+### reason
+
+• `Optional` **reason**: `string`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GameServer.ts:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GameServer.ts#L12)
+
+## Methods
+
+### toJSON
+
+▸ **toJSON**(): `Record`<`string`, `any`\>
+
+#### Returns
+
+`Record`<`string`, `any`\>
+
+#### Inherited from
+
+TakaroDTO.toJSON
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:8
+
+___
+
+### validate
+
+▸ **validate**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+TakaroDTO.validate
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:7

--- a/packages/web-docs/docs/development/packages/classes/takaro_http.APIOutput.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_http.APIOutput.md
@@ -1,0 +1,102 @@
+---
+id: "takaro_http.APIOutput"
+title: "Class: APIOutput<T>"
+sidebar_label: "@takaro/http.APIOutput"
+custom_edit_url: null
+---
+
+[@takaro/http](../modules/takaro_http.md).APIOutput
+
+## Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+## Hierarchy
+
+- `TakaroDTO`<[`APIOutput`](takaro_http.APIOutput.md)<`T`\>\>
+
+  ↳ **`APIOutput`**
+
+## Constructors
+
+### constructor
+
+• **new APIOutput**<`T`\>(`data?`)
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data?` | `Partial`<[`APIOutput`](takaro_http.APIOutput.md)<`T`\>\> |
+
+#### Inherited from
+
+TakaroDTO<APIOutput<T\>\>.constructor
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:6
+
+## Properties
+
+### data
+
+• **data**: `T`
+
+#### Defined in
+
+[packages/lib-http/src/util/apiResponse.ts:63](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/util/apiResponse.ts#L63)
+
+___
+
+### metadata
+
+• **metadata**: `MetadataOutput`
+
+#### Defined in
+
+[packages/lib-http/src/util/apiResponse.ts:61](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/util/apiResponse.ts#L61)
+
+## Methods
+
+### toJSON
+
+▸ **toJSON**(): `Record`<`string`, `any`\>
+
+#### Returns
+
+`Record`<`string`, `any`\>
+
+#### Inherited from
+
+TakaroDTO.toJSON
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:8
+
+___
+
+### validate
+
+▸ **validate**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+TakaroDTO.validate
+
+#### Defined in
+
+node_modules/@takaro/util/dist/dto/TakaroDTO.d.ts:7

--- a/packages/web-docs/docs/development/packages/classes/takaro_http.HTTP.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_http.HTTP.md
@@ -1,0 +1,121 @@
+---
+id: "takaro_http.HTTP"
+title: "Class: HTTP"
+sidebar_label: "@takaro/http.HTTP"
+custom_edit_url: null
+---
+
+[@takaro/http](../modules/takaro_http.md).HTTP
+
+## Constructors
+
+### constructor
+
+• **new HTTP**(`options?`, `httpOptions?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options` | `RoutingControllersOptions` |
+| `httpOptions` | `IHTTPOptions` |
+
+#### Defined in
+
+[packages/lib-http/src/app.ts:26](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/app.ts#L26)
+
+## Properties
+
+### app
+
+• `Private` **app**: `Application`
+
+#### Defined in
+
+[packages/lib-http/src/app.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/app.ts#L22)
+
+___
+
+### httpOptions
+
+• `Private` **httpOptions**: `IHTTPOptions` = `{}`
+
+#### Defined in
+
+[packages/lib-http/src/app.ts:28](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/app.ts#L28)
+
+___
+
+### httpServer
+
+• `Private` **httpServer**: `Server`<typeof `IncomingMessage`, typeof `ServerResponse`\>
+
+#### Defined in
+
+[packages/lib-http/src/app.ts:23](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/app.ts#L23)
+
+___
+
+### logger
+
+• `Private` **logger**: `Logger`
+
+#### Defined in
+
+[packages/lib-http/src/app.ts:24](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/app.ts#L24)
+
+## Accessors
+
+### expressInstance
+
+• `get` **expressInstance**(): `Application`
+
+#### Returns
+
+`Application`
+
+#### Defined in
+
+[packages/lib-http/src/app.ts:69](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/app.ts#L69)
+
+___
+
+### server
+
+• `get` **server**(): `Server`<typeof `IncomingMessage`, typeof `ServerResponse`\>
+
+#### Returns
+
+`Server`<typeof `IncomingMessage`, typeof `ServerResponse`\>
+
+#### Defined in
+
+[packages/lib-http/src/app.ts:73](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/app.ts#L73)
+
+## Methods
+
+### start
+
+▸ **start**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-http/src/app.ts:77](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/app.ts#L77)
+
+___
+
+### stop
+
+▸ **stop**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-http/src/app.ts:85](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/app.ts#L85)

--- a/packages/web-docs/docs/development/packages/classes/takaro_http.PaginationMiddleware.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_http.PaginationMiddleware.md
@@ -1,0 +1,44 @@
+---
+id: "takaro_http.PaginationMiddleware"
+title: "Class: PaginationMiddleware"
+sidebar_label: "@takaro/http.PaginationMiddleware"
+custom_edit_url: null
+---
+
+[@takaro/http](../modules/takaro_http.md).PaginationMiddleware
+
+## Implements
+
+- `ExpressMiddlewareInterface`
+
+## Constructors
+
+### constructor
+
+• **new PaginationMiddleware**()
+
+## Methods
+
+### use
+
+▸ **use**(`req`, `res`, `next`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | [`PaginatedRequest`](../interfaces/takaro_http.PaginatedRequest.md) |
+| `res` | `Response`<`any`, `Record`<`string`, `any`\>\> |
+| `next` | `NextFunction` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Implementation of
+
+ExpressMiddlewareInterface.use
+
+#### Defined in
+
+[packages/lib-http/src/middleware/paginationMiddleware.ts:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/middleware/paginationMiddleware.ts#L20)

--- a/packages/web-docs/docs/development/packages/classes/takaro_lib_components.errors.FailedLogOutError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_lib_components.errors.FailedLogOutError.md
@@ -1,0 +1,181 @@
+---
+id: "takaro_lib_components.errors.FailedLogOutError"
+title: "Class: FailedLogOutError"
+sidebar_label: "@takaro/lib-components.errors.FailedLogOutError"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[errors](../namespaces/takaro_lib_components.errors.md).FailedLogOutError
+
+## Hierarchy
+
+- `DomainError`
+
+  ↳ **`FailedLogOutError`**
+
+## Constructors
+
+### constructor
+
+• **new FailedLogOutError**(`message`, `options?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `options?` | `Partial`<`IErrorOptions`\> |
+
+#### Inherited from
+
+DomainError.constructor
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:6](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L6)
+
+## Properties
+
+### cause
+
+• `Optional` **cause**: `unknown`
+
+#### Inherited from
+
+DomainError.cause
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es2022.error.d.ts:26
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+DomainError.message
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L7)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+DomainError.name
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### options
+
+• `Protected` `Optional` **options**: `Partial`<`IErrorOptions`\>
+
+#### Inherited from
+
+DomainError.options
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L8)
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+DomainError.stack
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+DomainError.prepareStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+DomainError.stackTraceLimit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+DomainError.captureStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_lib_components.errors.InternalServerError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_lib_components.errors.InternalServerError.md
@@ -1,0 +1,174 @@
+---
+id: "takaro_lib_components.errors.InternalServerError"
+title: "Class: InternalServerError"
+sidebar_label: "@takaro/lib-components.errors.InternalServerError"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[errors](../namespaces/takaro_lib_components.errors.md).InternalServerError
+
+## Hierarchy
+
+- `DomainError`
+
+  ↳ **`InternalServerError`**
+
+## Constructors
+
+### constructor
+
+• **new InternalServerError**()
+
+#### Overrides
+
+DomainError.constructor
+
+#### Defined in
+
+[packages/lib-components/src/errors/errors.ts:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/errors.ts#L11)
+
+## Properties
+
+### cause
+
+• `Optional` **cause**: `unknown`
+
+#### Inherited from
+
+DomainError.cause
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es2022.error.d.ts:26
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+DomainError.message
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L7)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+DomainError.name
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### options
+
+• `Protected` `Optional` **options**: `Partial`<`IErrorOptions`\>
+
+#### Inherited from
+
+DomainError.options
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L8)
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+DomainError.stack
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+DomainError.prepareStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+DomainError.stackTraceLimit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+DomainError.captureStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_lib_components.errors.NotAuthorizedError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_lib_components.errors.NotAuthorizedError.md
@@ -1,0 +1,181 @@
+---
+id: "takaro_lib_components.errors.NotAuthorizedError"
+title: "Class: NotAuthorizedError"
+sidebar_label: "@takaro/lib-components.errors.NotAuthorizedError"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[errors](../namespaces/takaro_lib_components.errors.md).NotAuthorizedError
+
+## Hierarchy
+
+- `DomainError`
+
+  ↳ **`NotAuthorizedError`**
+
+## Constructors
+
+### constructor
+
+• **new NotAuthorizedError**(`message`, `options?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `options?` | `Partial`<`IErrorOptions`\> |
+
+#### Inherited from
+
+DomainError.constructor
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:6](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L6)
+
+## Properties
+
+### cause
+
+• `Optional` **cause**: `unknown`
+
+#### Inherited from
+
+DomainError.cause
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es2022.error.d.ts:26
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+DomainError.message
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L7)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+DomainError.name
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### options
+
+• `Protected` `Optional` **options**: `Partial`<`IErrorOptions`\>
+
+#### Inherited from
+
+DomainError.options
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L8)
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+DomainError.stack
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+DomainError.prepareStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+DomainError.stackTraceLimit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+DomainError.captureStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_lib_components.errors.ResponseClientError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_lib_components.errors.ResponseClientError.md
@@ -1,0 +1,181 @@
+---
+id: "takaro_lib_components.errors.ResponseClientError"
+title: "Class: ResponseClientError"
+sidebar_label: "@takaro/lib-components.errors.ResponseClientError"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[errors](../namespaces/takaro_lib_components.errors.md).ResponseClientError
+
+## Hierarchy
+
+- `DomainError`
+
+  ↳ **`ResponseClientError`**
+
+## Constructors
+
+### constructor
+
+• **new ResponseClientError**(`message`, `options?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `options?` | `Partial`<`IErrorOptions`\> |
+
+#### Inherited from
+
+DomainError.constructor
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:6](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L6)
+
+## Properties
+
+### cause
+
+• `Optional` **cause**: `unknown`
+
+#### Inherited from
+
+DomainError.cause
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es2022.error.d.ts:26
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+DomainError.message
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L7)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+DomainError.name
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### options
+
+• `Protected` `Optional` **options**: `Partial`<`IErrorOptions`\>
+
+#### Inherited from
+
+DomainError.options
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L8)
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+DomainError.stack
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+DomainError.prepareStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+DomainError.stackTraceLimit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+DomainError.captureStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_lib_components.errors.ResponseValidationError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_lib_components.errors.ResponseValidationError.md
@@ -1,0 +1,191 @@
+---
+id: "takaro_lib_components.errors.ResponseValidationError"
+title: "Class: ResponseValidationError"
+sidebar_label: "@takaro/lib-components.errors.ResponseValidationError"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[errors](../namespaces/takaro_lib_components.errors.md).ResponseValidationError
+
+## Hierarchy
+
+- `DomainError`
+
+  ↳ **`ResponseValidationError`**
+
+## Constructors
+
+### constructor
+
+• **new ResponseValidationError**(`message`, `validationErrors`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `validationErrors` | `default`[] |
+
+#### Overrides
+
+DomainError.constructor
+
+#### Defined in
+
+[packages/lib-components/src/errors/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/errors.ts#L5)
+
+## Properties
+
+### cause
+
+• `Optional` **cause**: `unknown`
+
+#### Inherited from
+
+DomainError.cause
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es2022.error.d.ts:26
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+DomainError.message
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L7)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+DomainError.name
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### options
+
+• `Protected` `Optional` **options**: `Partial`<`IErrorOptions`\>
+
+#### Inherited from
+
+DomainError.options
+
+#### Defined in
+
+[packages/lib-components/src/errors/base.ts:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/base.ts#L8)
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+DomainError.stack
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### validationErrors
+
+• **validationErrors**: `default`[]
+
+#### Defined in
+
+[packages/lib-components/src/errors/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/errors/errors.ts#L5)
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+DomainError.prepareStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+DomainError.stackTraceLimit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+DomainError.captureStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_queues.QueuesService.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_queues.QueuesService.md
@@ -1,0 +1,150 @@
+---
+id: "takaro_queues.QueuesService"
+title: "Class: QueuesService"
+sidebar_label: "@takaro/queues.QueuesService"
+custom_edit_url: null
+---
+
+[@takaro/queues](../modules/takaro_queues.md).QueuesService
+
+## Constructors
+
+### constructor
+
+• **new QueuesService**()
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:111](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L111)
+
+## Properties
+
+### queuesMap
+
+• `Private` **queuesMap**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `commands` | { `events`: `QueueEvents` ; `queue`: [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> ; `scheduler`: `QueueScheduler`  } |
+| `commands.events` | `QueueEvents` |
+| `commands.queue` | [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> |
+| `commands.scheduler` | `QueueScheduler` |
+| `cronjobs` | { `events`: `QueueEvents` ; `queue`: [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> ; `scheduler`: `QueueScheduler`  } |
+| `cronjobs.events` | `QueueEvents` |
+| `cronjobs.queue` | [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> |
+| `cronjobs.scheduler` | `QueueScheduler` |
+| `events` | { `events`: `QueueEvents` ; `queue`: [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IEventQueueData`](../interfaces/takaro_queues.IEventQueueData.md)\> ; `scheduler`: `QueueScheduler`  } |
+| `events.events` | `QueueEvents` |
+| `events.queue` | [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IEventQueueData`](../interfaces/takaro_queues.IEventQueueData.md)\> |
+| `events.scheduler` | `QueueScheduler` |
+| `hooks` | { `events`: `QueueEvents` ; `queue`: [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> ; `scheduler`: `QueueScheduler`  } |
+| `hooks.events` | `QueueEvents` |
+| `hooks.queue` | [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> |
+| `hooks.scheduler` | `QueueScheduler` |
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:72](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L72)
+
+___
+
+### workers
+
+• `Private` **workers**: ([`TakaroWorker`](takaro_queues.TakaroWorker.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> \| [`TakaroWorker`](takaro_queues.TakaroWorker.md)<[`IEventQueueData`](../interfaces/takaro_queues.IEventQueueData.md)\>)[] = `[]`
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:69](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L69)
+
+___
+
+### instance
+
+▪ `Static` `Private` **instance**: [`QueuesService`](takaro_queues.QueuesService.md)
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:60](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L60)
+
+## Accessors
+
+### queues
+
+• `get` **queues**(): `Object`
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `commands` | { `events`: `QueueEvents` ; `queue`: [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> ; `scheduler`: `QueueScheduler`  } |
+| `commands.events` | `QueueEvents` |
+| `commands.queue` | [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> |
+| `commands.scheduler` | `QueueScheduler` |
+| `cronjobs` | { `events`: `QueueEvents` ; `queue`: [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> ; `scheduler`: `QueueScheduler`  } |
+| `cronjobs.events` | `QueueEvents` |
+| `cronjobs.queue` | [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> |
+| `cronjobs.scheduler` | `QueueScheduler` |
+| `events` | { `events`: `QueueEvents` ; `queue`: [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IEventQueueData`](../interfaces/takaro_queues.IEventQueueData.md)\> ; `scheduler`: `QueueScheduler`  } |
+| `events.events` | `QueueEvents` |
+| `events.queue` | [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IEventQueueData`](../interfaces/takaro_queues.IEventQueueData.md)\> |
+| `events.scheduler` | `QueueScheduler` |
+| `hooks` | { `events`: `QueueEvents` ; `queue`: [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> ; `scheduler`: `QueueScheduler`  } |
+| `hooks.events` | `QueueEvents` |
+| `hooks.queue` | [`TakaroQueue`](takaro_queues.TakaroQueue.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> |
+| `hooks.scheduler` | `QueueScheduler` |
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:115](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L115)
+
+## Methods
+
+### initQueues
+
+▸ `Private` **initQueues**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:126](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L126)
+
+___
+
+### registerWorker
+
+▸ **registerWorker**(`worker`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `worker` | [`TakaroWorker`](takaro_queues.TakaroWorker.md)<[`IJobData`](../interfaces/takaro_queues.IJobData.md)\> \| [`TakaroWorker`](takaro_queues.TakaroWorker.md)<[`IEventQueueData`](../interfaces/takaro_queues.IEventQueueData.md)\> |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:119](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L119)
+
+___
+
+### getInstance
+
+▸ `Static` **getInstance**(): [`QueuesService`](takaro_queues.QueuesService.md)
+
+#### Returns
+
+[`QueuesService`](takaro_queues.QueuesService.md)
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:62](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L62)

--- a/packages/web-docs/docs/development/packages/classes/takaro_queues.TakaroQueue.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_queues.TakaroQueue.md
@@ -1,0 +1,2425 @@
+---
+id: "takaro_queues.TakaroQueue"
+title: "Class: TakaroQueue<T>"
+sidebar_label: "@takaro/queues.TakaroQueue"
+custom_edit_url: null
+---
+
+[@takaro/queues](../modules/takaro_queues.md).TakaroQueue
+
+## Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+## Hierarchy
+
+- `Queue`<`T`\>
+
+  ↳ **`TakaroQueue`**
+
+## Constructors
+
+### constructor
+
+• **new TakaroQueue**<`T`\>(`name`)
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+
+#### Overrides
+
+Queue&lt;T\&gt;.constructor
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:17](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L17)
+
+## Properties
+
+### closing
+
+• **closing**: `Promise`<`void`\>
+
+#### Inherited from
+
+Queue.closing
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:21
+
+___
+
+### connection
+
+• `Protected` **connection**: `RedisConnection`
+
+#### Inherited from
+
+Queue.connection
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:23
+
+___
+
+### jobsOpts
+
+• **jobsOpts**: `BaseJobOptions`
+
+#### Inherited from
+
+Queue.jobsOpts
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:72
+
+___
+
+### keys
+
+• **keys**: `KeysMap`
+
+#### Inherited from
+
+Queue.keys
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:20
+
+___
+
+### limiter
+
+• **limiter**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `groupKey` | `string` |
+
+#### Inherited from
+
+Queue.limiter
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:73
+
+___
+
+### name
+
+• `Readonly` **name**: `string`
+
+#### Inherited from
+
+Queue.name
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:17
+
+___
+
+### opts
+
+• **opts**: `QueueBaseOptions`
+
+#### Inherited from
+
+Queue.opts
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:18
+
+___
+
+### scripts
+
+• `Protected` **scripts**: `Scripts`
+
+#### Inherited from
+
+Queue.scripts
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:22
+
+___
+
+### toKey
+
+• **toKey**: (`type`: `string`) => `string`
+
+#### Type declaration
+
+▸ (`type`): `string`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `type` | `string` |
+
+##### Returns
+
+`string`
+
+#### Inherited from
+
+Queue.toKey
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:19
+
+___
+
+### token
+
+• **token**: `string`
+
+#### Inherited from
+
+Queue.token
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:71
+
+___
+
+### captureRejectionSymbol
+
+▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](takaro_queues.TakaroQueue.md#capturerejectionsymbol)
+
+#### Inherited from
+
+Queue.captureRejectionSymbol
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:291
+
+___
+
+### captureRejections
+
+▪ `Static` **captureRejections**: `boolean`
+
+Sets or gets the default captureRejection value for all emitters.
+
+#### Inherited from
+
+Queue.captureRejections
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:296
+
+___
+
+### defaultMaxListeners
+
+▪ `Static` **defaultMaxListeners**: `number`
+
+#### Inherited from
+
+Queue.defaultMaxListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:297
+
+___
+
+### errorMonitor
+
+▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](takaro_queues.TakaroQueue.md#errormonitor)
+
+This symbol shall be used to install a listener for only monitoring `'error'`
+events. Listeners installed using this symbol are called before the regular
+`'error'` listeners are called.
+
+Installing a listener using this symbol does not change the behavior once an
+`'error'` event is emitted, therefore the process will still crash if no
+regular `'error'` listener is installed.
+
+#### Inherited from
+
+Queue.errorMonitor
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:290
+
+## Accessors
+
+### Job
+
+• `Protected` `get` **Job**(): typeof `Job`
+
+Helper to easily extend Job class calls.
+
+#### Returns
+
+typeof `Job`
+
+#### Inherited from
+
+Queue.Job
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:18
+
+___
+
+### client
+
+• `get` **client**(): `Promise`<`RedisClient`\>
+
+Returns a promise that resolves to a redis client. Normally used only by subclasses.
+
+#### Returns
+
+`Promise`<`RedisClient`\>
+
+#### Inherited from
+
+Queue.client
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:35
+
+___
+
+### defaultJobOptions
+
+• `get` **defaultJobOptions**(): `JobsOptions`
+
+Returns this instance current default job options.
+
+#### Returns
+
+`JobsOptions`
+
+#### Inherited from
+
+Queue.defaultJobOptions
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:85
+
+___
+
+### redisVersion
+
+• `get` **redisVersion**(): `string`
+
+Returns the version of the Redis instance the client is connected to,
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+Queue.redisVersion
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:39
+
+___
+
+### repeat
+
+• `get` **repeat**(): `Promise`<`Repeat`\>
+
+#### Returns
+
+`Promise`<`Repeat`\>
+
+#### Inherited from
+
+Queue.repeat
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:86
+
+## Methods
+
+### add
+
+▸ **add**(`name`, `data`, `opts?`): `Promise`<`Job`<`T`, `any`, `string`\>\>
+
+Adds a new job to the queue.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | Name of the job to be added to the queue,. |
+| `data` | `T` | Arbitrary data to append to the job. |
+| `opts?` | `JobsOptions` | Job options that affects how the job is going to be processed. |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>\>
+
+#### Inherited from
+
+Queue.add
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:94
+
+___
+
+### addBulk
+
+▸ **addBulk**(`jobs`): `Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+Adds an array of jobs to the queue. This method may be faster than adding
+one job at a time in a sequence.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `jobs` | { `data`: `T` ; `name`: `string` ; `opts?`: `BulkJobOptions`  }[] | The array of jobs to add to the queue. Each job is defined by 3 properties, 'name', 'data' and 'opts'. They follow the same signature as 'Queue.add'. |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+#### Inherited from
+
+Queue.addBulk
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:102
+
+___
+
+### addListener
+
+▸ **addListener**(`eventName`, `listener`): [`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+Alias for `emitter.on(eventName, listener)`.
+
+**`Since`**
+
+v0.1.26
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Inherited from
+
+Queue.addListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:317
+
+___
+
+### base64Name
+
+▸ `Protected` **base64Name**(): `string`
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+Queue.base64Name
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:53
+
+___
+
+### checkConnectionError
+
+▸ `Protected` **checkConnectionError**<`T`\>(`fn`, `delayInMs?`): `Promise`<`T`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `fn` | () => `Promise`<`T`\> |
+| `delayInMs?` | `number` |
+
+#### Returns
+
+`Promise`<`T`\>
+
+#### Inherited from
+
+Queue.checkConnectionError
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:65
+
+___
+
+### clean
+
+▸ **clean**(`grace`, `limit`, `type?`): `Promise`<`string`[]\>
+
+Cleans jobs from a queue. Similar to drain but keeps jobs within a certain
+grace period.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `grace` | `number` | The grace period |
+| `limit` | `number` | Max number of jobs to clean |
+| `type?` | ``"active"`` \| ``"completed"`` \| ``"failed"`` \| ``"paused"`` \| ``"delayed"`` \| ``"wait"`` | The type of job to clean Possible values are completed, wait, active, paused, delayed, failed. Defaults to completed. |
+
+#### Returns
+
+`Promise`<`string`[]\>
+
+Id jobs from the deleted records
+
+#### Inherited from
+
+Queue.clean
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:206
+
+___
+
+### clientName
+
+▸ `Protected` **clientName**(`suffix?`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `suffix?` | `string` |
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+Queue.clientName
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:54
+
+___
+
+### close
+
+▸ **close**(): `Promise`<`void`\>
+
+Close the queue instance.
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Queue.close
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:123
+
+___
+
+### count
+
+▸ **count**(): `Promise`<`number`\>
+
+Returns the number of jobs waiting to be processed. This includes jobs that are "waiting" or "delayed".
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+Queue.count
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:23
+
+___
+
+### disconnect
+
+▸ **disconnect**(): `Promise`<`void`\>
+
+Force disconnects a connection.
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Queue.disconnect
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:64
+
+___
+
+### drain
+
+▸ **drain**(`delayed?`): `Promise`<`void`\>
+
+Drains the queue, i.e., removes all jobs that are waiting
+or delayed, but not active, completed or failed.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `delayed?` | `boolean` | Pass true if it should also clean the delayed jobs. |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Queue.drain
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:195
+
+___
+
+### emit
+
+▸ **emit**<`U`\>(`event`, ...`args`): `boolean`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `U` | extends keyof `QueueListener`<`DataType`, `ResultType`, `NameType`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `U` |
+| `...args` | `Parameters`<`QueueListener`<`T`, `any`, `string`\>[`U`]\> |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Queue.emit
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:78
+
+___
+
+### eventNames
+
+▸ **eventNames**(): (`string` \| `symbol`)[]
+
+Returns an array listing the events for which the emitter has registered
+listeners. The values in the array are strings or `Symbol`s.
+
+```js
+const EventEmitter = require('events');
+const myEE = new EventEmitter();
+myEE.on('foo', () => {});
+myEE.on('bar', () => {});
+
+const sym = Symbol('symbol');
+myEE.on(sym, () => {});
+
+console.log(myEE.eventNames());
+// Prints: [ 'foo', 'bar', Symbol(symbol) ]
+```
+
+**`Since`**
+
+v6.0.0
+
+#### Returns
+
+(`string` \| `symbol`)[]
+
+#### Inherited from
+
+Queue.eventNames
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:632
+
+___
+
+### getActive
+
+▸ **getActive**(`start?`, `end?`): `Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+Returns the jobs that are in the "active" status.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `start?` | `number` | zero based index from where to start returning jobs. |
+| `end?` | `number` | zeroo based index where to stop returning jobs. |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+#### Inherited from
+
+Queue.getActive
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:83
+
+___
+
+### getActiveCount
+
+▸ **getActiveCount**(): `Promise`<`number`\>
+
+Returns the number of jobs in active status.
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+Queue.getActiveCount
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:56
+
+___
+
+### getCompleted
+
+▸ **getCompleted**(`start?`, `end?`): `Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+Returns the jobs that are in the "completed" status.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `start?` | `number` | zero based index from where to start returning jobs. |
+| `end?` | `number` | zeroo based index where to stop returning jobs. |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+#### Inherited from
+
+Queue.getCompleted
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:95
+
+___
+
+### getCompletedCount
+
+▸ **getCompletedCount**(): `Promise`<`number`\>
+
+Returns the number of jobs in completed status.
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+Queue.getCompletedCount
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:44
+
+___
+
+### getDelayed
+
+▸ **getDelayed**(`start?`, `end?`): `Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+Returns the jobs that are in the "delayed" status.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `start?` | `number` | zero based index from where to start returning jobs. |
+| `end?` | `number` | zeroo based index where to stop returning jobs. |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+#### Inherited from
+
+Queue.getDelayed
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:89
+
+___
+
+### getDelayedCount
+
+▸ **getDelayedCount**(): `Promise`<`number`\>
+
+Returns the number of jobs in delayed status.
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+Queue.getDelayedCount
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:52
+
+___
+
+### getFailed
+
+▸ **getFailed**(`start?`, `end?`): `Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+Returns the jobs that are in the "failed" status.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `start?` | `number` | zero based index from where to start returning jobs. |
+| `end?` | `number` | zeroo based index where to stop returning jobs. |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+#### Inherited from
+
+Queue.getFailed
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:101
+
+___
+
+### getFailedCount
+
+▸ **getFailedCount**(): `Promise`<`number`\>
+
+Returns the number of jobs in failed status.
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+Queue.getFailedCount
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:48
+
+___
+
+### getJob
+
+▸ **getJob**(`jobId`): `Promise`<`undefined` \| `Job`<`T`, `any`, `string`\>\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `jobId` | `string` |
+
+#### Returns
+
+`Promise`<`undefined` \| `Job`<`T`, `any`, `string`\>\>
+
+#### Inherited from
+
+Queue.getJob
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:13
+
+___
+
+### getJobCountByTypes
+
+▸ **getJobCountByTypes**(...`types`): `Promise`<`number`\>
+
+Job counts by type
+
+Queue#getJobCountByTypes('completed') => completed count
+Queue#getJobCountByTypes('completed,failed') => completed + failed count
+Queue#getJobCountByTypes('completed', 'failed') => completed + failed count
+Queue#getJobCountByTypes('completed', 'waiting', 'failed') => completed + waiting + failed count
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...types` | `JobType`[] |
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+Queue.getJobCountByTypes
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:32
+
+___
+
+### getJobCounts
+
+▸ **getJobCounts**(...`types`): `Promise`<{ `[index: string]`: `number`;  }\>
+
+Returns the job counts for each type specified or every list/set in the queue by default.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...types` | `JobType`[] |
+
+#### Returns
+
+`Promise`<{ `[index: string]`: `number`;  }\>
+
+An object, key (type) and value (count)
+
+#### Inherited from
+
+Queue.getJobCounts
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:38
+
+___
+
+### getJobLogs
+
+▸ **getJobLogs**(`jobId`, `start?`, `end?`, `asc?`): `Promise`<{ `count`: `number` ; `logs`: [`string`]  }\>
+
+Returns the logs for a given Job.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `jobId` | `string` | the id of the job to get the logs for. |
+| `start?` | `number` | zero based index from where to start returning jobs. |
+| `end?` | `number` | zeroo based index where to stop returning jobs. |
+| `asc?` | `boolean` | if true, the jobs will be returned in ascending order. |
+
+#### Returns
+
+`Promise`<{ `count`: `number` ; `logs`: [`string`]  }\>
+
+#### Inherited from
+
+Queue.getJobLogs
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:118
+
+___
+
+### getJobs
+
+▸ **getJobs**(`types?`, `start?`, `end?`, `asc?`): `Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+Returns the jobs that are on the given statuses (note that JobType is synonym for job status)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `types?` | `JobType` \| `JobType`[] | the statuses of the jobs to return. |
+| `start?` | `number` | zero based index from where to start returning jobs. |
+| `end?` | `number` | zeroo based index where to stop returning jobs. |
+| `asc?` | `boolean` | if true, the jobs will be returned in ascending order. |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+#### Inherited from
+
+Queue.getJobs
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:110
+
+___
+
+### getMaxListeners
+
+▸ **getMaxListeners**(): `number`
+
+Returns the current max listener value for the `EventEmitter` which is either
+set by `emitter.setMaxListeners(n)` or defaults to [defaultMaxListeners](takaro_queues.TakaroQueue.md#defaultmaxlisteners).
+
+**`Since`**
+
+v1.0.0
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+Queue.getMaxListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:489
+
+___
+
+### getMetrics
+
+▸ **getMetrics**(`type`, `start?`, `end?`): `Promise`<`Metrics`\>
+
+Get queue metrics related to the queue.
+
+This method returns the gathered metrics for the queue.
+The metrics are represented as an array of job counts
+per unit of time (1 minute).
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `type` | ``"completed"`` \| ``"failed"`` | - |
+| `start?` | `number` | Start point of the metrics, where 0 is the newest point to be returned. |
+| `end?` | `number` | End point of the metrics, where -1 is the oldest point to be returned. |
+
+#### Returns
+
+`Promise`<`Metrics`\>
+
+- Returns an object with queue metrics.
+
+#### Inherited from
+
+Queue.getMetrics
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:162
+
+___
+
+### getQueueEvents
+
+▸ **getQueueEvents**(): `Promise`<{ `[index: string]`: `string`;  }[]\>
+
+Get queue events list related to the queue.
+
+#### Returns
+
+`Promise`<{ `[index: string]`: `string`;  }[]\>
+
+- Returns an array with queue events info.
+
+#### Inherited from
+
+Queue.getQueueEvents
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:145
+
+___
+
+### getQueueSchedulers
+
+▸ **getQueueSchedulers**(): `Promise`<{ `[index: string]`: `string`;  }[]\>
+
+Get queue schedulers list related to the queue.
+
+#### Returns
+
+`Promise`<{ `[index: string]`: `string`;  }[]\>
+
+- Returns an array with queue schedulers info.
+
+#### Inherited from
+
+Queue.getQueueSchedulers
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:137
+
+___
+
+### getRanges
+
+▸ **getRanges**(`types`, `start?`, `end?`, `asc?`): `Promise`<`string`[]\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `types` | `JobType`[] |
+| `start?` | `number` |
+| `end?` | `number` |
+| `asc?` | `boolean` |
+
+#### Returns
+
+`Promise`<`string`[]\>
+
+#### Inherited from
+
+Queue.getRanges
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:102
+
+___
+
+### getRepeatableJobs
+
+▸ **getRepeatableJobs**(`start?`, `end?`, `asc?`): `Promise`<{ `cron`: `string` ; `endDate`: `number` ; `id`: `string` ; `key`: `string` ; `name`: `string` ; `next`: `number` ; `pattern`: `string` ; `tz`: `string`  }[]\>
+
+Get all repeatable meta jobs.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `start?` | `number` | Offset of first job to return. |
+| `end?` | `number` | Offset of last job to return. |
+| `asc?` | `boolean` | Determine the order in which jobs are returned based on their next execution time. |
+
+#### Returns
+
+`Promise`<{ `cron`: `string` ; `endDate`: `number` ; `id`: `string` ; `key`: `string` ; `name`: `string` ; `next`: `number` ; `pattern`: `string` ; `tz`: `string`  }[]\>
+
+#### Inherited from
+
+Queue.getRepeatableJobs
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:143
+
+___
+
+### getWaiting
+
+▸ **getWaiting**(`start?`, `end?`): `Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+Returns the jobs that are in the "waiting" status.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `start?` | `number` | zero based index from where to start returning jobs. |
+| `end?` | `number` | zeroo based index where to stop returning jobs. |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+#### Inherited from
+
+Queue.getWaiting
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:71
+
+___
+
+### getWaitingChildren
+
+▸ **getWaitingChildren**(`start?`, `end?`): `Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+Returns the jobs that are in the "waiting" status.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `start?` | `number` | zero based index from where to start returning jobs. |
+| `end?` | `number` | zeroo based index where to stop returning jobs. |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>[]\>
+
+#### Inherited from
+
+Queue.getWaitingChildren
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:77
+
+___
+
+### getWaitingChildrenCount
+
+▸ **getWaitingChildrenCount**(): `Promise`<`number`\>
+
+Returns the number of jobs in waiting-children status.
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+Queue.getWaitingChildrenCount
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:64
+
+___
+
+### getWaitingCount
+
+▸ **getWaitingCount**(): `Promise`<`number`\>
+
+Returns the number of jobs in waiting or paused statuses.
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+Queue.getWaitingCount
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:60
+
+___
+
+### getWorkers
+
+▸ **getWorkers**(): `Promise`<{ `[index: string]`: `string`;  }[]\>
+
+Get the worker list related to the queue. i.e. all the known
+workers that are available to process jobs for this queue.
+
+#### Returns
+
+`Promise`<{ `[index: string]`: `string`;  }[]\>
+
+- Returns an array with workers info.
+
+#### Inherited from
+
+Queue.getWorkers
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-getters.d.ts:129
+
+___
+
+### isPaused
+
+▸ **isPaused**(): `Promise`<`boolean`\>
+
+Returns true if the queue is currently paused.
+
+#### Returns
+
+`Promise`<`boolean`\>
+
+#### Inherited from
+
+Queue.isPaused
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:134
+
+___
+
+### listenerCount
+
+▸ **listenerCount**(`eventName`): `number`
+
+Returns the number of listeners listening to the event named `eventName`.
+
+**`Since`**
+
+v3.2.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event being listened for |
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+Queue.listenerCount
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:579
+
+___
+
+### listeners
+
+▸ **listeners**(`eventName`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`.
+
+```js
+server.on('connection', (stream) => {
+  console.log('someone connected!');
+});
+console.log(util.inspect(server.listeners('connection')));
+// Prints: [ [Function] ]
+```
+
+**`Since`**
+
+v0.1.26
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+
+#### Returns
+
+`Function`[]
+
+#### Inherited from
+
+Queue.listeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:502
+
+___
+
+### obliterate
+
+▸ **obliterate**(`opts?`): `Promise`<`void`\>
+
+Completely destroys the queue and all of its contents irreversibly.
+This method will the *pause* the queue and requires that there are no
+active jobs. It is possible to bypass this requirement, i.e. not
+having active jobs using the "force" option.
+
+Note: This operation requires to iterate on all the jobs stored in the queue
+and can be slow for very large queues.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `opts?` | `ObliterateOpts` | Obliterate options. |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Queue.obliterate
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:218
+
+___
+
+### off
+
+▸ **off**<`U`\>(`eventName`, `listener`): [`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `U` | extends keyof `QueueListener`<`DataType`, `ResultType`, `NameType`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `U` |
+| `listener` | `QueueListener`<`T`, `any`, `string`\>[`U`] |
+
+#### Returns
+
+[`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Inherited from
+
+Queue.off
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:79
+
+___
+
+### on
+
+▸ **on**<`U`\>(`event`, `listener`): [`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `U` | extends keyof `QueueListener`<`DataType`, `ResultType`, `NameType`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `U` |
+| `listener` | `QueueListener`<`T`, `any`, `string`\>[`U`] |
+
+#### Returns
+
+[`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Inherited from
+
+Queue.on
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:80
+
+___
+
+### once
+
+▸ **once**<`U`\>(`event`, `listener`): [`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `U` | extends keyof `QueueListener`<`DataType`, `ResultType`, `NameType`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `U` |
+| `listener` | `QueueListener`<`T`, `any`, `string`\>[`U`] |
+
+#### Returns
+
+[`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Inherited from
+
+Queue.once
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:81
+
+___
+
+### pause
+
+▸ **pause**(): `Promise`<`void`\>
+
+Pauses the processing of this queue globally.
+
+We use an atomic RENAME operation on the wait queue. Since
+we have blocking calls with BRPOPLPUSH on the wait queue, as long as the queue
+is renamed to 'paused', no new jobs will be processed (the current ones
+will run until finalized).
+
+Adding jobs requires a LUA script to check first if the paused list exist
+and in that case it will add it there instead of the wait list.
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Queue.pause
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:118
+
+___
+
+### prependListener
+
+▸ **prependListener**(`eventName`, `listener`): [`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+Adds the `listener` function to the _beginning_ of the listeners array for the
+event named `eventName`. No checks are made to see if the `listener` has
+already been added. Multiple calls passing the same combination of `eventName`and `listener` will result in the `listener` being added, and called, multiple
+times.
+
+```js
+server.prependListener('connection', (stream) => {
+  console.log('someone connected!');
+});
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v6.0.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event. |
+| `listener` | (...`args`: `any`[]) => `void` | The callback function |
+
+#### Returns
+
+[`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Inherited from
+
+Queue.prependListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:597
+
+___
+
+### prependOnceListener
+
+▸ **prependOnceListener**(`eventName`, `listener`): [`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+Adds a **one-time**`listener` function for the event named `eventName` to the_beginning_ of the listeners array. The next time `eventName` is triggered, this
+listener is removed, and then invoked.
+
+```js
+server.prependOnceListener('connection', (stream) => {
+  console.log('Ah, we have our first user!');
+});
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v6.0.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event. |
+| `listener` | (...`args`: `any`[]) => `void` | The callback function |
+
+#### Returns
+
+[`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Inherited from
+
+Queue.prependOnceListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:613
+
+___
+
+### rawListeners
+
+▸ **rawListeners**(`eventName`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`,
+including any wrappers (such as those created by `.once()`).
+
+```js
+const emitter = new EventEmitter();
+emitter.once('log', () => console.log('log once'));
+
+// Returns a new Array with a function `onceWrapper` which has a property
+// `listener` which contains the original listener bound above
+const listeners = emitter.rawListeners('log');
+const logFnWrapper = listeners[0];
+
+// Logs "log once" to the console and does not unbind the `once` event
+logFnWrapper.listener();
+
+// Logs "log once" to the console and removes the listener
+logFnWrapper();
+
+emitter.on('log', () => console.log('log persistently'));
+// Will return a new Array with a single function bound by `.on()` above
+const newListeners = emitter.rawListeners('log');
+
+// Logs "log persistently" twice
+newListeners[0]();
+emitter.emit('log');
+```
+
+**`Since`**
+
+v9.4.0
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+
+#### Returns
+
+`Function`[]
+
+#### Inherited from
+
+Queue.rawListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:532
+
+___
+
+### remove
+
+▸ **remove**(`jobId`): `Promise`<`number`\>
+
+Removes the given job from the queue as well as all its
+dependencies.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `jobId` | `string` | The id of the job to remove |
+
+#### Returns
+
+`Promise`<`number`\>
+
+1 if it managed to remove the job or 0 if the job or
+any of its dependencies was locked.
+
+#### Inherited from
+
+Queue.remove
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:187
+
+___
+
+### removeAllListeners
+
+▸ **removeAllListeners**(`event?`): [`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+Removes all listeners, or those of the specified `eventName`.
+
+It is bad practice to remove listeners added elsewhere in the code,
+particularly when the `EventEmitter` instance was created by some other
+component or module (e.g. sockets or file streams).
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v0.1.26
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event?` | `string` \| `symbol` |
+
+#### Returns
+
+[`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Inherited from
+
+Queue.removeAllListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:473
+
+___
+
+### removeListener
+
+▸ **removeListener**(`eventName`, `listener`): [`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+Removes the specified `listener` from the listener array for the event named`eventName`.
+
+```js
+const callback = (stream) => {
+  console.log('someone connected!');
+};
+server.on('connection', callback);
+// ...
+server.removeListener('connection', callback);
+```
+
+`removeListener()` will remove, at most, one instance of a listener from the
+listener array. If any single listener has been added multiple times to the
+listener array for the specified `eventName`, then `removeListener()` must be
+called multiple times to remove each instance.
+
+Once an event is emitted, all listeners attached to it at the
+time of emitting are called in order. This implies that any`removeListener()` or `removeAllListeners()` calls _after_ emitting and_before_ the last listener finishes execution will
+not remove them from`emit()` in progress. Subsequent events behave as expected.
+
+```js
+const myEmitter = new MyEmitter();
+
+const callbackA = () => {
+  console.log('A');
+  myEmitter.removeListener('event', callbackB);
+};
+
+const callbackB = () => {
+  console.log('B');
+};
+
+myEmitter.on('event', callbackA);
+
+myEmitter.on('event', callbackB);
+
+// callbackA removes listener callbackB but it will still be called.
+// Internal listener array at time of emit [callbackA, callbackB]
+myEmitter.emit('event');
+// Prints:
+//   A
+//   B
+
+// callbackB is now removed.
+// Internal listener array [callbackA]
+myEmitter.emit('event');
+// Prints:
+//   A
+```
+
+Because listeners are managed using an internal array, calling this will
+change the position indices of any listener registered _after_ the listener
+being removed. This will not impact the order in which listeners are called,
+but it means that any copies of the listener array as returned by
+the `emitter.listeners()` method will need to be recreated.
+
+When a single function has been added as a handler multiple times for a single
+event (as in the example below), `removeListener()` will remove the most
+recently added instance. In the example the `once('ping')`listener is removed:
+
+```js
+const ee = new EventEmitter();
+
+function pong() {
+  console.log('pong');
+}
+
+ee.on('ping', pong);
+ee.once('ping', pong);
+ee.removeListener('ping', pong);
+
+ee.emit('ping');
+ee.emit('ping');
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v0.1.26
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Inherited from
+
+Queue.removeListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:457
+
+___
+
+### removeRepeatable
+
+▸ **removeRepeatable**(`name`, `repeatOpts`, `jobId?`): `Promise`<`boolean`\>
+
+Removes a repeatable job.
+
+Note: you need to use the exact same repeatOpts when deleting a repeatable job
+than when adding it.
+
+**`See`**
+
+removeRepeatableByKey
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+| `repeatOpts` | `RepeatOptions` |
+| `jobId?` | `string` |
+
+#### Returns
+
+`Promise`<`boolean`\>
+
+#### Inherited from
+
+Queue.removeRepeatable
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:166
+
+___
+
+### removeRepeatableByKey
+
+▸ **removeRepeatableByKey**(`key`): `Promise`<`boolean`\>
+
+Removes a repeatable job by its key. Note that the key is the one used
+to store the repeatable job metadata and not one of the job iterations
+themselves. You can use "getRepeatableJobs" in order to get the keys.
+
+**`See`**
+
+getRepeatableJobs
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `key` | `string` | to the repeatable job. |
+
+#### Returns
+
+`Promise`<`boolean`\>
+
+#### Inherited from
+
+Queue.removeRepeatableByKey
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:178
+
+___
+
+### resume
+
+▸ **resume**(): `Promise`<`void`\>
+
+Resumes the processing of this queue globally.
+
+The method reverses the pause operation by resuming the processing of the
+queue.
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Queue.resume
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:130
+
+___
+
+### retryJobs
+
+▸ **retryJobs**(`opts?`): `Promise`<`void`\>
+
+Retry all the failed jobs.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `opts?` | `Object` | contains number to limit how many jobs will be moved to wait status per iteration, state (failed, completed) failed by default or from which timestamp. |
+| `opts.count?` | `number` | - |
+| `opts.state?` | `FinishedStatus` | - |
+| `opts.timestamp?` | `number` | - |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Queue.retryJobs
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:226
+
+___
+
+### setMaxListeners
+
+▸ **setMaxListeners**(`n`): [`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+By default `EventEmitter`s will print a warning if more than `10` listeners are
+added for a particular event. This is a useful default that helps finding
+memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
+modified for this specific `EventEmitter` instance. The value can be set to`Infinity` (or `0`) to indicate an unlimited number of listeners.
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v0.3.5
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `n` | `number` |
+
+#### Returns
+
+[`TakaroQueue`](takaro_queues.TakaroQueue.md)<`T`\>
+
+#### Inherited from
+
+Queue.setMaxListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:483
+
+___
+
+### trimEvents
+
+▸ **trimEvents**(`maxLength`): `Promise`<`number`\>
+
+Trim the event stream to an approximately maxLength.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `maxLength` | `number` |
+
+#### Returns
+
+`Promise`<`number`\>
+
+#### Inherited from
+
+Queue.trimEvents
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue.d.ts:236
+
+___
+
+### waitUntilReady
+
+▸ **waitUntilReady**(): `Promise`<`RedisClient`\>
+
+#### Returns
+
+`Promise`<`RedisClient`\>
+
+#### Inherited from
+
+Queue.waitUntilReady
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:52
+
+___
+
+### getEventListeners
+
+▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`.
+
+For `EventEmitter`s this behaves exactly the same as calling `.listeners` on
+the emitter.
+
+For `EventTarget`s this is the only way to get the event listeners for the
+event target. This is useful for debugging and diagnostic purposes.
+
+```js
+const { getEventListeners, EventEmitter } = require('events');
+
+{
+  const ee = new EventEmitter();
+  const listener = () => console.log('Events are fun');
+  ee.on('foo', listener);
+  getEventListeners(ee, 'foo'); // [listener]
+}
+{
+  const et = new EventTarget();
+  const listener = () => console.log('Events are fun');
+  et.addEventListener('foo', listener);
+  getEventListeners(et, 'foo'); // [listener]
+}
+```
+
+**`Since`**
+
+v15.2.0
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `emitter` | `EventEmitter` \| `DOMEventTarget` |
+| `name` | `string` \| `symbol` |
+
+#### Returns
+
+`Function`[]
+
+#### Inherited from
+
+Queue.getEventListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:262
+
+___
+
+### listenerCount
+
+▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+
+A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+
+```js
+const { EventEmitter, listenerCount } = require('events');
+const myEmitter = new EventEmitter();
+myEmitter.on('event', () => {});
+myEmitter.on('event', () => {});
+console.log(listenerCount(myEmitter, 'event'));
+// Prints: 2
+```
+
+**`Since`**
+
+v0.9.12
+
+**`Deprecated`**
+
+Since v3.2.0 - Use `listenerCount` instead.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `emitter` | `EventEmitter` | The emitter to query |
+| `eventName` | `string` \| `symbol` | The event name |
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+Queue.listenerCount
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:234
+
+___
+
+### on
+
+▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+
+```js
+const { on, EventEmitter } = require('events');
+
+(async () => {
+  const ee = new EventEmitter();
+
+  // Emit later on
+  process.nextTick(() => {
+    ee.emit('foo', 'bar');
+    ee.emit('foo', 42);
+  });
+
+  for await (const event of on(ee, 'foo')) {
+    // The execution of this inner block is synchronous and it
+    // processes one event at a time (even with await). Do not use
+    // if concurrent execution is required.
+    console.log(event); // prints ['bar'] [42]
+  }
+  // Unreachable here
+})();
+```
+
+Returns an `AsyncIterator` that iterates `eventName` events. It will throw
+if the `EventEmitter` emits `'error'`. It removes all listeners when
+exiting the loop. The `value` returned by each iteration is an array
+composed of the emitted event arguments.
+
+An `AbortSignal` can be used to cancel waiting on events:
+
+```js
+const { on, EventEmitter } = require('events');
+const ac = new AbortController();
+
+(async () => {
+  const ee = new EventEmitter();
+
+  // Emit later on
+  process.nextTick(() => {
+    ee.emit('foo', 'bar');
+    ee.emit('foo', 42);
+  });
+
+  for await (const event of on(ee, 'foo', { signal: ac.signal })) {
+    // The execution of this inner block is synchronous and it
+    // processes one event at a time (even with await). Do not use
+    // if concurrent execution is required.
+    console.log(event); // prints ['bar'] [42]
+  }
+  // Unreachable here
+})();
+
+process.nextTick(() => ac.abort());
+```
+
+**`Since`**
+
+v13.6.0, v12.16.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `emitter` | `EventEmitter` | - |
+| `eventName` | `string` | The name of the event being listened for |
+| `options?` | `StaticEventEmitterOptions` | - |
+
+#### Returns
+
+`AsyncIterableIterator`<`any`\>
+
+that iterates `eventName` events emitted by the `emitter`
+
+#### Inherited from
+
+Queue.on
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:217
+
+___
+
+### once
+
+▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+
+Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
+event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
+The `Promise` will resolve with an array of all the arguments emitted to the
+given event.
+
+This method is intentionally generic and works with the web platform [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget) interface, which has no special`'error'` event
+semantics and does not listen to the `'error'` event.
+
+```js
+const { once, EventEmitter } = require('events');
+
+async function run() {
+  const ee = new EventEmitter();
+
+  process.nextTick(() => {
+    ee.emit('myevent', 42);
+  });
+
+  const [value] = await once(ee, 'myevent');
+  console.log(value);
+
+  const err = new Error('kaboom');
+  process.nextTick(() => {
+    ee.emit('error', err);
+  });
+
+  try {
+    await once(ee, 'myevent');
+  } catch (err) {
+    console.log('error happened', err);
+  }
+}
+
+run();
+```
+
+The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
+'`error'` event itself, then it is treated as any other kind of event without
+special handling:
+
+```js
+const { EventEmitter, once } = require('events');
+
+const ee = new EventEmitter();
+
+once(ee, 'error')
+  .then(([err]) => console.log('ok', err.message))
+  .catch((err) => console.log('error', err.message));
+
+ee.emit('error', new Error('boom'));
+
+// Prints: ok boom
+```
+
+An `AbortSignal` can be used to cancel waiting for the event:
+
+```js
+const { EventEmitter, once } = require('events');
+
+const ee = new EventEmitter();
+const ac = new AbortController();
+
+async function foo(emitter, event, signal) {
+  try {
+    await once(emitter, event, { signal });
+    console.log('event emitted!');
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      console.error('Waiting for the event was canceled!');
+    } else {
+      console.error('There was an error', error.message);
+    }
+  }
+}
+
+foo(ee, 'foo', ac.signal);
+ac.abort(); // Abort waiting for the event
+ee.emit('foo'); // Prints: Waiting for the event was canceled!
+```
+
+**`Since`**
+
+v11.13.0, v10.16.0
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `emitter` | `NodeEventTarget` |
+| `eventName` | `string` \| `symbol` |
+| `options?` | `StaticEventEmitterOptions` |
+
+#### Returns
+
+`Promise`<`any`[]\>
+
+#### Inherited from
+
+Queue.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:157
+
+▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `emitter` | `DOMEventTarget` |
+| `eventName` | `string` |
+| `options?` | `StaticEventEmitterOptions` |
+
+#### Returns
+
+`Promise`<`any`[]\>
+
+#### Inherited from
+
+Queue.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:158
+
+___
+
+### setMaxListeners
+
+▸ `Static` **setMaxListeners**(`n?`, ...`eventTargets`): `void`
+
+```js
+const {
+  setMaxListeners,
+  EventEmitter
+} = require('events');
+
+const target = new EventTarget();
+const emitter = new EventEmitter();
+
+setMaxListeners(5, target, emitter);
+```
+
+**`Since`**
+
+v15.4.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `n?` | `number` | A non-negative number. The maximum number of listeners per `EventTarget` event. |
+| `...eventTargets` | (`EventEmitter` \| `DOMEventTarget`)[] | - |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Queue.setMaxListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:280

--- a/packages/web-docs/docs/development/packages/classes/takaro_queues.TakaroWorker.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_queues.TakaroWorker.md
@@ -1,0 +1,1763 @@
+---
+id: "takaro_queues.TakaroWorker"
+title: "Class: TakaroWorker<T>"
+sidebar_label: "@takaro/queues.TakaroWorker"
+custom_edit_url: null
+---
+
+[@takaro/queues](../modules/takaro_queues.md).TakaroWorker
+
+## Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+## Hierarchy
+
+- `Worker`<`T`\>
+
+  ↳ **`TakaroWorker`**
+
+## Constructors
+
+### constructor
+
+• **new TakaroWorker**<`T`\>(`name`, `fn`)
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+| `fn` | `Processor`<`T`, `any`, `string`\> |
+
+#### Overrides
+
+Worker&lt;T\&gt;.constructor
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:25](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L25)
+
+## Properties
+
+### closing
+
+• **closing**: `Promise`<`void`\>
+
+#### Inherited from
+
+Worker.closing
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:21
+
+___
+
+### connection
+
+• `Protected` **connection**: `RedisConnection`
+
+#### Inherited from
+
+Worker.connection
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:23
+
+___
+
+### keys
+
+• **keys**: `KeysMap`
+
+#### Inherited from
+
+Worker.keys
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:20
+
+___
+
+### log
+
+• **log**: `Logger`
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:23](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L23)
+
+___
+
+### name
+
+• `Readonly` **name**: `string`
+
+#### Inherited from
+
+Worker.name
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:17
+
+___
+
+### opts
+
+• `Readonly` **opts**: `WorkerOptions`
+
+#### Inherited from
+
+Worker.opts
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:82
+
+___
+
+### paused
+
+• `Protected` **paused**: `Promise`<`void`\>
+
+#### Inherited from
+
+Worker.paused
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:89
+
+___
+
+### processFn
+
+• `Protected` **processFn**: `Processor`<`T`, `any`, `string`\>
+
+#### Inherited from
+
+Worker.processFn
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:87
+
+___
+
+### scripts
+
+• `Protected` **scripts**: `Scripts`
+
+#### Inherited from
+
+Worker.scripts
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:22
+
+___
+
+### timerManager
+
+• `Protected` **timerManager**: `TimerManager`
+
+#### Inherited from
+
+Worker.timerManager
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:92
+
+___
+
+### toKey
+
+• **toKey**: (`type`: `string`) => `string`
+
+#### Type declaration
+
+▸ (`type`): `string`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `type` | `string` |
+
+##### Returns
+
+`string`
+
+#### Inherited from
+
+Worker.toKey
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:19
+
+___
+
+### captureRejectionSymbol
+
+▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](takaro_queues.TakaroQueue.md#capturerejectionsymbol)
+
+#### Inherited from
+
+Worker.captureRejectionSymbol
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:291
+
+___
+
+### captureRejections
+
+▪ `Static` **captureRejections**: `boolean`
+
+Sets or gets the default captureRejection value for all emitters.
+
+#### Inherited from
+
+Worker.captureRejections
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:296
+
+___
+
+### defaultMaxListeners
+
+▪ `Static` **defaultMaxListeners**: `number`
+
+#### Inherited from
+
+Worker.defaultMaxListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:297
+
+___
+
+### errorMonitor
+
+▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](takaro_queues.TakaroQueue.md#errormonitor)
+
+This symbol shall be used to install a listener for only monitoring `'error'`
+events. Listeners installed using this symbol are called before the regular
+`'error'` listeners are called.
+
+Installing a listener using this symbol does not change the behavior once an
+`'error'` event is emitted, therefore the process will still crash if no
+regular `'error'` listener is installed.
+
+#### Inherited from
+
+Worker.errorMonitor
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:290
+
+## Accessors
+
+### Job
+
+• `Protected` `get` **Job**(): typeof `Job`
+
+Helper to easily extend Job class calls.
+
+#### Returns
+
+typeof `Job`
+
+#### Inherited from
+
+Worker.Job
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:43
+
+___
+
+### client
+
+• `get` **client**(): `Promise`<`RedisClient`\>
+
+Returns a promise that resolves to a redis client. Normally used only by subclasses.
+
+#### Returns
+
+`Promise`<`RedisClient`\>
+
+#### Inherited from
+
+Worker.client
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:35
+
+___
+
+### concurrency
+
+• `set` **concurrency**(`concurrency`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `concurrency` | `number` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Worker.concurrency
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:109
+
+___
+
+### redisVersion
+
+• `get` **redisVersion**(): `string`
+
+Returns the version of the Redis instance the client is connected to,
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+Worker.redisVersion
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:39
+
+___
+
+### repeat
+
+• `get` **repeat**(): `Promise`<`Repeat`\>
+
+#### Returns
+
+`Promise`<`Repeat`\>
+
+#### Inherited from
+
+Worker.repeat
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:110
+
+## Methods
+
+### addListener
+
+▸ **addListener**(`eventName`, `listener`): [`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+Alias for `emitter.on(eventName, listener)`.
+
+**`Since`**
+
+v0.1.26
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Inherited from
+
+Worker.addListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:317
+
+___
+
+### base64Name
+
+▸ `Protected` **base64Name**(): `string`
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+Worker.base64Name
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:53
+
+___
+
+### callProcessJob
+
+▸ `Protected` **callProcessJob**(`job`, `token`): `Promise`<`any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `job` | `Job`<`T`, `any`, `string`\> |
+| `token` | `string` |
+
+#### Returns
+
+`Promise`<`any`\>
+
+#### Inherited from
+
+Worker.callProcessJob
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:100
+
+___
+
+### checkConnectionError
+
+▸ `Protected` **checkConnectionError**<`T`\>(`fn`, `delayInMs?`): `Promise`<`T`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `fn` | () => `Promise`<`T`\> |
+| `delayInMs?` | `number` |
+
+#### Returns
+
+`Promise`<`T`\>
+
+#### Inherited from
+
+Worker.checkConnectionError
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:65
+
+___
+
+### clientName
+
+▸ `Protected` **clientName**(`suffix?`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `suffix?` | `string` |
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+Worker.clientName
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:54
+
+___
+
+### close
+
+▸ **close**(`force?`): `Promise`<`void`\>
+
+Closes the worker and related redis connections.
+
+This method waits for current jobs to finalize before returning.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `force?` | `boolean` | Use force boolean parameter if you do not want to wait for current jobs to be processed. |
+
+#### Returns
+
+`Promise`<`void`\>
+
+Promise that resolves when the worker has been closed.
+
+#### Inherited from
+
+Worker.close
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:162
+
+___
+
+### createJob
+
+▸ `Protected` **createJob**(`data`, `jobId`): `Job`<`T`, `any`, `string`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `JobJsonRaw` |
+| `jobId` | `string` |
+
+#### Returns
+
+`Job`<`T`, `any`, `string`\>
+
+#### Inherited from
+
+Worker.createJob
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:101
+
+___
+
+### delay
+
+▸ **delay**(): `Promise`<`void`\>
+
+This function is exposed only for testing purposes.
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Worker.delay
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:124
+
+___
+
+### disconnect
+
+▸ **disconnect**(): `Promise`<`void`\>
+
+Force disconnects a connection.
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Worker.disconnect
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/queue-base.d.ts:64
+
+___
+
+### emit
+
+▸ **emit**<`U`\>(`event`, ...`args`): `boolean`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `U` | extends keyof `WorkerListener`<`DataType`, `ResultType`, `NameType`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `U` |
+| `...args` | `Parameters`<`WorkerListener`<`T`, `any`, `string`\>[`U`]\> |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Worker.emit
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:96
+
+___
+
+### eventNames
+
+▸ **eventNames**(): (`string` \| `symbol`)[]
+
+Returns an array listing the events for which the emitter has registered
+listeners. The values in the array are strings or `Symbol`s.
+
+```js
+const EventEmitter = require('events');
+const myEE = new EventEmitter();
+myEE.on('foo', () => {});
+myEE.on('bar', () => {});
+
+const sym = Symbol('symbol');
+myEE.on(sym, () => {});
+
+console.log(myEE.eventNames());
+// Prints: [ 'foo', 'bar', Symbol(symbol) ]
+```
+
+**`Since`**
+
+v6.0.0
+
+#### Returns
+
+(`string` \| `symbol`)[]
+
+#### Inherited from
+
+Worker.eventNames
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:632
+
+___
+
+### getMaxListeners
+
+▸ **getMaxListeners**(): `number`
+
+Returns the current max listener value for the `EventEmitter` which is either
+set by `emitter.setMaxListeners(n)` or defaults to [defaultMaxListeners](takaro_queues.TakaroWorker.md#defaultmaxlisteners).
+
+**`Since`**
+
+v1.0.0
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+Worker.getMaxListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:489
+
+___
+
+### getNextJob
+
+▸ **getNextJob**(`token`, `__namedParameters?`): `Promise`<`Job`<`T`, `any`, `string`\>\>
+
+Returns a promise that resolves to the next job in queue.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `token` | `string` | worker token to be assigned to retrieved job |
+| `__namedParameters?` | `GetNextJobOptions` | - |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>\>
+
+a Job or undefined if no job was available in the queue.
+
+#### Inherited from
+
+Worker.getNextJob
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:117
+
+___
+
+### isPaused
+
+▸ **isPaused**(): `boolean`
+
+Checks if worker is paused.
+
+#### Returns
+
+`boolean`
+
+true if worker is paused, false otherwise.
+
+#### Inherited from
+
+Worker.isPaused
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:143
+
+___
+
+### isRunning
+
+▸ **isRunning**(): `boolean`
+
+Checks if worker is currently running.
+
+#### Returns
+
+`boolean`
+
+true if worker is running, false otherwise.
+
+#### Inherited from
+
+Worker.isRunning
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:150
+
+___
+
+### listenerCount
+
+▸ **listenerCount**(`eventName`): `number`
+
+Returns the number of listeners listening to the event named `eventName`.
+
+**`Since`**
+
+v3.2.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event being listened for |
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+Worker.listenerCount
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:579
+
+___
+
+### listeners
+
+▸ **listeners**(`eventName`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`.
+
+```js
+server.on('connection', (stream) => {
+  console.log('someone connected!');
+});
+console.log(util.inspect(server.listeners('connection')));
+// Prints: [ [Function] ]
+```
+
+**`Since`**
+
+v0.1.26
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+
+#### Returns
+
+`Function`[]
+
+#### Inherited from
+
+Worker.listeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:502
+
+___
+
+### moveToActive
+
+▸ `Protected` **moveToActive**(`token`, `jobId?`): `Promise`<`Job`<`T`, `any`, `string`\>\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `token` | `string` |
+| `jobId?` | `string` |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>\>
+
+#### Inherited from
+
+Worker.moveToActive
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:118
+
+___
+
+### nextJobFromJobData
+
+▸ `Protected` **nextJobFromJobData**(`jobData?`, `jobId?`): `Promise`<`Job`<`T`, `any`, `string`\>\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `jobData?` | `number` \| `JobJsonRaw` |
+| `jobId?` | `string` |
+
+#### Returns
+
+`Promise`<`Job`<`T`, `any`, `string`\>\>
+
+#### Inherited from
+
+Worker.nextJobFromJobData
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:125
+
+___
+
+### off
+
+▸ **off**<`U`\>(`eventName`, `listener`): [`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `U` | extends keyof `WorkerListener`<`DataType`, `ResultType`, `NameType`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `U` |
+| `listener` | `WorkerListener`<`T`, `any`, `string`\>[`U`] |
+
+#### Returns
+
+[`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Inherited from
+
+Worker.off
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:97
+
+___
+
+### on
+
+▸ **on**<`U`\>(`event`, `listener`): [`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `U` | extends keyof `WorkerListener`<`DataType`, `ResultType`, `NameType`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `U` |
+| `listener` | `WorkerListener`<`T`, `any`, `string`\>[`U`] |
+
+#### Returns
+
+[`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Inherited from
+
+Worker.on
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:98
+
+___
+
+### once
+
+▸ **once**<`U`\>(`event`, `listener`): [`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `U` | extends keyof `WorkerListener`<`DataType`, `ResultType`, `NameType`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `U` |
+| `listener` | `WorkerListener`<`T`, `any`, `string`\>[`U`] |
+
+#### Returns
+
+[`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Inherited from
+
+Worker.once
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:99
+
+___
+
+### pause
+
+▸ **pause**(`doNotWaitActive?`): `Promise`<`void`\>
+
+Pauses the processing of this queue only for this worker.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `doNotWaitActive?` | `boolean` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Inherited from
+
+Worker.pause
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:131
+
+___
+
+### prependListener
+
+▸ **prependListener**(`eventName`, `listener`): [`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+Adds the `listener` function to the _beginning_ of the listeners array for the
+event named `eventName`. No checks are made to see if the `listener` has
+already been added. Multiple calls passing the same combination of `eventName`and `listener` will result in the `listener` being added, and called, multiple
+times.
+
+```js
+server.prependListener('connection', (stream) => {
+  console.log('someone connected!');
+});
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v6.0.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event. |
+| `listener` | (...`args`: `any`[]) => `void` | The callback function |
+
+#### Returns
+
+[`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Inherited from
+
+Worker.prependListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:597
+
+___
+
+### prependOnceListener
+
+▸ **prependOnceListener**(`eventName`, `listener`): [`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+Adds a **one-time**`listener` function for the event named `eventName` to the_beginning_ of the listeners array. The next time `eventName` is triggered, this
+listener is removed, and then invoked.
+
+```js
+server.prependOnceListener('connection', (stream) => {
+  console.log('Ah, we have our first user!');
+});
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v6.0.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event. |
+| `listener` | (...`args`: `any`[]) => `void` | The callback function |
+
+#### Returns
+
+[`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Inherited from
+
+Worker.prependOnceListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:613
+
+___
+
+### processJob
+
+▸ **processJob**(`job`, `token`, `fetchNextCallback?`): `Promise`<`void` \| `Job`<`T`, `any`, `string`\>\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `job` | `Job`<`T`, `any`, `string`\> |
+| `token` | `string` |
+| `fetchNextCallback?` | () => `boolean` |
+
+#### Returns
+
+`Promise`<`void` \| `Job`<`T`, `any`, `string`\>\>
+
+#### Inherited from
+
+Worker.processJob
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:126
+
+___
+
+### rawListeners
+
+▸ **rawListeners**(`eventName`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`,
+including any wrappers (such as those created by `.once()`).
+
+```js
+const emitter = new EventEmitter();
+emitter.once('log', () => console.log('log once'));
+
+// Returns a new Array with a function `onceWrapper` which has a property
+// `listener` which contains the original listener bound above
+const listeners = emitter.rawListeners('log');
+const logFnWrapper = listeners[0];
+
+// Logs "log once" to the console and does not unbind the `once` event
+logFnWrapper.listener();
+
+// Logs "log once" to the console and removes the listener
+logFnWrapper();
+
+emitter.on('log', () => console.log('log persistently'));
+// Will return a new Array with a single function bound by `.on()` above
+const newListeners = emitter.rawListeners('log');
+
+// Logs "log persistently" twice
+newListeners[0]();
+emitter.emit('log');
+```
+
+**`Since`**
+
+v9.4.0
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+
+#### Returns
+
+`Function`[]
+
+#### Inherited from
+
+Worker.rawListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:532
+
+___
+
+### removeAllListeners
+
+▸ **removeAllListeners**(`event?`): [`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+Removes all listeners, or those of the specified `eventName`.
+
+It is bad practice to remove listeners added elsewhere in the code,
+particularly when the `EventEmitter` instance was created by some other
+component or module (e.g. sockets or file streams).
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v0.1.26
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event?` | `string` \| `symbol` |
+
+#### Returns
+
+[`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Inherited from
+
+Worker.removeAllListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:473
+
+___
+
+### removeListener
+
+▸ **removeListener**(`eventName`, `listener`): [`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+Removes the specified `listener` from the listener array for the event named`eventName`.
+
+```js
+const callback = (stream) => {
+  console.log('someone connected!');
+};
+server.on('connection', callback);
+// ...
+server.removeListener('connection', callback);
+```
+
+`removeListener()` will remove, at most, one instance of a listener from the
+listener array. If any single listener has been added multiple times to the
+listener array for the specified `eventName`, then `removeListener()` must be
+called multiple times to remove each instance.
+
+Once an event is emitted, all listeners attached to it at the
+time of emitting are called in order. This implies that any`removeListener()` or `removeAllListeners()` calls _after_ emitting and_before_ the last listener finishes execution will
+not remove them from`emit()` in progress. Subsequent events behave as expected.
+
+```js
+const myEmitter = new MyEmitter();
+
+const callbackA = () => {
+  console.log('A');
+  myEmitter.removeListener('event', callbackB);
+};
+
+const callbackB = () => {
+  console.log('B');
+};
+
+myEmitter.on('event', callbackA);
+
+myEmitter.on('event', callbackB);
+
+// callbackA removes listener callbackB but it will still be called.
+// Internal listener array at time of emit [callbackA, callbackB]
+myEmitter.emit('event');
+// Prints:
+//   A
+//   B
+
+// callbackB is now removed.
+// Internal listener array [callbackA]
+myEmitter.emit('event');
+// Prints:
+//   A
+```
+
+Because listeners are managed using an internal array, calling this will
+change the position indices of any listener registered _after_ the listener
+being removed. This will not impact the order in which listeners are called,
+but it means that any copies of the listener array as returned by
+the `emitter.listeners()` method will need to be recreated.
+
+When a single function has been added as a handler multiple times for a single
+event (as in the example below), `removeListener()` will remove the most
+recently added instance. In the example the `once('ping')`listener is removed:
+
+```js
+const ee = new EventEmitter();
+
+function pong() {
+  console.log('pong');
+}
+
+ee.on('ping', pong);
+ee.once('ping', pong);
+ee.removeListener('ping', pong);
+
+ee.emit('ping');
+ee.emit('ping');
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v0.1.26
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Inherited from
+
+Worker.removeListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:457
+
+___
+
+### resume
+
+▸ **resume**(): `void`
+
+Resumes processing of this worker (if paused).
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Worker.resume
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:136
+
+___
+
+### run
+
+▸ **run**(): `Promise`<`any`[]\>
+
+#### Returns
+
+`Promise`<`any`[]\>
+
+#### Inherited from
+
+Worker.run
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:111
+
+___
+
+### setMaxListeners
+
+▸ **setMaxListeners**(`n`): [`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+By default `EventEmitter`s will print a warning if more than `10` listeners are
+added for a particular event. This is a useful default that helps finding
+memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
+modified for this specific `EventEmitter` instance. The value can be set to`Infinity` (or `0`) to indicate an unlimited number of listeners.
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v0.3.5
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `n` | `number` |
+
+#### Returns
+
+[`TakaroWorker`](takaro_queues.TakaroWorker.md)<`T`\>
+
+#### Inherited from
+
+Worker.setMaxListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:483
+
+___
+
+### waitUntilReady
+
+▸ **waitUntilReady**(): `Promise`<`RedisClient`\>
+
+Waits until the worker is ready to start processing jobs.
+In general only useful when writing tests.
+
+#### Returns
+
+`Promise`<`RedisClient`\>
+
+#### Inherited from
+
+Worker.waitUntilReady
+
+#### Defined in
+
+node_modules/bullmq/dist/esm/classes/worker.d.ts:108
+
+___
+
+### getEventListeners
+
+▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`.
+
+For `EventEmitter`s this behaves exactly the same as calling `.listeners` on
+the emitter.
+
+For `EventTarget`s this is the only way to get the event listeners for the
+event target. This is useful for debugging and diagnostic purposes.
+
+```js
+const { getEventListeners, EventEmitter } = require('events');
+
+{
+  const ee = new EventEmitter();
+  const listener = () => console.log('Events are fun');
+  ee.on('foo', listener);
+  getEventListeners(ee, 'foo'); // [listener]
+}
+{
+  const et = new EventTarget();
+  const listener = () => console.log('Events are fun');
+  et.addEventListener('foo', listener);
+  getEventListeners(et, 'foo'); // [listener]
+}
+```
+
+**`Since`**
+
+v15.2.0
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `emitter` | `EventEmitter` \| `DOMEventTarget` |
+| `name` | `string` \| `symbol` |
+
+#### Returns
+
+`Function`[]
+
+#### Inherited from
+
+Worker.getEventListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:262
+
+___
+
+### listenerCount
+
+▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+
+A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+
+```js
+const { EventEmitter, listenerCount } = require('events');
+const myEmitter = new EventEmitter();
+myEmitter.on('event', () => {});
+myEmitter.on('event', () => {});
+console.log(listenerCount(myEmitter, 'event'));
+// Prints: 2
+```
+
+**`Since`**
+
+v0.9.12
+
+**`Deprecated`**
+
+Since v3.2.0 - Use `listenerCount` instead.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `emitter` | `EventEmitter` | The emitter to query |
+| `eventName` | `string` \| `symbol` | The event name |
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+Worker.listenerCount
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:234
+
+___
+
+### on
+
+▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+
+```js
+const { on, EventEmitter } = require('events');
+
+(async () => {
+  const ee = new EventEmitter();
+
+  // Emit later on
+  process.nextTick(() => {
+    ee.emit('foo', 'bar');
+    ee.emit('foo', 42);
+  });
+
+  for await (const event of on(ee, 'foo')) {
+    // The execution of this inner block is synchronous and it
+    // processes one event at a time (even with await). Do not use
+    // if concurrent execution is required.
+    console.log(event); // prints ['bar'] [42]
+  }
+  // Unreachable here
+})();
+```
+
+Returns an `AsyncIterator` that iterates `eventName` events. It will throw
+if the `EventEmitter` emits `'error'`. It removes all listeners when
+exiting the loop. The `value` returned by each iteration is an array
+composed of the emitted event arguments.
+
+An `AbortSignal` can be used to cancel waiting on events:
+
+```js
+const { on, EventEmitter } = require('events');
+const ac = new AbortController();
+
+(async () => {
+  const ee = new EventEmitter();
+
+  // Emit later on
+  process.nextTick(() => {
+    ee.emit('foo', 'bar');
+    ee.emit('foo', 42);
+  });
+
+  for await (const event of on(ee, 'foo', { signal: ac.signal })) {
+    // The execution of this inner block is synchronous and it
+    // processes one event at a time (even with await). Do not use
+    // if concurrent execution is required.
+    console.log(event); // prints ['bar'] [42]
+  }
+  // Unreachable here
+})();
+
+process.nextTick(() => ac.abort());
+```
+
+**`Since`**
+
+v13.6.0, v12.16.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `emitter` | `EventEmitter` | - |
+| `eventName` | `string` | The name of the event being listened for |
+| `options?` | `StaticEventEmitterOptions` | - |
+
+#### Returns
+
+`AsyncIterableIterator`<`any`\>
+
+that iterates `eventName` events emitted by the `emitter`
+
+#### Inherited from
+
+Worker.on
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:217
+
+___
+
+### once
+
+▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+
+Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
+event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
+The `Promise` will resolve with an array of all the arguments emitted to the
+given event.
+
+This method is intentionally generic and works with the web platform [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget) interface, which has no special`'error'` event
+semantics and does not listen to the `'error'` event.
+
+```js
+const { once, EventEmitter } = require('events');
+
+async function run() {
+  const ee = new EventEmitter();
+
+  process.nextTick(() => {
+    ee.emit('myevent', 42);
+  });
+
+  const [value] = await once(ee, 'myevent');
+  console.log(value);
+
+  const err = new Error('kaboom');
+  process.nextTick(() => {
+    ee.emit('error', err);
+  });
+
+  try {
+    await once(ee, 'myevent');
+  } catch (err) {
+    console.log('error happened', err);
+  }
+}
+
+run();
+```
+
+The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
+'`error'` event itself, then it is treated as any other kind of event without
+special handling:
+
+```js
+const { EventEmitter, once } = require('events');
+
+const ee = new EventEmitter();
+
+once(ee, 'error')
+  .then(([err]) => console.log('ok', err.message))
+  .catch((err) => console.log('error', err.message));
+
+ee.emit('error', new Error('boom'));
+
+// Prints: ok boom
+```
+
+An `AbortSignal` can be used to cancel waiting for the event:
+
+```js
+const { EventEmitter, once } = require('events');
+
+const ee = new EventEmitter();
+const ac = new AbortController();
+
+async function foo(emitter, event, signal) {
+  try {
+    await once(emitter, event, { signal });
+    console.log('event emitted!');
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      console.error('Waiting for the event was canceled!');
+    } else {
+      console.error('There was an error', error.message);
+    }
+  }
+}
+
+foo(ee, 'foo', ac.signal);
+ac.abort(); // Abort waiting for the event
+ee.emit('foo'); // Prints: Waiting for the event was canceled!
+```
+
+**`Since`**
+
+v11.13.0, v10.16.0
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `emitter` | `NodeEventTarget` |
+| `eventName` | `string` \| `symbol` |
+| `options?` | `StaticEventEmitterOptions` |
+
+#### Returns
+
+`Promise`<`any`[]\>
+
+#### Inherited from
+
+Worker.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:157
+
+▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `emitter` | `DOMEventTarget` |
+| `eventName` | `string` |
+| `options?` | `StaticEventEmitterOptions` |
+
+#### Returns
+
+`Promise`<`any`[]\>
+
+#### Inherited from
+
+Worker.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:158
+
+___
+
+### setMaxListeners
+
+▸ `Static` **setMaxListeners**(`n?`, ...`eventTargets`): `void`
+
+```js
+const {
+  setMaxListeners,
+  EventEmitter
+} = require('events');
+
+const target = new EventTarget();
+const emitter = new EventEmitter();
+
+setMaxListeners(5, target, emitter);
+```
+
+**`Since`**
+
+v15.4.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `n?` | `number` | A non-negative number. The maximum number of listeners per `EventTarget` event. |
+| `...eventTargets` | (`EventEmitter` \| `DOMEventTarget`)[] | - |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Worker.setMaxListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:280

--- a/packages/web-docs/docs/development/packages/classes/takaro_test.IntegrationTest.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_test.IntegrationTest.md
@@ -1,0 +1,150 @@
+---
+id: "takaro_test.IntegrationTest"
+title: "Class: IntegrationTest<SetupData>"
+sidebar_label: "@takaro/test.IntegrationTest"
+custom_edit_url: null
+---
+
+[@takaro/test](../modules/takaro_test.md).IntegrationTest
+
+## Type parameters
+
+| Name |
+| :------ |
+| `SetupData` |
+
+## Constructors
+
+### constructor
+
+• **new IntegrationTest**<`SetupData`\>(`test`)
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SetupData` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `test` | `IIntegrationTest`<`SetupData`\> \| [`ITestWithSnapshot`](takaro_test.snapshot.ITestWithSnapshot.md)<`SetupData`\> |
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:45](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L45)
+
+## Properties
+
+### adminClient
+
+• `Readonly` **adminClient**: `AdminClient`
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:35](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L35)
+
+___
+
+### client
+
+• `Readonly` **client**: `Client`
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:36](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L36)
+
+___
+
+### log
+
+• `Protected` **log**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `debug` | () => `void` |
+| `error` | () => `void` |
+| `info` | () => `void` |
+| `warn` | () => `void` |
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:28](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L28)
+
+___
+
+### setupData
+
+• **setupData**: `Awaited`<`SetupData`\>
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:39](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L39)
+
+___
+
+### standardDomainId
+
+• **standardDomainId**: ``null`` \| `string` = `null`
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:38](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L38)
+
+___
+
+### standardLogin
+
+• **standardLogin**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `password` | `string` |
+| `username` | `string` |
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:40](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L40)
+
+___
+
+### test
+
+• **test**: `IIntegrationTest`<`SetupData`\> \| [`ITestWithSnapshot`](takaro_test.snapshot.ITestWithSnapshot.md)<`SetupData`\>
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:46](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L46)
+
+## Methods
+
+### run
+
+▸ **run**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:86](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L86)
+
+___
+
+### setupStandardEnvironment
+
+▸ `Private` **setupStandardEnvironment**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:69](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L69)

--- a/packages/web-docs/docs/development/packages/classes/takaro_test.snapshot.ITestWithSnapshot.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_test.snapshot.ITestWithSnapshot.md
@@ -1,0 +1,204 @@
+---
+id: "takaro_test.snapshot.ITestWithSnapshot"
+title: "Class: ITestWithSnapshot<SetupData>"
+sidebar_label: "@takaro/test.snapshot.ITestWithSnapshot"
+custom_edit_url: null
+---
+
+[@takaro/test](../modules/takaro_test.md).[snapshot](../namespaces/takaro_test.snapshot.md).ITestWithSnapshot
+
+## Type parameters
+
+| Name |
+| :------ |
+| `SetupData` |
+
+## Hierarchy
+
+- `IIntegrationTest`<`SetupData`\>
+
+  ↳ **`ITestWithSnapshot`**
+
+## Constructors
+
+### constructor
+
+• **new ITestWithSnapshot**<`SetupData`\>()
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `SetupData` |
+
+#### Inherited from
+
+IIntegrationTest<SetupData\>.constructor
+
+## Properties
+
+### expectedStatus
+
+• `Optional` **expectedStatus**: `number` = `200`
+
+#### Overrides
+
+IIntegrationTest.expectedStatus
+
+#### Defined in
+
+[packages/test/src/snapshots.ts:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/snapshots.ts#L20)
+
+___
+
+### filteredFields
+
+• `Optional` **filteredFields**: `string`[]
+
+#### Overrides
+
+IIntegrationTest.filteredFields
+
+#### Defined in
+
+[packages/test/src/snapshots.ts:21](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/snapshots.ts#L21)
+
+___
+
+### group
+
+• **group**: `string`
+
+#### Overrides
+
+IIntegrationTest.group
+
+#### Defined in
+
+[packages/test/src/snapshots.ts:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/snapshots.ts#L12)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Overrides
+
+IIntegrationTest.name
+
+#### Defined in
+
+[packages/test/src/snapshots.ts:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/snapshots.ts#L13)
+
+___
+
+### setup
+
+• `Optional` **setup**: (`this`: [`IntegrationTest`](takaro_test.IntegrationTest.md)<`SetupData`\>) => `Promise`<`SetupData`\>
+
+#### Type declaration
+
+▸ (`this`): `Promise`<`SetupData`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`IntegrationTest`](takaro_test.IntegrationTest.md)<`SetupData`\> |
+
+##### Returns
+
+`Promise`<`SetupData`\>
+
+#### Overrides
+
+IIntegrationTest.setup
+
+#### Defined in
+
+[packages/test/src/snapshots.ts:15](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/snapshots.ts#L15)
+
+___
+
+### snapshot
+
+• **snapshot**: `boolean` = `true`
+
+#### Overrides
+
+IIntegrationTest.snapshot
+
+#### Defined in
+
+[packages/test/src/snapshots.ts:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/snapshots.ts#L11)
+
+___
+
+### standardEnvironment
+
+• `Optional` **standardEnvironment**: `boolean` = `true`
+
+#### Overrides
+
+IIntegrationTest.standardEnvironment
+
+#### Defined in
+
+[packages/test/src/snapshots.ts:14](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/snapshots.ts#L14)
+
+___
+
+### teardown
+
+• `Optional` **teardown**: (`this`: [`IntegrationTest`](takaro_test.IntegrationTest.md)<`SetupData`\>) => `Promise`<`void`\>
+
+#### Type declaration
+
+▸ (`this`): `Promise`<`void`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`IntegrationTest`](takaro_test.IntegrationTest.md)<`SetupData`\> |
+
+##### Returns
+
+`Promise`<`void`\>
+
+#### Overrides
+
+IIntegrationTest.teardown
+
+#### Defined in
+
+[packages/test/src/snapshots.ts:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/snapshots.ts#L16)
+
+___
+
+### test
+
+• **test**: (`this`: [`IntegrationTest`](takaro_test.IntegrationTest.md)<`SetupData`\>) => `Promise`<`ITakaroAPIAxiosResponse`<`unknown`\>\>
+
+#### Type declaration
+
+▸ (`this`): `Promise`<`ITakaroAPIAxiosResponse`<`unknown`\>\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `this` | [`IntegrationTest`](takaro_test.IntegrationTest.md)<`SetupData`\> |
+
+##### Returns
+
+`Promise`<`ITakaroAPIAxiosResponse`<`unknown`\>\>
+
+#### Overrides
+
+IIntegrationTest.test
+
+#### Defined in
+
+[packages/test/src/snapshots.ts:17](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/snapshots.ts#L17)

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.TakaroDTO.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.TakaroDTO.md
@@ -1,0 +1,67 @@
+---
+id: "takaro_util.TakaroDTO"
+title: "Class: TakaroDTO<T>"
+sidebar_label: "@takaro/util.TakaroDTO"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).TakaroDTO
+
+Generic Data Transfer Object, used widely in Takaro to pass data back and forth between components
+Allows validation of properties when instantiated and JSON (de)serialization
+
+## Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+## Constructors
+
+### constructor
+
+• **new TakaroDTO**<`T`\>(`data?`)
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Partial`<`T`\> |
+
+#### Defined in
+
+[packages/lib-util/src/dto/TakaroDTO.ts:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/dto/TakaroDTO.ts#L11)
+
+## Methods
+
+### toJSON
+
+▸ **toJSON**(): `Record`<`string`, `any`\>
+
+#### Returns
+
+`Record`<`string`, `any`\>
+
+#### Defined in
+
+[packages/lib-util/src/dto/TakaroDTO.ts:29](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/dto/TakaroDTO.ts#L29)
+
+___
+
+### validate
+
+▸ **validate**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-util/src/dto/TakaroDTO.ts:15](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/dto/TakaroDTO.ts#L15)

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.BadRequestError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.BadRequestError.md
@@ -1,0 +1,166 @@
+---
+id: "takaro_util.errors.BadRequestError"
+title: "Class: BadRequestError"
+sidebar_label: "@takaro/util.errors.BadRequestError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).BadRequestError
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`BadRequestError`**
+
+## Constructors
+
+### constructor
+
+• **new BadRequestError**(`message?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `message` | `string` | `'Bad request'` |
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:65](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L65)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.ConfigError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.ConfigError.md
@@ -1,0 +1,166 @@
+---
+id: "takaro_util.errors.ConfigError"
+title: "Class: ConfigError"
+sidebar_label: "@takaro/util.errors.ConfigError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).ConfigError
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`ConfigError`**
+
+## Constructors
+
+### constructor
+
+• **new ConfigError**(`message`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:21](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L21)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.ConflictError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.ConflictError.md
@@ -1,0 +1,166 @@
+---
+id: "takaro_util.errors.ConflictError"
+title: "Class: ConflictError"
+sidebar_label: "@takaro/util.errors.ConflictError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).ConflictError
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`ConflictError`**
+
+## Constructors
+
+### constructor
+
+• **new ConflictError**(`message?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `message` | `string` | `'Conflict'` |
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:101](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L101)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.ForbiddenError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.ForbiddenError.md
@@ -1,0 +1,163 @@
+---
+id: "takaro_util.errors.ForbiddenError"
+title: "Class: ForbiddenError"
+sidebar_label: "@takaro/util.errors.ForbiddenError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).ForbiddenError
+
+Intentionally does not accept metadata.
+log additional info and do not leak info to the client
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`ForbiddenError`**
+
+## Constructors
+
+### constructor
+
+• **new ForbiddenError**()
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:87](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L87)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.GameServerError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.GameServerError.md
@@ -1,0 +1,166 @@
+---
+id: "takaro_util.errors.GameServerError"
+title: "Class: GameServerError"
+sidebar_label: "@takaro/util.errors.GameServerError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).GameServerError
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`GameServerError`**
+
+## Constructors
+
+### constructor
+
+• **new GameServerError**(`message?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `message` | `string` | `'Game server error'` |
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:52](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L52)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.InternalServerError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.InternalServerError.md
@@ -1,0 +1,160 @@
+---
+id: "takaro_util.errors.InternalServerError"
+title: "Class: InternalServerError"
+sidebar_label: "@takaro/util.errors.InternalServerError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).InternalServerError
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`InternalServerError`**
+
+## Constructors
+
+### constructor
+
+• **new InternalServerError**()
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:14](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L14)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.NotFoundError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.NotFoundError.md
@@ -1,0 +1,166 @@
+---
+id: "takaro_util.errors.NotFoundError"
+title: "Class: NotFoundError"
+sidebar_label: "@takaro/util.errors.NotFoundError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).NotFoundError
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`NotFoundError`**
+
+## Constructors
+
+### constructor
+
+• **new NotFoundError**(`message?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `message` | `string` | `'Not found'` |
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:94](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L94)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.NotImplementedError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.NotImplementedError.md
@@ -1,0 +1,160 @@
+---
+id: "takaro_util.errors.NotImplementedError"
+title: "Class: NotImplementedError"
+sidebar_label: "@takaro/util.errors.NotImplementedError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).NotImplementedError
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`NotImplementedError`**
+
+## Constructors
+
+### constructor
+
+• **new NotImplementedError**()
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:28](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L28)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.TakaroError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.TakaroError.md
@@ -1,0 +1,184 @@
+---
+id: "takaro_util.errors.TakaroError"
+title: "Class: TakaroError"
+sidebar_label: "@takaro/util.errors.TakaroError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).TakaroError
+
+## Hierarchy
+
+- `Error`
+
+  ↳ **`TakaroError`**
+
+  ↳↳ [`InternalServerError`](takaro_util.errors.InternalServerError.md)
+
+  ↳↳ [`ConfigError`](takaro_util.errors.ConfigError.md)
+
+  ↳↳ [`NotImplementedError`](takaro_util.errors.NotImplementedError.md)
+
+  ↳↳ [`ValidationError`](takaro_util.errors.ValidationError.md)
+
+  ↳↳ [`GameServerError`](takaro_util.errors.GameServerError.md)
+
+  ↳↳ [`WsTimeOutError`](takaro_util.errors.WsTimeOutError.md)
+
+  ↳↳ [`BadRequestError`](takaro_util.errors.BadRequestError.md)
+
+  ↳↳ [`UnauthorizedError`](takaro_util.errors.UnauthorizedError.md)
+
+  ↳↳ [`ForbiddenError`](takaro_util.errors.ForbiddenError.md)
+
+  ↳↳ [`NotFoundError`](takaro_util.errors.NotFoundError.md)
+
+  ↳↳ [`ConflictError`](takaro_util.errors.ConflictError.md)
+
+## Constructors
+
+### constructor
+
+• **new TakaroError**(`message`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+
+#### Overrides
+
+Error.constructor
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:6](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L6)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+Error.message
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+Error.name
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+Error.stack
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+Error.prepareStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+Error.stackTraceLimit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Error.captureStackTrace
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.UnauthorizedError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.UnauthorizedError.md
@@ -1,0 +1,163 @@
+---
+id: "takaro_util.errors.UnauthorizedError"
+title: "Class: UnauthorizedError"
+sidebar_label: "@takaro/util.errors.UnauthorizedError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).UnauthorizedError
+
+Intentionally does not accept metadata.
+log additional info and do not leak info to the client
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`UnauthorizedError`**
+
+## Constructors
+
+### constructor
+
+• **new UnauthorizedError**()
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:76](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L76)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.ValidationError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.ValidationError.md
@@ -1,0 +1,177 @@
+---
+id: "takaro_util.errors.ValidationError"
+title: "Class: ValidationError"
+sidebar_label: "@takaro/util.errors.ValidationError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).ValidationError
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`ValidationError`**
+
+## Constructors
+
+### constructor
+
+• **new ValidationError**(`message`, `details?`)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | `string` |
+| `details?` | `ValidationError`[] \| `default`[] |
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:35](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L35)
+
+## Properties
+
+### details
+
+• `Optional` **details**: `ValidationError`[] \| `default`[]
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:37](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L37)
+
+___
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/classes/takaro_util.errors.WsTimeOutError.md
+++ b/packages/web-docs/docs/development/packages/classes/takaro_util.errors.WsTimeOutError.md
@@ -1,0 +1,166 @@
+---
+id: "takaro_util.errors.WsTimeOutError"
+title: "Class: WsTimeOutError"
+sidebar_label: "@takaro/util.errors.WsTimeOutError"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).[errors](../namespaces/takaro_util.errors.md).WsTimeOutError
+
+## Hierarchy
+
+- [`TakaroError`](takaro_util.errors.TakaroError.md)
+
+  ↳ **`WsTimeOutError`**
+
+## Constructors
+
+### constructor
+
+• **new WsTimeOutError**(`message?`)
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `message` | `string` | `'Websocket timeout Error'` |
+
+#### Overrides
+
+[TakaroError](takaro_util.errors.TakaroError.md).[constructor](takaro_util.errors.TakaroError.md#constructor)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L58)
+
+## Properties
+
+### http
+
+• **http**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[http](takaro_util.errors.TakaroError.md#http)
+
+#### Defined in
+
+[packages/lib-util/src/errors.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/errors.ts#L5)
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[message](takaro_util.errors.TakaroError.md#message)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[name](takaro_util.errors.TakaroError.md#name)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stack](takaro_util.errors.TakaroError.md#stack)
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[prepareStackTrace](takaro_util.errors.TakaroError.md#preparestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[stackTraceLimit](takaro_util.errors.TakaroError.md#stacktracelimit)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:13
+
+## Methods
+
+### captureStackTrace
+
+▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+[TakaroError](takaro_util.errors.TakaroError.md).[captureStackTrace](takaro_util.errors.TakaroError.md#capturestacktrace)
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/globals.d.ts:4

--- a/packages/web-docs/docs/development/packages/enums/_category_.yml
+++ b/packages/web-docs/docs/development/packages/enums/_category_.yml
@@ -1,0 +1,2 @@
+label: "Enumerations"
+position: 2

--- a/packages/web-docs/docs/development/packages/enums/takaro_gameserver.GameEvents.md
+++ b/packages/web-docs/docs/development/packages/enums/takaro_gameserver.GameEvents.md
@@ -1,0 +1,48 @@
+---
+id: "takaro_gameserver.GameEvents"
+title: "Enumeration: GameEvents"
+sidebar_label: "@takaro/gameserver.GameEvents"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).GameEvents
+
+## Enumeration Members
+
+### CHAT\_MESSAGE
+
+• **CHAT\_MESSAGE** = ``"chat-message"``
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L10)
+
+___
+
+### LOG\_LINE
+
+• **LOG\_LINE** = ``"log"``
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L7)
+
+___
+
+### PLAYER\_CONNECTED
+
+• **PLAYER\_CONNECTED** = ``"player-connected"``
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L8)
+
+___
+
+### PLAYER\_DISCONNECTED
+
+• **PLAYER\_DISCONNECTED** = ``"player-disconnected"``
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L9)

--- a/packages/web-docs/docs/development/packages/index.md
+++ b/packages/web-docs/docs/development/packages/index.md
@@ -1,0 +1,8 @@
+---
+id: "index"
+title: "Documentation"
+sidebar_label: "Readme"
+sidebar_position: 0
+custom_edit_url: null
+---
+

--- a/packages/web-docs/docs/development/packages/interfaces/_category_.yml
+++ b/packages/web-docs/docs/development/packages/interfaces/_category_.yml
@@ -1,0 +1,2 @@
+label: "Interfaces"
+position: 4

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.APIOutput.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.APIOutput.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.APIOutput"
+title: "Interface: APIOutput"
+sidebar_label: "@takaro/apiclient.APIOutput"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).APIOutput
+
+**`Export`**
+
+**`Interface`**
+
+APIOutput
+
+## Properties
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+APIOutput
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L55)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.AxiosError.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.AxiosError.md
@@ -1,0 +1,131 @@
+---
+id: "takaro_apiclient.AxiosError"
+title: "Interface: AxiosError<T, D>"
+sidebar_label: "@takaro/apiclient.AxiosError"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).AxiosError
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | `any` |
+| `D` | `any` |
+
+## Hierarchy
+
+- `Error`
+
+  ↳ **`AxiosError`**
+
+## Properties
+
+### code
+
+• `Optional` **code**: `string`
+
+#### Defined in
+
+node_modules/axios/index.d.ts:141
+
+___
+
+### config
+
+• **config**: `AxiosRequestConfig`<`D`\>
+
+#### Defined in
+
+node_modules/axios/index.d.ts:140
+
+___
+
+### isAxiosError
+
+• **isAxiosError**: `boolean`
+
+#### Defined in
+
+node_modules/axios/index.d.ts:144
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+Error.message
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1041
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+Error.name
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1040
+
+___
+
+### request
+
+• `Optional` **request**: `any`
+
+#### Defined in
+
+node_modules/axios/index.d.ts:142
+
+___
+
+### response
+
+• `Optional` **response**: [`AxiosResponse`](takaro_apiclient.AxiosResponse.md)<`T`, `D`\>
+
+#### Defined in
+
+node_modules/axios/index.d.ts:143
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+Error.stack
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1042
+
+___
+
+### toJSON
+
+• **toJSON**: () => `object`
+
+#### Type declaration
+
+▸ (): `object`
+
+##### Returns
+
+`object`
+
+#### Defined in
+
+node_modules/axios/index.d.ts:145

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.AxiosResponse.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.AxiosResponse.md
@@ -1,0 +1,75 @@
+---
+id: "takaro_apiclient.AxiosResponse"
+title: "Interface: AxiosResponse<T, D>"
+sidebar_label: "@takaro/apiclient.AxiosResponse"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).AxiosResponse
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | `any` |
+| `D` | `any` |
+
+## Properties
+
+### config
+
+• **config**: `AxiosRequestConfig`<`D`\>
+
+#### Defined in
+
+node_modules/axios/index.d.ts:135
+
+___
+
+### data
+
+• **data**: `T`
+
+#### Defined in
+
+node_modules/axios/index.d.ts:131
+
+___
+
+### headers
+
+• **headers**: `AxiosResponseHeaders`
+
+#### Defined in
+
+node_modules/axios/index.d.ts:134
+
+___
+
+### request
+
+• `Optional` **request**: `any`
+
+#### Defined in
+
+node_modules/axios/index.d.ts:136
+
+___
+
+### status
+
+• **status**: `number`
+
+#### Defined in
+
+node_modules/axios/index.d.ts:132
+
+___
+
+### statusText
+
+• **statusText**: `string`
+
+#### Defined in
+
+node_modules/axios/index.d.ts:133

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.BaseEvent.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.BaseEvent.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.BaseEvent"
+title: "Interface: BaseEvent"
+sidebar_label: "@takaro/apiclient.BaseEvent"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).BaseEvent
+
+**`Export`**
+
+**`Interface`**
+
+BaseEvent
+
+## Properties
+
+### msg
+
+• **msg**: `string`
+
+**`Memberof`**
+
+BaseEvent
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:80](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L80)
+
+___
+
+### timestamp
+
+• **timestamp**: `string`
+
+**`Memberof`**
+
+BaseEvent
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:68](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L68)
+
+___
+
+### type
+
+• **type**: [`BaseEventTypeEnum`](../modules/takaro_apiclient.md#baseeventtypeenum-1)
+
+**`Memberof`**
+
+BaseEvent
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:74](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L74)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CapabilityOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CapabilityOutputDTO.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.CapabilityOutputDTO"
+title: "Interface: CapabilityOutputDTO"
+sidebar_label: "@takaro/apiclient.CapabilityOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CapabilityOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+CapabilityOutputDTO
+
+## Properties
+
+### capability
+
+• **capability**: [`CapabilityOutputDTOCapabilityEnum`](../modules/takaro_apiclient.md#capabilityoutputdtocapabilityenum-1)
+
+**`Memberof`**
+
+CapabilityOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:116](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L116)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+CapabilityOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:110](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L110)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandCreateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandCreateDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.CommandCreateDTO"
+title: "Interface: CommandCreateDTO"
+sidebar_label: "@takaro/apiclient.CommandCreateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CommandCreateDTO
+
+**`Export`**
+
+**`Interface`**
+
+CommandCreateDTO
+
+## Properties
+
+### enabled
+
+• `Optional` **enabled**: `boolean`
+
+**`Memberof`**
+
+CommandCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:175](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L175)
+
+___
+
+### function
+
+• `Optional` **function**: `string`
+
+**`Memberof`**
+
+CommandCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:187](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L187)
+
+___
+
+### helpText
+
+• `Optional` **helpText**: `string`
+
+**`Memberof`**
+
+CommandCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:169](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L169)
+
+___
+
+### moduleId
+
+• **moduleId**: `string`
+
+**`Memberof`**
+
+CommandCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:181](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L181)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+CommandCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:157](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L157)
+
+___
+
+### trigger
+
+• **trigger**: `string`
+
+**`Memberof`**
+
+CommandCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:163](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L163)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandOutputArrayDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandOutputArrayDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.CommandOutputArrayDTOAPI"
+title: "Interface: CommandOutputArrayDTOAPI"
+sidebar_label: "@takaro/apiclient.CommandOutputArrayDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CommandOutputArrayDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+CommandOutputArrayDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`CommandOutputDTO`](takaro_apiclient.CommandOutputDTO.md)[]
+
+**`Memberof`**
+
+CommandOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:200](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L200)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+CommandOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:206](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L206)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandOutputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.CommandOutputDTO"
+title: "Interface: CommandOutputDTO"
+sidebar_label: "@takaro/apiclient.CommandOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CommandOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+CommandOutputDTO
+
+## Properties
+
+### enabled
+
+• **enabled**: `boolean`
+
+**`Memberof`**
+
+CommandOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:243](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L243)
+
+___
+
+### function
+
+• **function**: [`FunctionOutputDTO`](takaro_apiclient.FunctionOutputDTO.md)
+
+**`Memberof`**
+
+CommandOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:249](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L249)
+
+___
+
+### helpText
+
+• **helpText**: `string`
+
+**`Memberof`**
+
+CommandOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:237](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L237)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+CommandOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:219](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L219)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+CommandOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:225](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L225)
+
+___
+
+### trigger
+
+• **trigger**: `string`
+
+**`Memberof`**
+
+CommandOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:231](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L231)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.CommandOutputDTOAPI"
+title: "Interface: CommandOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.CommandOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CommandOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+CommandOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`CommandOutputDTO`](takaro_apiclient.CommandOutputDTO.md)
+
+**`Memberof`**
+
+CommandOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:262](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L262)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+CommandOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:268](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L268)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandSearchInputAllowedFilters.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandSearchInputAllowedFilters.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.CommandSearchInputAllowedFilters"
+title: "Interface: CommandSearchInputAllowedFilters"
+sidebar_label: "@takaro/apiclient.CommandSearchInputAllowedFilters"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CommandSearchInputAllowedFilters
+
+**`Export`**
+
+**`Interface`**
+
+CommandSearchInputAllowedFilters
+
+## Properties
+
+### enabled
+
+• `Optional` **enabled**: `boolean`
+
+**`Memberof`**
+
+CommandSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:293](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L293)
+
+___
+
+### id
+
+• `Optional` **id**: `string`
+
+**`Memberof`**
+
+CommandSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:281](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L281)
+
+___
+
+### name
+
+• `Optional` **name**: `string`
+
+**`Memberof`**
+
+CommandSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:287](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L287)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandSearchInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandSearchInputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.CommandSearchInputDTO"
+title: "Interface: CommandSearchInputDTO"
+sidebar_label: "@takaro/apiclient.CommandSearchInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CommandSearchInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+CommandSearchInputDTO
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+CommandSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:336](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L336)
+
+___
+
+### filters
+
+• `Optional` **filters**: [`CommandSearchInputAllowedFilters`](takaro_apiclient.CommandSearchInputAllowedFilters.md)
+
+**`Memberof`**
+
+CommandSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:306](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L306)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+CommandSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:318](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L318)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+CommandSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:312](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L312)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+CommandSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:324](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L324)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`CommandSearchInputDTOSortDirectionEnum`](../modules/takaro_apiclient.md#commandsearchinputdtosortdirectionenum-1)
+
+**`Memberof`**
+
+CommandSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:330](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L330)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandUpdateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CommandUpdateDTO.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.CommandUpdateDTO"
+title: "Interface: CommandUpdateDTO"
+sidebar_label: "@takaro/apiclient.CommandUpdateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CommandUpdateDTO
+
+**`Export`**
+
+**`Interface`**
+
+CommandUpdateDTO
+
+## Properties
+
+### enabled
+
+• `Optional` **enabled**: `boolean`
+
+**`Memberof`**
+
+CommandUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:376](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L376)
+
+___
+
+### helpText
+
+• `Optional` **helpText**: `string`
+
+**`Memberof`**
+
+CommandUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:370](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L370)
+
+___
+
+### name
+
+• `Optional` **name**: `string`
+
+**`Memberof`**
+
+CommandUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:358](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L358)
+
+___
+
+### trigger
+
+• `Optional` **trigger**: `string`
+
+**`Memberof`**
+
+CommandUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:364](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L364)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobCreateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobCreateDTO.md
@@ -1,0 +1,84 @@
+---
+id: "takaro_apiclient.CronJobCreateDTO"
+title: "Interface: CronJobCreateDTO"
+sidebar_label: "@takaro/apiclient.CronJobCreateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CronJobCreateDTO
+
+**`Export`**
+
+**`Interface`**
+
+CronJobCreateDTO
+
+## Properties
+
+### enabled
+
+• `Optional` **enabled**: `string`
+
+**`Memberof`**
+
+CronJobCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:395](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L395)
+
+___
+
+### function
+
+• `Optional` **function**: `string`
+
+**`Memberof`**
+
+CronJobCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:413](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L413)
+
+___
+
+### moduleId
+
+• **moduleId**: `string`
+
+**`Memberof`**
+
+CronJobCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:407](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L407)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+CronJobCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:389](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L389)
+
+___
+
+### temporalValue
+
+• **temporalValue**: `string`
+
+**`Memberof`**
+
+CronJobCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:401](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L401)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobOutputArrayDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobOutputArrayDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.CronJobOutputArrayDTOAPI"
+title: "Interface: CronJobOutputArrayDTOAPI"
+sidebar_label: "@takaro/apiclient.CronJobOutputArrayDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CronJobOutputArrayDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+CronJobOutputArrayDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`CronJobOutputDTO`](takaro_apiclient.CronJobOutputDTO.md)[]
+
+**`Memberof`**
+
+CronJobOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:426](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L426)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+CronJobOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:432](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L432)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobOutputDTO.md
@@ -1,0 +1,84 @@
+---
+id: "takaro_apiclient.CronJobOutputDTO"
+title: "Interface: CronJobOutputDTO"
+sidebar_label: "@takaro/apiclient.CronJobOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CronJobOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+CronJobOutputDTO
+
+## Properties
+
+### enabled
+
+• **enabled**: `boolean`
+
+**`Memberof`**
+
+CronJobOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:457](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L457)
+
+___
+
+### function
+
+• **function**: [`FunctionOutputDTO`](takaro_apiclient.FunctionOutputDTO.md)
+
+**`Memberof`**
+
+CronJobOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:469](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L469)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+CronJobOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:445](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L445)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+CronJobOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:451](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L451)
+
+___
+
+### temporalValue
+
+• **temporalValue**: `string`
+
+**`Memberof`**
+
+CronJobOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:463](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L463)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.CronJobOutputDTOAPI"
+title: "Interface: CronJobOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.CronJobOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CronJobOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+CronJobOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`CronJobOutputDTO`](takaro_apiclient.CronJobOutputDTO.md)
+
+**`Memberof`**
+
+CronJobOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:482](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L482)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+CronJobOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:488](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L488)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobSearchInputAllowedFilters.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobSearchInputAllowedFilters.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.CronJobSearchInputAllowedFilters"
+title: "Interface: CronJobSearchInputAllowedFilters"
+sidebar_label: "@takaro/apiclient.CronJobSearchInputAllowedFilters"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CronJobSearchInputAllowedFilters
+
+**`Export`**
+
+**`Interface`**
+
+CronJobSearchInputAllowedFilters
+
+## Properties
+
+### enabled
+
+• `Optional` **enabled**: `string`
+
+**`Memberof`**
+
+CronJobSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:513](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L513)
+
+___
+
+### id
+
+• `Optional` **id**: `string`
+
+**`Memberof`**
+
+CronJobSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:501](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L501)
+
+___
+
+### name
+
+• `Optional` **name**: `string`
+
+**`Memberof`**
+
+CronJobSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:507](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L507)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobSearchInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobSearchInputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.CronJobSearchInputDTO"
+title: "Interface: CronJobSearchInputDTO"
+sidebar_label: "@takaro/apiclient.CronJobSearchInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CronJobSearchInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+CronJobSearchInputDTO
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+CronJobSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:556](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L556)
+
+___
+
+### filters
+
+• `Optional` **filters**: [`CronJobSearchInputAllowedFilters`](takaro_apiclient.CronJobSearchInputAllowedFilters.md)
+
+**`Memberof`**
+
+CronJobSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:526](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L526)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+CronJobSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:538](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L538)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+CronJobSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:532](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L532)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+CronJobSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:544](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L544)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`CronJobSearchInputDTOSortDirectionEnum`](../modules/takaro_apiclient.md#cronjobsearchinputdtosortdirectionenum-1)
+
+**`Memberof`**
+
+CronJobSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:550](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L550)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobUpdateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.CronJobUpdateDTO.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.CronJobUpdateDTO"
+title: "Interface: CronJobUpdateDTO"
+sidebar_label: "@takaro/apiclient.CronJobUpdateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).CronJobUpdateDTO
+
+**`Export`**
+
+**`Interface`**
+
+CronJobUpdateDTO
+
+## Properties
+
+### enabled
+
+• **enabled**: `boolean`
+
+**`Memberof`**
+
+CronJobUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:584](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L584)
+
+___
+
+### moduleId
+
+• `Optional` **moduleId**: `string`
+
+**`Memberof`**
+
+CronJobUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:596](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L596)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+CronJobUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:578](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L578)
+
+___
+
+### temporalValue
+
+• **temporalValue**: `string`
+
+**`Memberof`**
+
+CronJobUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:590](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L590)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainCreateInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainCreateInputDTO.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.DomainCreateInputDTO"
+title: "Interface: DomainCreateInputDTO"
+sidebar_label: "@takaro/apiclient.DomainCreateInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).DomainCreateInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+DomainCreateInputDTO
+
+## Properties
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+DomainCreateInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:615](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L615)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+DomainCreateInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:609](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L609)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainCreateOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainCreateOutputDTO.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.DomainCreateOutputDTO"
+title: "Interface: DomainCreateOutputDTO"
+sidebar_label: "@takaro/apiclient.DomainCreateOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).DomainCreateOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+DomainCreateOutputDTO
+
+## Properties
+
+### domain
+
+• **domain**: [`DomainOutputDTO`](takaro_apiclient.DomainOutputDTO.md)
+
+**`Memberof`**
+
+DomainCreateOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:628](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L628)
+
+___
+
+### password
+
+• **password**: `string`
+
+**`Memberof`**
+
+DomainCreateOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:646](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L646)
+
+___
+
+### rootRole
+
+• **rootRole**: [`RoleOutputDTO`](takaro_apiclient.RoleOutputDTO.md)
+
+**`Memberof`**
+
+DomainCreateOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:640](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L640)
+
+___
+
+### rootUser
+
+• **rootUser**: [`UserOutputDTO`](takaro_apiclient.UserOutputDTO.md)
+
+**`Memberof`**
+
+DomainCreateOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:634](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L634)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainCreateOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainCreateOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.DomainCreateOutputDTOAPI"
+title: "Interface: DomainCreateOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.DomainCreateOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).DomainCreateOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+DomainCreateOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`DomainCreateOutputDTO`](takaro_apiclient.DomainCreateOutputDTO.md)
+
+**`Memberof`**
+
+DomainCreateOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:659](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L659)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+DomainCreateOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:665](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L665)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainOutputArrayDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainOutputArrayDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.DomainOutputArrayDTOAPI"
+title: "Interface: DomainOutputArrayDTOAPI"
+sidebar_label: "@takaro/apiclient.DomainOutputArrayDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).DomainOutputArrayDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+DomainOutputArrayDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`DomainOutputDTO`](takaro_apiclient.DomainOutputDTO.md)[]
+
+**`Memberof`**
+
+DomainOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:678](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L678)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+DomainOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:684](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L684)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainOutputDTO.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.DomainOutputDTO"
+title: "Interface: DomainOutputDTO"
+sidebar_label: "@takaro/apiclient.DomainOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).DomainOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+DomainOutputDTO
+
+## Properties
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+DomainOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:697](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L697)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+DomainOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:703](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L703)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.DomainOutputDTOAPI"
+title: "Interface: DomainOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.DomainOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).DomainOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+DomainOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`DomainOutputDTO`](takaro_apiclient.DomainOutputDTO.md)
+
+**`Memberof`**
+
+DomainOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:716](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L716)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+DomainOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:722](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L722)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainSearchInputAllowedFilters.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainSearchInputAllowedFilters.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.DomainSearchInputAllowedFilters"
+title: "Interface: DomainSearchInputAllowedFilters"
+sidebar_label: "@takaro/apiclient.DomainSearchInputAllowedFilters"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).DomainSearchInputAllowedFilters
+
+**`Export`**
+
+**`Interface`**
+
+DomainSearchInputAllowedFilters
+
+## Properties
+
+### name
+
+• `Optional` **name**: `string`
+
+**`Memberof`**
+
+DomainSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:735](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L735)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainSearchInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainSearchInputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.DomainSearchInputDTO"
+title: "Interface: DomainSearchInputDTO"
+sidebar_label: "@takaro/apiclient.DomainSearchInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).DomainSearchInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+DomainSearchInputDTO
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+DomainSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:778](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L778)
+
+___
+
+### filters
+
+• `Optional` **filters**: [`DomainSearchInputAllowedFilters`](takaro_apiclient.DomainSearchInputAllowedFilters.md)
+
+**`Memberof`**
+
+DomainSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:748](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L748)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+DomainSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:760](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L760)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+DomainSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:754](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L754)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+DomainSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:766](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L766)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`DomainSearchInputDTOSortDirectionEnum`](../modules/takaro_apiclient.md#domainsearchinputdtosortdirectionenum-1)
+
+**`Memberof`**
+
+DomainSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:772](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L772)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainUpdateInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.DomainUpdateInputDTO.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.DomainUpdateInputDTO"
+title: "Interface: DomainUpdateInputDTO"
+sidebar_label: "@takaro/apiclient.DomainUpdateInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).DomainUpdateInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+DomainUpdateInputDTO
+
+## Properties
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+DomainUpdateInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:800](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L800)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ErrorOutput.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ErrorOutput.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.ErrorOutput"
+title: "Interface: ErrorOutput"
+sidebar_label: "@takaro/apiclient.ErrorOutput"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ErrorOutput
+
+**`Export`**
+
+**`Interface`**
+
+ErrorOutput
+
+## Properties
+
+### code
+
+• **code**: `string`
+
+**`Memberof`**
+
+ErrorOutput
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:813](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L813)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.EventChatMessage.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.EventChatMessage.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.EventChatMessage"
+title: "Interface: EventChatMessage"
+sidebar_label: "@takaro/apiclient.EventChatMessage"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).EventChatMessage
+
+**`Export`**
+
+**`Interface`**
+
+EventChatMessage
+
+## Properties
+
+### msg
+
+• **msg**: `string`
+
+**`Memberof`**
+
+EventChatMessage
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:844](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L844)
+
+___
+
+### player
+
+• **player**: [`IGamePlayer`](takaro_apiclient.IGamePlayer.md)
+
+**`Memberof`**
+
+EventChatMessage
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:826](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L826)
+
+___
+
+### timestamp
+
+• **timestamp**: `string`
+
+**`Memberof`**
+
+EventChatMessage
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:832](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L832)
+
+___
+
+### type
+
+• **type**: [`EventChatMessageTypeEnum`](../modules/takaro_apiclient.md#eventchatmessagetypeenum-1)
+
+**`Memberof`**
+
+EventChatMessage
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:838](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L838)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.EventPlayerConnected.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.EventPlayerConnected.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.EventPlayerConnected"
+title: "Interface: EventPlayerConnected"
+sidebar_label: "@takaro/apiclient.EventPlayerConnected"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).EventPlayerConnected
+
+**`Export`**
+
+**`Interface`**
+
+EventPlayerConnected
+
+## Properties
+
+### msg
+
+• **msg**: `string`
+
+**`Memberof`**
+
+EventPlayerConnected
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:886](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L886)
+
+___
+
+### player
+
+• **player**: [`IGamePlayer`](takaro_apiclient.IGamePlayer.md)
+
+**`Memberof`**
+
+EventPlayerConnected
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:868](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L868)
+
+___
+
+### timestamp
+
+• **timestamp**: `string`
+
+**`Memberof`**
+
+EventPlayerConnected
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:874](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L874)
+
+___
+
+### type
+
+• **type**: [`EventPlayerConnectedTypeEnum`](../modules/takaro_apiclient.md#eventplayerconnectedtypeenum-1)
+
+**`Memberof`**
+
+EventPlayerConnected
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:880](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L880)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.EventPlayerDisconnected.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.EventPlayerDisconnected.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.EventPlayerDisconnected"
+title: "Interface: EventPlayerDisconnected"
+sidebar_label: "@takaro/apiclient.EventPlayerDisconnected"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).EventPlayerDisconnected
+
+**`Export`**
+
+**`Interface`**
+
+EventPlayerDisconnected
+
+## Properties
+
+### msg
+
+• **msg**: `string`
+
+**`Memberof`**
+
+EventPlayerDisconnected
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:928](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L928)
+
+___
+
+### player
+
+• **player**: [`IGamePlayer`](takaro_apiclient.IGamePlayer.md)
+
+**`Memberof`**
+
+EventPlayerDisconnected
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:910](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L910)
+
+___
+
+### timestamp
+
+• **timestamp**: `string`
+
+**`Memberof`**
+
+EventPlayerDisconnected
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:916](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L916)
+
+___
+
+### type
+
+• **type**: [`EventPlayerDisconnectedTypeEnum`](../modules/takaro_apiclient.md#eventplayerdisconnectedtypeenum-1)
+
+**`Memberof`**
+
+EventPlayerDisconnected
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:922](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L922)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionCreateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionCreateDTO.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.FunctionCreateDTO"
+title: "Interface: FunctionCreateDTO"
+sidebar_label: "@takaro/apiclient.FunctionCreateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).FunctionCreateDTO
+
+**`Export`**
+
+**`Interface`**
+
+FunctionCreateDTO
+
+## Properties
+
+### code
+
+• **code**: `string`
+
+**`Memberof`**
+
+FunctionCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:952](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L952)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionOutputArrayDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionOutputArrayDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.FunctionOutputArrayDTOAPI"
+title: "Interface: FunctionOutputArrayDTOAPI"
+sidebar_label: "@takaro/apiclient.FunctionOutputArrayDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).FunctionOutputArrayDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+FunctionOutputArrayDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`FunctionOutputDTO`](takaro_apiclient.FunctionOutputDTO.md)[]
+
+**`Memberof`**
+
+FunctionOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:965](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L965)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+FunctionOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:971](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L971)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionOutputDTO.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.FunctionOutputDTO"
+title: "Interface: FunctionOutputDTO"
+sidebar_label: "@takaro/apiclient.FunctionOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).FunctionOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+FunctionOutputDTO
+
+## Properties
+
+### code
+
+• **code**: `string`
+
+**`Memberof`**
+
+FunctionOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:990](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L990)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+FunctionOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:984](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L984)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.FunctionOutputDTOAPI"
+title: "Interface: FunctionOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.FunctionOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).FunctionOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+FunctionOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`FunctionOutputDTO`](takaro_apiclient.FunctionOutputDTO.md)
+
+**`Memberof`**
+
+FunctionOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1003](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1003)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+FunctionOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1009](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1009)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionSearchInputAllowedFilters.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionSearchInputAllowedFilters.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.FunctionSearchInputAllowedFilters"
+title: "Interface: FunctionSearchInputAllowedFilters"
+sidebar_label: "@takaro/apiclient.FunctionSearchInputAllowedFilters"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).FunctionSearchInputAllowedFilters
+
+**`Export`**
+
+**`Interface`**
+
+FunctionSearchInputAllowedFilters
+
+## Properties
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+FunctionSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1022](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1022)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionSearchInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionSearchInputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.FunctionSearchInputDTO"
+title: "Interface: FunctionSearchInputDTO"
+sidebar_label: "@takaro/apiclient.FunctionSearchInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).FunctionSearchInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+FunctionSearchInputDTO
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+FunctionSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1065](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1065)
+
+___
+
+### filters
+
+• `Optional` **filters**: [`FunctionSearchInputAllowedFilters`](takaro_apiclient.FunctionSearchInputAllowedFilters.md)
+
+**`Memberof`**
+
+FunctionSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1035](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1035)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+FunctionSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1047](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1047)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+FunctionSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1041](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1041)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+FunctionSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1053](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1053)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`FunctionSearchInputDTOSortDirectionEnum`](../modules/takaro_apiclient.md#functionsearchinputdtosortdirectionenum-1)
+
+**`Memberof`**
+
+FunctionSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1059](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1059)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionUpdateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.FunctionUpdateDTO.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.FunctionUpdateDTO"
+title: "Interface: FunctionUpdateDTO"
+sidebar_label: "@takaro/apiclient.FunctionUpdateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).FunctionUpdateDTO
+
+**`Export`**
+
+**`Interface`**
+
+FunctionUpdateDTO
+
+## Properties
+
+### code
+
+• **code**: `string`
+
+**`Memberof`**
+
+FunctionUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1087](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1087)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerCreateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerCreateDTO.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.GameServerCreateDTO"
+title: "Interface: GameServerCreateDTO"
+sidebar_label: "@takaro/apiclient.GameServerCreateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GameServerCreateDTO
+
+**`Export`**
+
+**`Interface`**
+
+GameServerCreateDTO
+
+## Properties
+
+### connectionInfo
+
+• **connectionInfo**: `string`
+
+**`Memberof`**
+
+GameServerCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1106](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1106)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+GameServerCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1100](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1100)
+
+___
+
+### type
+
+• **type**: [`GameServerCreateDTOTypeEnum`](../modules/takaro_apiclient.md#gameservercreatedtotypeenum-1)
+
+**`Memberof`**
+
+GameServerCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1112](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1112)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerOutputArrayDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerOutputArrayDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.GameServerOutputArrayDTOAPI"
+title: "Interface: GameServerOutputArrayDTOAPI"
+sidebar_label: "@takaro/apiclient.GameServerOutputArrayDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GameServerOutputArrayDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+GameServerOutputArrayDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`GameServerOutputDTO`](takaro_apiclient.GameServerOutputDTO.md)[]
+
+**`Memberof`**
+
+GameServerOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1135](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1135)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+GameServerOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1141](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1141)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerOutputDTO.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.GameServerOutputDTO"
+title: "Interface: GameServerOutputDTO"
+sidebar_label: "@takaro/apiclient.GameServerOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GameServerOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+GameServerOutputDTO
+
+## Properties
+
+### connectionInfo
+
+• **connectionInfo**: `object`
+
+**`Memberof`**
+
+GameServerOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1166](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1166)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+GameServerOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1154](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1154)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+GameServerOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1160](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1160)
+
+___
+
+### type
+
+• **type**: [`GameServerOutputDTOTypeEnum`](../modules/takaro_apiclient.md#gameserveroutputdtotypeenum-1)
+
+**`Memberof`**
+
+GameServerOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1172](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1172)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.GameServerOutputDTOAPI"
+title: "Interface: GameServerOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.GameServerOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GameServerOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+GameServerOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`GameServerOutputDTO`](takaro_apiclient.GameServerOutputDTO.md)
+
+**`Memberof`**
+
+GameServerOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1195](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1195)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+GameServerOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1201](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1201)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerSearchInputAllowedFilters.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerSearchInputAllowedFilters.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.GameServerSearchInputAllowedFilters"
+title: "Interface: GameServerSearchInputAllowedFilters"
+sidebar_label: "@takaro/apiclient.GameServerSearchInputAllowedFilters"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GameServerSearchInputAllowedFilters
+
+**`Export`**
+
+**`Interface`**
+
+GameServerSearchInputAllowedFilters
+
+## Properties
+
+### name
+
+• `Optional` **name**: `string`
+
+**`Memberof`**
+
+GameServerSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1214](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1214)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerSearchInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerSearchInputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.GameServerSearchInputDTO"
+title: "Interface: GameServerSearchInputDTO"
+sidebar_label: "@takaro/apiclient.GameServerSearchInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GameServerSearchInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+GameServerSearchInputDTO
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+GameServerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1257](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1257)
+
+___
+
+### filters
+
+• `Optional` **filters**: [`GameServerSearchInputAllowedFilters`](takaro_apiclient.GameServerSearchInputAllowedFilters.md)
+
+**`Memberof`**
+
+GameServerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1227](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1227)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+GameServerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1239](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1239)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+GameServerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1233](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1233)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+GameServerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1245](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1245)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`GameServerSearchInputDTOSortDirectionEnum`](../modules/takaro_apiclient.md#gameserversearchinputdtosortdirectionenum-1)
+
+**`Memberof`**
+
+GameServerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1251](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1251)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.GameServerTestReachabilityDTOAPI"
+title: "Interface: GameServerTestReachabilityDTOAPI"
+sidebar_label: "@takaro/apiclient.GameServerTestReachabilityDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GameServerTestReachabilityDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+GameServerTestReachabilityDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`TestReachabilityOutput`](takaro_apiclient.TestReachabilityOutput.md)
+
+**`Memberof`**
+
+GameServerTestReachabilityDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1279](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1279)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+GameServerTestReachabilityDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1285](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1285)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerTestReachabilityInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerTestReachabilityInputDTO.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.GameServerTestReachabilityInputDTO"
+title: "Interface: GameServerTestReachabilityInputDTO"
+sidebar_label: "@takaro/apiclient.GameServerTestReachabilityInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GameServerTestReachabilityInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+GameServerTestReachabilityInputDTO
+
+## Properties
+
+### connectionInfo
+
+• **connectionInfo**: `string`
+
+**`Memberof`**
+
+GameServerTestReachabilityInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1298](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1298)
+
+___
+
+### type
+
+• **type**: [`GameServerTestReachabilityInputDTOTypeEnum`](../modules/takaro_apiclient.md#gameservertestreachabilityinputdtotypeenum-1)
+
+**`Memberof`**
+
+GameServerTestReachabilityInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1304](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1304)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerUpdateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GameServerUpdateDTO.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.GameServerUpdateDTO"
+title: "Interface: GameServerUpdateDTO"
+sidebar_label: "@takaro/apiclient.GameServerUpdateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GameServerUpdateDTO
+
+**`Export`**
+
+**`Interface`**
+
+GameServerUpdateDTO
+
+## Properties
+
+### connectionInfo
+
+• **connectionInfo**: `string`
+
+**`Memberof`**
+
+GameServerUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1333](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1333)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+GameServerUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1327](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1327)
+
+___
+
+### type
+
+• **type**: [`GameServerUpdateDTOTypeEnum`](../modules/takaro_apiclient.md#gameserverupdatedtotypeenum-1)
+
+**`Memberof`**
+
+GameServerUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1339](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1339)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GetSettingsInput.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GetSettingsInput.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.GetSettingsInput"
+title: "Interface: GetSettingsInput"
+sidebar_label: "@takaro/apiclient.GetSettingsInput"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GetSettingsInput
+
+**`Export`**
+
+**`Interface`**
+
+GetSettingsInput
+
+## Properties
+
+### gameServerId
+
+• `Optional` **gameServerId**: `string`
+
+**`Memberof`**
+
+GetSettingsInput
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1368](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1368)
+
+___
+
+### keys
+
+• `Optional` **keys**: [`GetSettingsInputKeysEnum`](../modules/takaro_apiclient.md#getsettingsinputkeysenum-1)[]
+
+**`Memberof`**
+
+GetSettingsInput
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1362](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1362)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GetSettingsOneInput.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GetSettingsOneInput.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.GetSettingsOneInput"
+title: "Interface: GetSettingsOneInput"
+sidebar_label: "@takaro/apiclient.GetSettingsOneInput"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GetSettingsOneInput
+
+**`Export`**
+
+**`Interface`**
+
+GetSettingsOneInput
+
+## Properties
+
+### gameServerId
+
+• `Optional` **gameServerId**: `string`
+
+**`Memberof`**
+
+GetSettingsOneInput
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1390](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1390)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GetUserDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.GetUserDTO.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.GetUserDTO"
+title: "Interface: GetUserDTO"
+sidebar_label: "@takaro/apiclient.GetUserDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).GetUserDTO
+
+**`Export`**
+
+**`Interface`**
+
+GetUserDTO
+
+## Properties
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+GetUserDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1403](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1403)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HealthOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HealthOutputDTO.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.HealthOutputDTO"
+title: "Interface: HealthOutputDTO"
+sidebar_label: "@takaro/apiclient.HealthOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).HealthOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+HealthOutputDTO
+
+## Properties
+
+### healthy
+
+• **healthy**: `boolean`
+
+**`Memberof`**
+
+HealthOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1416](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1416)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookCreateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookCreateDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.HookCreateDTO"
+title: "Interface: HookCreateDTO"
+sidebar_label: "@takaro/apiclient.HookCreateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).HookCreateDTO
+
+**`Export`**
+
+**`Interface`**
+
+HookCreateDTO
+
+## Properties
+
+### enabled
+
+• `Optional` **enabled**: `boolean`
+
+**`Memberof`**
+
+HookCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1435](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1435)
+
+___
+
+### eventType
+
+• **eventType**: [`HookCreateDTOEventTypeEnum`](../modules/takaro_apiclient.md#hookcreatedtoeventtypeenum-1)
+
+**`Memberof`**
+
+HookCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1453](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1453)
+
+___
+
+### function
+
+• `Optional` **function**: `string`
+
+**`Memberof`**
+
+HookCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1459](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1459)
+
+___
+
+### moduleId
+
+• **moduleId**: `string`
+
+**`Memberof`**
+
+HookCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1447](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1447)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+HookCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1429](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1429)
+
+___
+
+### regex
+
+• **regex**: `string`
+
+**`Memberof`**
+
+HookCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1441](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1441)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookOutputArrayDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookOutputArrayDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.HookOutputArrayDTOAPI"
+title: "Interface: HookOutputArrayDTOAPI"
+sidebar_label: "@takaro/apiclient.HookOutputArrayDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).HookOutputArrayDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+HookOutputArrayDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`HookOutputDTO`](takaro_apiclient.HookOutputDTO.md)[]
+
+**`Memberof`**
+
+HookOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1483](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1483)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+HookOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1489](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1489)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookOutputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.HookOutputDTO"
+title: "Interface: HookOutputDTO"
+sidebar_label: "@takaro/apiclient.HookOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).HookOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+HookOutputDTO
+
+## Properties
+
+### enabled
+
+• **enabled**: `boolean`
+
+**`Memberof`**
+
+HookOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1514](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1514)
+
+___
+
+### eventType
+
+• **eventType**: [`HookOutputDTOEventTypeEnum`](../modules/takaro_apiclient.md#hookoutputdtoeventtypeenum-1)
+
+**`Memberof`**
+
+HookOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1532](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1532)
+
+___
+
+### function
+
+• **function**: [`FunctionOutputDTO`](takaro_apiclient.FunctionOutputDTO.md)
+
+**`Memberof`**
+
+HookOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1526](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1526)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+HookOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1502](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1502)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+HookOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1508](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1508)
+
+___
+
+### regex
+
+• **regex**: `string`
+
+**`Memberof`**
+
+HookOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1520](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1520)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.HookOutputDTOAPI"
+title: "Interface: HookOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.HookOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).HookOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+HookOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`HookOutputDTO`](takaro_apiclient.HookOutputDTO.md)
+
+**`Memberof`**
+
+HookOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1556](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1556)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+HookOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1562](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1562)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookSearchInputAllowedFilters.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookSearchInputAllowedFilters.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.HookSearchInputAllowedFilters"
+title: "Interface: HookSearchInputAllowedFilters"
+sidebar_label: "@takaro/apiclient.HookSearchInputAllowedFilters"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).HookSearchInputAllowedFilters
+
+**`Export`**
+
+**`Interface`**
+
+HookSearchInputAllowedFilters
+
+## Properties
+
+### enabled
+
+• `Optional` **enabled**: `boolean`
+
+**`Memberof`**
+
+HookSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1587](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1587)
+
+___
+
+### eventType
+
+• `Optional` **eventType**: [`HookSearchInputAllowedFiltersEventTypeEnum`](../modules/takaro_apiclient.md#hooksearchinputallowedfilterseventtypeenum-1)
+
+**`Memberof`**
+
+HookSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1593](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1593)
+
+___
+
+### id
+
+• `Optional` **id**: `string`
+
+**`Memberof`**
+
+HookSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1575](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1575)
+
+___
+
+### name
+
+• `Optional` **name**: `string`
+
+**`Memberof`**
+
+HookSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1581](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1581)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookSearchInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookSearchInputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.HookSearchInputDTO"
+title: "Interface: HookSearchInputDTO"
+sidebar_label: "@takaro/apiclient.HookSearchInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).HookSearchInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+HookSearchInputDTO
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+HookSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1647](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1647)
+
+___
+
+### filters
+
+• `Optional` **filters**: [`HookSearchInputAllowedFilters`](takaro_apiclient.HookSearchInputAllowedFilters.md)
+
+**`Memberof`**
+
+HookSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1617](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1617)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+HookSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1629](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1629)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+HookSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1623](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1623)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+HookSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1635](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1635)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`HookSearchInputDTOSortDirectionEnum`](../modules/takaro_apiclient.md#hooksearchinputdtosortdirectionenum-1)
+
+**`Memberof`**
+
+HookSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1641](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1641)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookUpdateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.HookUpdateDTO.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.HookUpdateDTO"
+title: "Interface: HookUpdateDTO"
+sidebar_label: "@takaro/apiclient.HookUpdateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).HookUpdateDTO
+
+**`Export`**
+
+**`Interface`**
+
+HookUpdateDTO
+
+## Properties
+
+### enabled
+
+• **enabled**: `boolean`
+
+**`Memberof`**
+
+HookUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1675](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1675)
+
+___
+
+### moduleId
+
+• `Optional` **moduleId**: `string`
+
+**`Memberof`**
+
+HookUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1687](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1687)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+HookUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1669](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1669)
+
+___
+
+### regex
+
+• **regex**: `string`
+
+**`Memberof`**
+
+HookUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1681](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1681)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.IGamePlayer.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.IGamePlayer.md
@@ -1,0 +1,126 @@
+---
+id: "takaro_apiclient.IGamePlayer"
+title: "Interface: IGamePlayer"
+sidebar_label: "@takaro/apiclient.IGamePlayer"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).IGamePlayer
+
+**`Export`**
+
+**`Interface`**
+
+IGamePlayer
+
+## Properties
+
+### device
+
+• `Optional` **device**: `string`
+
+**`Memberof`**
+
+IGamePlayer
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1736](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1736)
+
+___
+
+### epicOnlineServicesId
+
+• `Optional` **epicOnlineServicesId**: `string`
+
+**`Memberof`**
+
+IGamePlayer
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1718](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1718)
+
+___
+
+### gameId
+
+• **gameId**: `string`
+
+**`Memberof`**
+
+IGamePlayer
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1700](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1700)
+
+___
+
+### ip
+
+• `Optional` **ip**: `string`
+
+**`Memberof`**
+
+IGamePlayer
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1742](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1742)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+IGamePlayer
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1706](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1706)
+
+___
+
+### platformId
+
+• `Optional` **platformId**: `string`
+
+**`Memberof`**
+
+IGamePlayer
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1730](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1730)
+
+___
+
+### steamId
+
+• `Optional` **steamId**: `string`
+
+**`Memberof`**
+
+IGamePlayer
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1712](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1712)
+
+___
+
+### xboxLiveId
+
+• `Optional` **xboxLiveId**: `string`
+
+**`Memberof`**
+
+IGamePlayer
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1724](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1724)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ITakaroQuery.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ITakaroQuery.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.ITakaroQuery"
+title: "Interface: ITakaroQuery"
+sidebar_label: "@takaro/apiclient.ITakaroQuery"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ITakaroQuery
+
+**`Export`**
+
+**`Interface`**
+
+ITakaroQuery
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+ITakaroQuery
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1785](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1785)
+
+___
+
+### filters
+
+• `Optional` **filters**: `any`
+
+**`Memberof`**
+
+ITakaroQuery
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1755](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1755)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+ITakaroQuery
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1767](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1767)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+ITakaroQuery
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1761](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1761)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+ITakaroQuery
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1773](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1773)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`ITakaroQuerySortDirectionEnum`](../modules/takaro_apiclient.md#itakaroquerysortdirectionenum-1)
+
+**`Memberof`**
+
+ITakaroQuery
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1779](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1779)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.LoginCreateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.LoginCreateDTO.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.LoginCreateDTO"
+title: "Interface: LoginCreateDTO"
+sidebar_label: "@takaro/apiclient.LoginCreateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).LoginCreateDTO
+
+**`Export`**
+
+**`Interface`**
+
+LoginCreateDTO
+
+## Properties
+
+### domain
+
+• **domain**: `string`
+
+**`Memberof`**
+
+LoginCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1813](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1813)
+
+___
+
+### email
+
+• **email**: `string`
+
+**`Memberof`**
+
+LoginCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1819](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1819)
+
+___
+
+### userId
+
+• **userId**: `string`
+
+**`Memberof`**
+
+LoginCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1807](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1807)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.LoginDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.LoginDTO.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.LoginDTO"
+title: "Interface: LoginDTO"
+sidebar_label: "@takaro/apiclient.LoginDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).LoginDTO
+
+**`Export`**
+
+**`Interface`**
+
+LoginDTO
+
+## Properties
+
+### password
+
+• **password**: `string`
+
+**`Memberof`**
+
+LoginDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1838](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1838)
+
+___
+
+### username
+
+• **username**: `string`
+
+**`Memberof`**
+
+LoginDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1832](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1832)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.LoginOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.LoginOutputDTO.md
@@ -1,0 +1,84 @@
+---
+id: "takaro_apiclient.LoginOutputDTO"
+title: "Interface: LoginOutputDTO"
+sidebar_label: "@takaro/apiclient.LoginOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).LoginOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+LoginOutputDTO
+
+## Properties
+
+### domain
+
+• **domain**: `string`
+
+**`Memberof`**
+
+LoginOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1869](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1869)
+
+___
+
+### email
+
+• **email**: `string`
+
+**`Memberof`**
+
+LoginOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1863](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1863)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+LoginOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1851](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1851)
+
+___
+
+### token
+
+• **token**: `string`
+
+**`Memberof`**
+
+LoginOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1875](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1875)
+
+___
+
+### userId
+
+• **userId**: `string`
+
+**`Memberof`**
+
+LoginOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1857](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1857)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.LoginOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.LoginOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.LoginOutputDTOAPI"
+title: "Interface: LoginOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.LoginOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).LoginOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+LoginOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`LoginOutputDTO`](takaro_apiclient.LoginOutputDTO.md)
+
+**`Memberof`**
+
+LoginOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1888](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1888)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+LoginOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1894](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1894)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.LoginUpdateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.LoginUpdateDTO.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.LoginUpdateDTO"
+title: "Interface: LoginUpdateDTO"
+sidebar_label: "@takaro/apiclient.LoginUpdateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).LoginUpdateDTO
+
+**`Export`**
+
+**`Interface`**
+
+LoginUpdateDTO
+
+## Properties
+
+### email
+
+• **email**: `string`
+
+**`Memberof`**
+
+LoginUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1907](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1907)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.MetadataOutput.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.MetadataOutput.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.MetadataOutput"
+title: "Interface: MetadataOutput"
+sidebar_label: "@takaro/apiclient.MetadataOutput"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).MetadataOutput
+
+**`Export`**
+
+**`Interface`**
+
+MetadataOutput
+
+## Properties
+
+### error
+
+• **error**: [`ErrorOutput`](takaro_apiclient.ErrorOutput.md)
+
+**`Memberof`**
+
+MetadataOutput
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1926](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1926)
+
+___
+
+### serverTime
+
+• **serverTime**: `string`
+
+**`Memberof`**
+
+MetadataOutput
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1920](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1920)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.MockConnectionInfo.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.MockConnectionInfo.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.MockConnectionInfo"
+title: "Interface: MockConnectionInfo"
+sidebar_label: "@takaro/apiclient.MockConnectionInfo"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).MockConnectionInfo
+
+**`Export`**
+
+**`Interface`**
+
+MockConnectionInfo
+
+## Properties
+
+### eventInterval
+
+• **eventInterval**: `number`
+
+**`Memberof`**
+
+MockConnectionInfo
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1945](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1945)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleCreateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleCreateDTO.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.ModuleCreateDTO"
+title: "Interface: ModuleCreateDTO"
+sidebar_label: "@takaro/apiclient.ModuleCreateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ModuleCreateDTO
+
+**`Export`**
+
+**`Interface`**
+
+ModuleCreateDTO
+
+## Properties
+
+### config
+
+• `Optional` **config**: `object`
+
+**`Memberof`**
+
+ModuleCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1970](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1970)
+
+___
+
+### enabled
+
+• `Optional` **enabled**: `boolean`
+
+**`Memberof`**
+
+ModuleCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1964](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1964)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+ModuleCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1958](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1958)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleOutputArrayDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleOutputArrayDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.ModuleOutputArrayDTOAPI"
+title: "Interface: ModuleOutputArrayDTOAPI"
+sidebar_label: "@takaro/apiclient.ModuleOutputArrayDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ModuleOutputArrayDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+ModuleOutputArrayDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`ModuleOutputDTO`](takaro_apiclient.ModuleOutputDTO.md)[]
+
+**`Memberof`**
+
+ModuleOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1983](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1983)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+ModuleOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1989](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1989)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleOutputDTO.md
@@ -1,0 +1,112 @@
+---
+id: "takaro_apiclient.ModuleOutputDTO"
+title: "Interface: ModuleOutputDTO"
+sidebar_label: "@takaro/apiclient.ModuleOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ModuleOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+ModuleOutputDTO
+
+## Properties
+
+### commands
+
+• **commands**: [`CommandOutputDTO`](takaro_apiclient.CommandOutputDTO.md)[]
+
+**`Memberof`**
+
+ModuleOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2038](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2038)
+
+___
+
+### config
+
+• **config**: `object`
+
+**`Memberof`**
+
+ModuleOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2020](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2020)
+
+___
+
+### cronJobs
+
+• **cronJobs**: [`CronJobOutputDTO`](takaro_apiclient.CronJobOutputDTO.md)[]
+
+**`Memberof`**
+
+ModuleOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2026](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2026)
+
+___
+
+### enabled
+
+• **enabled**: `boolean`
+
+**`Memberof`**
+
+ModuleOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2014](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2014)
+
+___
+
+### hooks
+
+• **hooks**: [`HookOutputDTO`](takaro_apiclient.HookOutputDTO.md)[]
+
+**`Memberof`**
+
+ModuleOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2032](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2032)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+ModuleOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2002](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2002)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+ModuleOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2008](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2008)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.ModuleOutputDTOAPI"
+title: "Interface: ModuleOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.ModuleOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ModuleOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+ModuleOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`ModuleOutputDTO`](takaro_apiclient.ModuleOutputDTO.md)
+
+**`Memberof`**
+
+ModuleOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2051](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2051)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+ModuleOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2057](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2057)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleSearchInputAllowedFilters.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleSearchInputAllowedFilters.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.ModuleSearchInputAllowedFilters"
+title: "Interface: ModuleSearchInputAllowedFilters"
+sidebar_label: "@takaro/apiclient.ModuleSearchInputAllowedFilters"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ModuleSearchInputAllowedFilters
+
+**`Export`**
+
+**`Interface`**
+
+ModuleSearchInputAllowedFilters
+
+## Properties
+
+### enabled
+
+• `Optional` **enabled**: `boolean`
+
+**`Memberof`**
+
+ModuleSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2082](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2082)
+
+___
+
+### id
+
+• `Optional` **id**: `string`
+
+**`Memberof`**
+
+ModuleSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2070](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2070)
+
+___
+
+### name
+
+• `Optional` **name**: `string`
+
+**`Memberof`**
+
+ModuleSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2076](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2076)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleSearchInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleSearchInputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.ModuleSearchInputDTO"
+title: "Interface: ModuleSearchInputDTO"
+sidebar_label: "@takaro/apiclient.ModuleSearchInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ModuleSearchInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+ModuleSearchInputDTO
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+ModuleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2125](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2125)
+
+___
+
+### filters
+
+• `Optional` **filters**: [`ModuleSearchInputAllowedFilters`](takaro_apiclient.ModuleSearchInputAllowedFilters.md)
+
+**`Memberof`**
+
+ModuleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2095](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2095)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+ModuleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2107](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2107)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+ModuleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2101](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2101)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+ModuleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2113](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2113)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`ModuleSearchInputDTOSortDirectionEnum`](../modules/takaro_apiclient.md#modulesearchinputdtosortdirectionenum-1)
+
+**`Memberof`**
+
+ModuleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2119](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2119)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleUpdateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ModuleUpdateDTO.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.ModuleUpdateDTO"
+title: "Interface: ModuleUpdateDTO"
+sidebar_label: "@takaro/apiclient.ModuleUpdateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ModuleUpdateDTO
+
+**`Export`**
+
+**`Interface`**
+
+ModuleUpdateDTO
+
+## Properties
+
+### config
+
+• `Optional` **config**: `object`
+
+**`Memberof`**
+
+ModuleUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2159](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2159)
+
+___
+
+### enabled
+
+• **enabled**: `boolean`
+
+**`Memberof`**
+
+ModuleUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2153](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2153)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+ModuleUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2147](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2147)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ParamId.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ParamId.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.ParamId"
+title: "Interface: ParamId"
+sidebar_label: "@takaro/apiclient.ParamId"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ParamId
+
+**`Export`**
+
+**`Interface`**
+
+ParamId
+
+## Properties
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+ParamId
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2172](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2172)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ParamIdAndRoleId.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ParamIdAndRoleId.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.ParamIdAndRoleId"
+title: "Interface: ParamIdAndRoleId"
+sidebar_label: "@takaro/apiclient.ParamIdAndRoleId"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ParamIdAndRoleId
+
+**`Export`**
+
+**`Interface`**
+
+ParamIdAndRoleId
+
+## Properties
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+ParamIdAndRoleId
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2191](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2191)
+
+___
+
+### roleId
+
+• **roleId**: `string`
+
+**`Memberof`**
+
+ParamIdAndRoleId
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2185](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2185)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ParamKey.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.ParamKey.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.ParamKey"
+title: "Interface: ParamKey"
+sidebar_label: "@takaro/apiclient.ParamKey"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).ParamKey
+
+**`Export`**
+
+**`Interface`**
+
+ParamKey
+
+## Properties
+
+### key
+
+• **key**: [`ParamKeyKeyEnum`](../modules/takaro_apiclient.md#paramkeykeyenum-1)[]
+
+**`Memberof`**
+
+ParamKey
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2204](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2204)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerCreateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerCreateDTO.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.PlayerCreateDTO"
+title: "Interface: PlayerCreateDTO"
+sidebar_label: "@takaro/apiclient.PlayerCreateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).PlayerCreateDTO
+
+**`Export`**
+
+**`Interface`**
+
+PlayerCreateDTO
+
+## Properties
+
+### epicOnlineServicesId
+
+• `Optional` **epicOnlineServicesId**: `string`
+
+**`Memberof`**
+
+PlayerCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2244](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2244)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+PlayerCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2226](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2226)
+
+___
+
+### steamId
+
+• `Optional` **steamId**: `string`
+
+**`Memberof`**
+
+PlayerCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2232](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2232)
+
+___
+
+### xboxLiveId
+
+• `Optional` **xboxLiveId**: `string`
+
+**`Memberof`**
+
+PlayerCreateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2238](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2238)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerOutputArrayDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerOutputArrayDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.PlayerOutputArrayDTOAPI"
+title: "Interface: PlayerOutputArrayDTOAPI"
+sidebar_label: "@takaro/apiclient.PlayerOutputArrayDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).PlayerOutputArrayDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+PlayerOutputArrayDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`PlayerOutputDTO`](takaro_apiclient.PlayerOutputDTO.md)[]
+
+**`Memberof`**
+
+PlayerOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2257](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2257)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+PlayerOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2263](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2263)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerOutputDTO.md
@@ -1,0 +1,84 @@
+---
+id: "takaro_apiclient.PlayerOutputDTO"
+title: "Interface: PlayerOutputDTO"
+sidebar_label: "@takaro/apiclient.PlayerOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).PlayerOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+PlayerOutputDTO
+
+## Properties
+
+### epicOnlineServicesId
+
+• `Optional` **epicOnlineServicesId**: `string`
+
+**`Memberof`**
+
+PlayerOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2300](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2300)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+PlayerOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2276](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2276)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+PlayerOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2282](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2282)
+
+___
+
+### steamId
+
+• `Optional` **steamId**: `string`
+
+**`Memberof`**
+
+PlayerOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2288](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2288)
+
+___
+
+### xboxLiveId
+
+• `Optional` **xboxLiveId**: `string`
+
+**`Memberof`**
+
+PlayerOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2294](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2294)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.PlayerOutputDTOAPI"
+title: "Interface: PlayerOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.PlayerOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).PlayerOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+PlayerOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`PlayerOutputDTO`](takaro_apiclient.PlayerOutputDTO.md)
+
+**`Memberof`**
+
+PlayerOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2313](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2313)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+PlayerOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2319](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2319)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerSearchInputAllowedFilters.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerSearchInputAllowedFilters.md
@@ -1,0 +1,84 @@
+---
+id: "takaro_apiclient.PlayerSearchInputAllowedFilters"
+title: "Interface: PlayerSearchInputAllowedFilters"
+sidebar_label: "@takaro/apiclient.PlayerSearchInputAllowedFilters"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).PlayerSearchInputAllowedFilters
+
+**`Export`**
+
+**`Interface`**
+
+PlayerSearchInputAllowedFilters
+
+## Properties
+
+### epicOnlineServicesId
+
+• `Optional` **epicOnlineServicesId**: `string`
+
+**`Memberof`**
+
+PlayerSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2350](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2350)
+
+___
+
+### id
+
+• `Optional` **id**: `string`
+
+**`Memberof`**
+
+PlayerSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2332](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2332)
+
+___
+
+### name
+
+• `Optional` **name**: `string`
+
+**`Memberof`**
+
+PlayerSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2338](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2338)
+
+___
+
+### steamId
+
+• `Optional` **steamId**: `string`
+
+**`Memberof`**
+
+PlayerSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2344](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2344)
+
+___
+
+### xboxLiveId
+
+• `Optional` **xboxLiveId**: `string`
+
+**`Memberof`**
+
+PlayerSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2356](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2356)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerSearchInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerSearchInputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.PlayerSearchInputDTO"
+title: "Interface: PlayerSearchInputDTO"
+sidebar_label: "@takaro/apiclient.PlayerSearchInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).PlayerSearchInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+PlayerSearchInputDTO
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+PlayerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2399](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2399)
+
+___
+
+### filters
+
+• `Optional` **filters**: [`PlayerSearchInputAllowedFilters`](takaro_apiclient.PlayerSearchInputAllowedFilters.md)
+
+**`Memberof`**
+
+PlayerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2369](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2369)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+PlayerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2381](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2381)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+PlayerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2375](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2375)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+PlayerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2387](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2387)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`PlayerSearchInputDTOSortDirectionEnum`](../modules/takaro_apiclient.md#playersearchinputdtosortdirectionenum-1)
+
+**`Memberof`**
+
+PlayerSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2393](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2393)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerUpdateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.PlayerUpdateDTO.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.PlayerUpdateDTO"
+title: "Interface: PlayerUpdateDTO"
+sidebar_label: "@takaro/apiclient.PlayerUpdateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).PlayerUpdateDTO
+
+**`Export`**
+
+**`Interface`**
+
+PlayerUpdateDTO
+
+## Properties
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+PlayerUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2421](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2421)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleCreateInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleCreateInputDTO.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.RoleCreateInputDTO"
+title: "Interface: RoleCreateInputDTO"
+sidebar_label: "@takaro/apiclient.RoleCreateInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).RoleCreateInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+RoleCreateInputDTO
+
+## Properties
+
+### capabilities
+
+• **capabilities**: [`RoleCreateInputDTOCapabilitiesEnum`](../modules/takaro_apiclient.md#rolecreateinputdtocapabilitiesenum-1)[]
+
+**`Memberof`**
+
+RoleCreateInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2440](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2440)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+RoleCreateInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2434](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2434)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleOutputArrayDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleOutputArrayDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.RoleOutputArrayDTOAPI"
+title: "Interface: RoleOutputArrayDTOAPI"
+sidebar_label: "@takaro/apiclient.RoleOutputArrayDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).RoleOutputArrayDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+RoleOutputArrayDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`RoleOutputDTO`](takaro_apiclient.RoleOutputDTO.md)[]
+
+**`Memberof`**
+
+RoleOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2481](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2481)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+RoleOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2487](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2487)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleOutputDTO.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.RoleOutputDTO"
+title: "Interface: RoleOutputDTO"
+sidebar_label: "@takaro/apiclient.RoleOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).RoleOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+RoleOutputDTO
+
+## Properties
+
+### capabilities
+
+• **capabilities**: `any`[]
+
+**`Memberof`**
+
+RoleOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2512](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2512)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+RoleOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2500](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2500)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+RoleOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2506](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2506)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.RoleOutputDTOAPI"
+title: "Interface: RoleOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.RoleOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).RoleOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+RoleOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`RoleOutputDTO`](takaro_apiclient.RoleOutputDTO.md)
+
+**`Memberof`**
+
+RoleOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2525](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2525)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+RoleOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2531](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2531)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleSearchInputAllowedFilters.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleSearchInputAllowedFilters.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.RoleSearchInputAllowedFilters"
+title: "Interface: RoleSearchInputAllowedFilters"
+sidebar_label: "@takaro/apiclient.RoleSearchInputAllowedFilters"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).RoleSearchInputAllowedFilters
+
+**`Export`**
+
+**`Interface`**
+
+RoleSearchInputAllowedFilters
+
+## Properties
+
+### name
+
+• `Optional` **name**: `string`
+
+**`Memberof`**
+
+RoleSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2544](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2544)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleSearchInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleSearchInputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.RoleSearchInputDTO"
+title: "Interface: RoleSearchInputDTO"
+sidebar_label: "@takaro/apiclient.RoleSearchInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).RoleSearchInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+RoleSearchInputDTO
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+RoleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2587](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2587)
+
+___
+
+### filters
+
+• `Optional` **filters**: [`RoleSearchInputAllowedFilters`](takaro_apiclient.RoleSearchInputAllowedFilters.md)
+
+**`Memberof`**
+
+RoleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2557](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2557)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+RoleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2569](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2569)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+RoleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2563](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2563)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+RoleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2575](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2575)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`RoleSearchInputDTOSortDirectionEnum`](../modules/takaro_apiclient.md#rolesearchinputdtosortdirectionenum-1)
+
+**`Memberof`**
+
+RoleSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2581](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2581)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleUpdateInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RoleUpdateInputDTO.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.RoleUpdateInputDTO"
+title: "Interface: RoleUpdateInputDTO"
+sidebar_label: "@takaro/apiclient.RoleUpdateInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).RoleUpdateInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+RoleUpdateInputDTO
+
+## Properties
+
+### capabilities
+
+• **capabilities**: [`RoleUpdateInputDTOCapabilitiesEnum`](../modules/takaro_apiclient.md#roleupdateinputdtocapabilitiesenum-1)[]
+
+**`Memberof`**
+
+RoleUpdateInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2615](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2615)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+RoleUpdateInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2609](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2609)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RustConfig.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RustConfig.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.RustConfig"
+title: "Interface: RustConfig"
+sidebar_label: "@takaro/apiclient.RustConfig"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).RustConfig
+
+**`Export`**
+
+**`Interface`**
+
+RustConfig
+
+## Properties
+
+### hostname
+
+• **hostname**: `string`
+
+**`Memberof`**
+
+RustConfig
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2656](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2656)
+
+___
+
+### password
+
+• **password**: `string`
+
+**`Memberof`**
+
+RustConfig
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2668](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2668)
+
+___
+
+### port
+
+• **port**: `string`
+
+**`Memberof`**
+
+RustConfig
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2662](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2662)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RustConnectionInfo.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.RustConnectionInfo.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.RustConnectionInfo"
+title: "Interface: RustConnectionInfo"
+sidebar_label: "@takaro/apiclient.RustConnectionInfo"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).RustConnectionInfo
+
+**`Export`**
+
+**`Interface`**
+
+RustConnectionInfo
+
+## Properties
+
+### host
+
+• **host**: `string`
+
+**`Memberof`**
+
+RustConnectionInfo
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2681](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2681)
+
+___
+
+### rconPassword
+
+• **rconPassword**: `string`
+
+**`Memberof`**
+
+RustConnectionInfo
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2693](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2693)
+
+___
+
+### rconPort
+
+• **rconPort**: `number`
+
+**`Memberof`**
+
+RustConnectionInfo
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2687](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2687)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.SdtdConnectionInfo.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.SdtdConnectionInfo.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.SdtdConnectionInfo"
+title: "Interface: SdtdConnectionInfo"
+sidebar_label: "@takaro/apiclient.SdtdConnectionInfo"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).SdtdConnectionInfo
+
+**`Export`**
+
+**`Interface`**
+
+SdtdConnectionInfo
+
+## Properties
+
+### adminToken
+
+• **adminToken**: `string`
+
+**`Memberof`**
+
+SdtdConnectionInfo
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2718](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2718)
+
+___
+
+### adminUser
+
+• **adminUser**: `string`
+
+**`Memberof`**
+
+SdtdConnectionInfo
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2712](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2712)
+
+___
+
+### host
+
+• **host**: `string`
+
+**`Memberof`**
+
+SdtdConnectionInfo
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2706](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2706)
+
+___
+
+### useTls
+
+• **useTls**: `boolean`
+
+**`Memberof`**
+
+SdtdConnectionInfo
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2724](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2724)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.SearchRoleInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.SearchRoleInputDTO.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.SearchRoleInputDTO"
+title: "Interface: SearchRoleInputDTO"
+sidebar_label: "@takaro/apiclient.SearchRoleInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).SearchRoleInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+SearchRoleInputDTO
+
+## Properties
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+SearchRoleInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2737](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2737)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.Settings.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.Settings.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.Settings"
+title: "Interface: Settings"
+sidebar_label: "@takaro/apiclient.Settings"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).Settings
+
+**`Export`**
+
+**`Interface`**
+
+Settings
+
+## Properties
+
+### commandPrefix
+
+• **commandPrefix**: `string`
+
+**`Memberof`**
+
+Settings
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2750](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2750)
+
+___
+
+### serverChatName
+
+• **serverChatName**: `string`
+
+**`Memberof`**
+
+Settings
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2756](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2756)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.SettingsOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.SettingsOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.SettingsOutputDTOAPI"
+title: "Interface: SettingsOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.SettingsOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).SettingsOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+SettingsOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: `string`
+
+**`Memberof`**
+
+SettingsOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2769](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2769)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+SettingsOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2775](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2775)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.SettingsOutputObjectDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.SettingsOutputObjectDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.SettingsOutputObjectDTOAPI"
+title: "Interface: SettingsOutputObjectDTOAPI"
+sidebar_label: "@takaro/apiclient.SettingsOutputObjectDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).SettingsOutputObjectDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+SettingsOutputObjectDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`Settings`](takaro_apiclient.Settings.md)
+
+**`Memberof`**
+
+SettingsOutputObjectDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2788](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2788)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+SettingsOutputObjectDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2794](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2794)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.SettingsSetDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.SettingsSetDTO.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.SettingsSetDTO"
+title: "Interface: SettingsSetDTO"
+sidebar_label: "@takaro/apiclient.SettingsSetDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).SettingsSetDTO
+
+**`Export`**
+
+**`Interface`**
+
+SettingsSetDTO
+
+## Properties
+
+### gameServerId
+
+• `Optional` **gameServerId**: `string`
+
+**`Memberof`**
+
+SettingsSetDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2807](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2807)
+
+___
+
+### value
+
+• **value**: `string`
+
+**`Memberof`**
+
+SettingsSetDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2813](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2813)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.TestReachabilityOutput.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.TestReachabilityOutput.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.TestReachabilityOutput"
+title: "Interface: TestReachabilityOutput"
+sidebar_label: "@takaro/apiclient.TestReachabilityOutput"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).TestReachabilityOutput
+
+**`Export`**
+
+**`Interface`**
+
+TestReachabilityOutput
+
+## Properties
+
+### connectable
+
+• **connectable**: `boolean`
+
+**`Memberof`**
+
+TestReachabilityOutput
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2826](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2826)
+
+___
+
+### reason
+
+• `Optional` **reason**: `string`
+
+**`Memberof`**
+
+TestReachabilityOutput
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2832](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2832)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserCreateInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserCreateInputDTO.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.UserCreateInputDTO"
+title: "Interface: UserCreateInputDTO"
+sidebar_label: "@takaro/apiclient.UserCreateInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).UserCreateInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+UserCreateInputDTO
+
+## Properties
+
+### email
+
+• **email**: `string`
+
+**`Memberof`**
+
+UserCreateInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2851](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2851)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+UserCreateInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2845](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2845)
+
+___
+
+### password
+
+• **password**: `string`
+
+**`Memberof`**
+
+UserCreateInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2857](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2857)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserOutputArrayDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserOutputArrayDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.UserOutputArrayDTOAPI"
+title: "Interface: UserOutputArrayDTOAPI"
+sidebar_label: "@takaro/apiclient.UserOutputArrayDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).UserOutputArrayDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+UserOutputArrayDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`UserOutputDTO`](takaro_apiclient.UserOutputDTO.md)[]
+
+**`Memberof`**
+
+UserOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2870](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2870)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+UserOutputArrayDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2876](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2876)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserOutputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserOutputDTO.md
@@ -1,0 +1,56 @@
+---
+id: "takaro_apiclient.UserOutputDTO"
+title: "Interface: UserOutputDTO"
+sidebar_label: "@takaro/apiclient.UserOutputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).UserOutputDTO
+
+**`Export`**
+
+**`Interface`**
+
+UserOutputDTO
+
+## Properties
+
+### email
+
+• **email**: `string`
+
+**`Memberof`**
+
+UserOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2901](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2901)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+UserOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2889](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2889)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+UserOutputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2895](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2895)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserOutputDTOAPI.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserOutputDTOAPI.md
@@ -1,0 +1,42 @@
+---
+id: "takaro_apiclient.UserOutputDTOAPI"
+title: "Interface: UserOutputDTOAPI"
+sidebar_label: "@takaro/apiclient.UserOutputDTOAPI"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).UserOutputDTOAPI
+
+**`Export`**
+
+**`Interface`**
+
+UserOutputDTOAPI
+
+## Properties
+
+### data
+
+• **data**: [`UserOutputDTO`](takaro_apiclient.UserOutputDTO.md)
+
+**`Memberof`**
+
+UserOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2914](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2914)
+
+___
+
+### metadata
+
+• **metadata**: [`MetadataOutput`](takaro_apiclient.MetadataOutput.md)
+
+**`Memberof`**
+
+UserOutputDTOAPI
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2920](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2920)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserOutputWithRolesDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserOutputWithRolesDTO.md
@@ -1,0 +1,70 @@
+---
+id: "takaro_apiclient.UserOutputWithRolesDTO"
+title: "Interface: UserOutputWithRolesDTO"
+sidebar_label: "@takaro/apiclient.UserOutputWithRolesDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).UserOutputWithRolesDTO
+
+**`Export`**
+
+**`Interface`**
+
+UserOutputWithRolesDTO
+
+## Properties
+
+### email
+
+• **email**: `string`
+
+**`Memberof`**
+
+UserOutputWithRolesDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2951](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2951)
+
+___
+
+### id
+
+• **id**: `string`
+
+**`Memberof`**
+
+UserOutputWithRolesDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2939](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2939)
+
+___
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+UserOutputWithRolesDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2945](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2945)
+
+___
+
+### roles
+
+• **roles**: [`RoleOutputDTO`](takaro_apiclient.RoleOutputDTO.md)
+
+**`Memberof`**
+
+UserOutputWithRolesDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2933](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2933)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserSearchInputAllowedFilters.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserSearchInputAllowedFilters.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.UserSearchInputAllowedFilters"
+title: "Interface: UserSearchInputAllowedFilters"
+sidebar_label: "@takaro/apiclient.UserSearchInputAllowedFilters"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).UserSearchInputAllowedFilters
+
+**`Export`**
+
+**`Interface`**
+
+UserSearchInputAllowedFilters
+
+## Properties
+
+### name
+
+• `Optional` **name**: `string`
+
+**`Memberof`**
+
+UserSearchInputAllowedFilters
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2964](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2964)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserSearchInputDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserSearchInputDTO.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_apiclient.UserSearchInputDTO"
+title: "Interface: UserSearchInputDTO"
+sidebar_label: "@takaro/apiclient.UserSearchInputDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).UserSearchInputDTO
+
+**`Export`**
+
+**`Interface`**
+
+UserSearchInputDTO
+
+## Properties
+
+### extend
+
+• `Optional` **extend**: `string`[]
+
+**`Memberof`**
+
+UserSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3007](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3007)
+
+___
+
+### filters
+
+• `Optional` **filters**: [`UserSearchInputAllowedFilters`](takaro_apiclient.UserSearchInputAllowedFilters.md)
+
+**`Memberof`**
+
+UserSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2977](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2977)
+
+___
+
+### limit
+
+• `Optional` **limit**: `number`
+
+**`Memberof`**
+
+UserSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2989](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2989)
+
+___
+
+### page
+
+• `Optional` **page**: `number`
+
+**`Memberof`**
+
+UserSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2983](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2983)
+
+___
+
+### sortBy
+
+• `Optional` **sortBy**: `string`
+
+**`Memberof`**
+
+UserSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2995](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2995)
+
+___
+
+### sortDirection
+
+• `Optional` **sortDirection**: [`UserSearchInputDTOSortDirectionEnum`](../modules/takaro_apiclient.md#usersearchinputdtosortdirectionenum-1)
+
+**`Memberof`**
+
+UserSearchInputDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3001](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3001)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserUpdateDTO.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_apiclient.UserUpdateDTO.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_apiclient.UserUpdateDTO"
+title: "Interface: UserUpdateDTO"
+sidebar_label: "@takaro/apiclient.UserUpdateDTO"
+custom_edit_url: null
+---
+
+[@takaro/apiclient](../modules/takaro_apiclient.md).UserUpdateDTO
+
+**`Export`**
+
+**`Interface`**
+
+UserUpdateDTO
+
+## Properties
+
+### name
+
+• **name**: `string`
+
+**`Memberof`**
+
+UserUpdateDTO
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3029](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3029)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_config.IBaseConfig.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_config.IBaseConfig.md
@@ -1,0 +1,34 @@
+---
+id: "takaro_config.IBaseConfig"
+title: "Interface: IBaseConfig"
+sidebar_label: "@takaro/config.IBaseConfig"
+custom_edit_url: null
+---
+
+[@takaro/config](../modules/takaro_config.md).IBaseConfig
+
+## Properties
+
+### app
+
+• **app**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+
+#### Defined in
+
+[packages/lib-config/src/main.ts:4](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-config/src/main.ts#L4)
+
+___
+
+### mode
+
+• **mode**: ``"development"`` \| ``"production"`` \| ``"test"``
+
+#### Defined in
+
+[packages/lib-config/src/main.ts:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-config/src/main.ts#L7)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_db.IDbConfig.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_db.IDbConfig.md
@@ -1,0 +1,98 @@
+---
+id: "takaro_db.IDbConfig"
+title: "Interface: IDbConfig"
+sidebar_label: "@takaro/db.IDbConfig"
+custom_edit_url: null
+---
+
+[@takaro/db](../modules/takaro_db.md).IDbConfig
+
+## Hierarchy
+
+- `IBaseConfig`
+
+  ↳ **`IDbConfig`**
+
+## Properties
+
+### app
+
+• **app**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+
+#### Inherited from
+
+IBaseConfig.app
+
+#### Defined in
+
+node_modules/@takaro/config/dist/main.d.ts:3
+
+___
+
+### baseDomainSchema
+
+• **baseDomainSchema**: `string`
+
+#### Defined in
+
+[packages/lib-db/src/config.ts:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/config.ts#L12)
+
+___
+
+### encryptionKey
+
+• **encryptionKey**: `string`
+
+#### Defined in
+
+[packages/lib-db/src/config.ts:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/config.ts#L13)
+
+___
+
+### mode
+
+• **mode**: ``"development"`` \| ``"production"`` \| ``"test"``
+
+#### Inherited from
+
+IBaseConfig.mode
+
+#### Defined in
+
+node_modules/@takaro/config/dist/main.d.ts:6
+
+___
+
+### postgres
+
+• **postgres**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `database` | `string` |
+| `host` | `string` |
+| `password` | `string` |
+| `port` | `number` |
+| `user` | `string` |
+
+#### Defined in
+
+[packages/lib-db/src/config.ts:4](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/config.ts#L4)
+
+___
+
+### systemSchema
+
+• **systemSchema**: `string`
+
+#### Defined in
+
+[packages/lib-db/src/config.ts:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/config.ts#L11)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_gameserver.IGameServer.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_gameserver.IGameServer.md
@@ -1,0 +1,89 @@
+---
+id: "takaro_gameserver.IGameServer"
+title: "Interface: IGameServer"
+sidebar_label: "@takaro/gameserver.IGameServer"
+custom_edit_url: null
+---
+
+[@takaro/gameserver](../modules/takaro_gameserver.md).IGameServer
+
+## Implemented by
+
+- [`Mock`](../classes/takaro_gameserver.Mock.md)
+- [`Rust`](../classes/takaro_gameserver.Rust.md)
+- [`SevenDaysToDie`](../classes/takaro_gameserver.SevenDaysToDie.md)
+
+## Properties
+
+### connectionInfo
+
+• **connectionInfo**: `unknown`
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GameServer.ts:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GameServer.ts#L16)
+
+## Methods
+
+### getEventEmitter
+
+▸ **getEventEmitter**(): [`TakaroEmitter`](../classes/takaro_gameserver.TakaroEmitter.md)
+
+#### Returns
+
+[`TakaroEmitter`](../classes/takaro_gameserver.TakaroEmitter.md)
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GameServer.ts:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GameServer.ts#L20)
+
+___
+
+### getPlayer
+
+▸ **getPlayer**(`id`): `Promise`<``null`` \| [`IGamePlayer`](../classes/takaro_gameserver.IGamePlayer.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `id` | `string` |
+
+#### Returns
+
+`Promise`<``null`` \| [`IGamePlayer`](../classes/takaro_gameserver.IGamePlayer.md)\>
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GameServer.ts:18](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GameServer.ts#L18)
+
+___
+
+### getPlayers
+
+▸ **getPlayers**(): `Promise`<[`IGamePlayer`](../classes/takaro_gameserver.IGamePlayer.md)[]\>
+
+#### Returns
+
+`Promise`<[`IGamePlayer`](../classes/takaro_gameserver.IGamePlayer.md)[]\>
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GameServer.ts:19](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GameServer.ts#L19)
+
+___
+
+### testReachability
+
+▸ **testReachability**(): `Promise`<[`TestReachabilityOutput`](../classes/takaro_gameserver.TestReachabilityOutput.md)\>
+
+Try and connect to the gameserver
+If anything goes wrong, this function will report a detailed reason
+
+#### Returns
+
+`Promise`<[`TestReachabilityOutput`](../classes/takaro_gameserver.TestReachabilityOutput.md)\>
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/GameServer.ts:26](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/GameServer.ts#L26)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_http.PaginatedRequest.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_http.PaginatedRequest.md
@@ -1,0 +1,3776 @@
+---
+id: "takaro_http.PaginatedRequest"
+title: "Interface: PaginatedRequest"
+sidebar_label: "@takaro/http.PaginatedRequest"
+custom_edit_url: null
+---
+
+[@takaro/http](../modules/takaro_http.md).PaginatedRequest
+
+## Hierarchy
+
+- `Request`
+
+  ↳ **`PaginatedRequest`**
+
+## Properties
+
+### aborted
+
+• **aborted**: `boolean`
+
+The `message.aborted` property will be `true` if the request has
+been aborted.
+
+**`Since`**
+
+v10.1.0
+
+#### Inherited from
+
+Request.aborted
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:864
+
+___
+
+### accepted
+
+• **accepted**: `MediaType`[]
+
+Return an array of Accepted media types
+ordered from highest quality to lowest.
+
+#### Inherited from
+
+Request.accepted
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:497
+
+___
+
+### app
+
+• **app**: `Application`<`Record`<`string`, `any`\>\>
+
+#### Inherited from
+
+Request.app
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:640
+
+___
+
+### baseUrl
+
+• **baseUrl**: `string`
+
+#### Inherited from
+
+Request.baseUrl
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:638
+
+___
+
+### body
+
+• **body**: `any`
+
+#### Inherited from
+
+Request.body
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:619
+
+___
+
+### complete
+
+• **complete**: `boolean`
+
+The `message.complete` property will be `true` if a complete HTTP message has
+been received and successfully parsed.
+
+This property is particularly useful as a means of determining if a client or
+server fully transmitted a message before a connection was terminated:
+
+```js
+const req = http.request({
+  host: '127.0.0.1',
+  port: 8080,
+  method: 'POST'
+}, (res) => {
+  res.resume();
+  res.on('end', () => {
+    if (!res.complete)
+      console.error(
+        'The connection was terminated while the message was still being sent');
+  });
+});
+```
+
+**`Since`**
+
+v0.3.0
+
+#### Inherited from
+
+Request.complete
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:899
+
+___
+
+### connection
+
+• **connection**: `Socket`
+
+Alias for `message.socket`.
+
+**`Since`**
+
+v0.1.90
+
+**`Deprecated`**
+
+Since v16.0.0 - Use `socket`.
+
+#### Inherited from
+
+Request.connection
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:905
+
+___
+
+### cookies
+
+• **cookies**: `any`
+
+#### Inherited from
+
+Request.cookies
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:622
+
+___
+
+### destroyed
+
+• **destroyed**: `boolean`
+
+Is `true` after `readable.destroy()` has been called.
+
+**`Since`**
+
+v8.0.0
+
+#### Inherited from
+
+Request.destroyed
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:116
+
+___
+
+### file
+
+• `Optional` **file**: `File`
+
+`Multer.File` object populated by `single()` middleware.
+
+#### Inherited from
+
+Request.file
+
+#### Defined in
+
+node_modules/@types/multer/index.d.ts:52
+
+___
+
+### files
+
+• `Optional` **files**: { `[fieldname: string]`: `Multer.File`[];  } \| `File`[]
+
+Array or dictionary of `Multer.File` object populated by `array()`,
+`fields()`, and `any()` middleware.
+
+#### Inherited from
+
+Request.files
+
+#### Defined in
+
+node_modules/@types/multer/index.d.ts:57
+
+___
+
+### fresh
+
+• **fresh**: `boolean`
+
+Check if the request is fresh, aka
+Last-Modified and/or the ETag
+still match.
+
+#### Inherited from
+
+Request.fresh
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:604
+
+___
+
+### headers
+
+• **headers**: `IncomingHttpHeaders`
+
+The request/response headers object.
+
+Key-value pairs of header names and values. Header names are lower-cased.
+
+```js
+// Prints something like:
+//
+// { 'user-agent': 'curl/7.22.0',
+//   host: '127.0.0.1:8000',
+//   accept: '*' }
+console.log(request.headers);
+```
+
+Duplicates in raw headers are handled in the following ways, depending on the
+header name:
+
+* Duplicates of `age`, `authorization`, `content-length`, `content-type`,`etag`, `expires`, `from`, `host`, `if-modified-since`, `if-unmodified-since`,`last-modified`, `location`,
+`max-forwards`, `proxy-authorization`, `referer`,`retry-after`, `server`, or `user-agent` are discarded.
+* `set-cookie` is always an array. Duplicates are added to the array.
+* For duplicate `cookie` headers, the values are joined together with '; '.
+* For all other headers, the values are joined together with ', '.
+
+**`Since`**
+
+v0.1.5
+
+#### Inherited from
+
+Request.headers
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:942
+
+___
+
+### host
+
+• **host**: `string`
+
+**`Deprecated`**
+
+Use hostname instead.
+
+#### Inherited from
+
+Request.host
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:597
+
+___
+
+### hostname
+
+• **hostname**: `string`
+
+Parse the "Host" header field hostname.
+
+#### Inherited from
+
+Request.hostname
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:592
+
+___
+
+### httpVersion
+
+• **httpVersion**: `string`
+
+In case of server request, the HTTP version sent by the client. In the case of
+client response, the HTTP version of the connected-to server.
+Probably either `'1.1'` or `'1.0'`.
+
+Also `message.httpVersionMajor` is the first integer and`message.httpVersionMinor` is the second.
+
+**`Since`**
+
+v0.1.1
+
+#### Inherited from
+
+Request.httpVersion
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:873
+
+___
+
+### httpVersionMajor
+
+• **httpVersionMajor**: `number`
+
+#### Inherited from
+
+Request.httpVersionMajor
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:874
+
+___
+
+### httpVersionMinor
+
+• **httpVersionMinor**: `number`
+
+#### Inherited from
+
+Request.httpVersionMinor
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:875
+
+___
+
+### ip
+
+• **ip**: `string`
+
+Return the remote address, or when
+"trust proxy" is `true` return
+the upstream addr.
+
+#### Inherited from
+
+Request.ip
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:559
+
+___
+
+### ips
+
+• **ips**: `string`[]
+
+When "trust proxy" is `true`, parse
+the "X-Forwarded-For" ip address list.
+
+For example if the value were "client, proxy1, proxy2"
+you would receive the array `["client", "proxy1", "proxy2"]`
+where "proxy2" is the furthest down-stream.
+
+#### Inherited from
+
+Request.ips
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:569
+
+___
+
+### limit
+
+• **limit**: `number`
+
+#### Defined in
+
+[packages/lib-http/src/middleware/paginationMiddleware.ts:15](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/middleware/paginationMiddleware.ts#L15)
+
+___
+
+### method
+
+• **method**: `string`
+
+#### Inherited from
+
+Request.method
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:624
+
+___
+
+### next
+
+• `Optional` **next**: `NextFunction`
+
+#### Inherited from
+
+Request.next
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:647
+
+___
+
+### originalUrl
+
+• **originalUrl**: `string`
+
+#### Inherited from
+
+Request.originalUrl
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:634
+
+___
+
+### page
+
+• **page**: `number`
+
+#### Defined in
+
+[packages/lib-http/src/middleware/paginationMiddleware.ts:14](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/middleware/paginationMiddleware.ts#L14)
+
+___
+
+### params
+
+• **params**: `ParamsDictionary`
+
+#### Inherited from
+
+Request.params
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:626
+
+___
+
+### path
+
+• **path**: `string`
+
+Short-hand for `url.parse(req.url).pathname`.
+
+#### Inherited from
+
+Request.path
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:587
+
+___
+
+### protocol
+
+• **protocol**: `string`
+
+Return the protocol string "http" or "https"
+when requested with TLS. When the "trust proxy"
+setting is enabled the "X-Forwarded-Proto" header
+field will be trusted. If you're running behind
+a reverse proxy that supplies https for you this
+may be enabled.
+
+#### Inherited from
+
+Request.protocol
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:545
+
+___
+
+### query
+
+• **query**: `ParsedQs`
+
+#### Inherited from
+
+Request.query
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:628
+
+___
+
+### rawHeaders
+
+• **rawHeaders**: `string`[]
+
+The raw request/response headers list exactly as they were received.
+
+The keys and values are in the same list. It is _not_ a
+list of tuples. So, the even-numbered offsets are key values, and the
+odd-numbered offsets are the associated values.
+
+Header names are not lowercased, and duplicates are not merged.
+
+```js
+// Prints something like:
+//
+// [ 'user-agent',
+//   'this is invalid because there can be only one',
+//   'User-Agent',
+//   'curl/7.22.0',
+//   'Host',
+//   '127.0.0.1:8000',
+//   'ACCEPT',
+//   '*' ]
+console.log(request.rawHeaders);
+```
+
+**`Since`**
+
+v0.11.6
+
+#### Inherited from
+
+Request.rawHeaders
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:967
+
+___
+
+### rawTrailers
+
+• **rawTrailers**: `string`[]
+
+The raw request/response trailer keys and values exactly as they were
+received. Only populated at the `'end'` event.
+
+**`Since`**
+
+v0.11.6
+
+#### Inherited from
+
+Request.rawTrailers
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:978
+
+___
+
+### readable
+
+• **readable**: `boolean`
+
+Is `true` if it is safe to call `readable.read()`, which means
+the stream has not been destroyed or emitted `'error'` or `'end'`.
+
+**`Since`**
+
+v11.4.0
+
+#### Inherited from
+
+Request.readable
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:72
+
+___
+
+### readableAborted
+
+• `Readonly` **readableAborted**: `boolean`
+
+Returns whether the stream was destroyed or errored before emitting `'end'`.
+
+**`Since`**
+
+v16.8.0
+
+#### Inherited from
+
+Request.readableAborted
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:66
+
+___
+
+### readableDidRead
+
+• `Readonly` **readableDidRead**: `boolean`
+
+Returns whether `'data'` has been emitted.
+
+**`Since`**
+
+v16.7.0
+
+#### Inherited from
+
+Request.readableDidRead
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:78
+
+___
+
+### readableEncoding
+
+• `Readonly` **readableEncoding**: ``null`` \| `BufferEncoding`
+
+Getter for the property `encoding` of a given `Readable` stream. The `encoding`property can be set using the `readable.setEncoding()` method.
+
+**`Since`**
+
+v12.7.0
+
+#### Inherited from
+
+Request.readableEncoding
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:83
+
+___
+
+### readableEnded
+
+• `Readonly` **readableEnded**: `boolean`
+
+Becomes `true` when `'end'` event is emitted.
+
+**`Since`**
+
+v12.9.0
+
+#### Inherited from
+
+Request.readableEnded
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:88
+
+___
+
+### readableFlowing
+
+• `Readonly` **readableFlowing**: ``null`` \| `boolean`
+
+This property reflects the current state of a `Readable` stream as described
+in the `Three states` section.
+
+**`Since`**
+
+v9.4.0
+
+#### Inherited from
+
+Request.readableFlowing
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:94
+
+___
+
+### readableHighWaterMark
+
+• `Readonly` **readableHighWaterMark**: `number`
+
+Returns the value of `highWaterMark` passed when creating this `Readable`.
+
+**`Since`**
+
+v9.3.0
+
+#### Inherited from
+
+Request.readableHighWaterMark
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:99
+
+___
+
+### readableLength
+
+• `Readonly` **readableLength**: `number`
+
+This property contains the number of bytes (or objects) in the queue
+ready to be read. The value provides introspection data regarding
+the status of the `highWaterMark`.
+
+**`Since`**
+
+v9.4.0
+
+#### Inherited from
+
+Request.readableLength
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:106
+
+___
+
+### readableObjectMode
+
+• `Readonly` **readableObjectMode**: `boolean`
+
+Getter for the property `objectMode` of a given `Readable` stream.
+
+**`Since`**
+
+v12.3.0
+
+#### Inherited from
+
+Request.readableObjectMode
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:111
+
+___
+
+### res
+
+• `Optional` **res**: `Response`<`any`, `Record`<`string`, `any`\>, `number`\>
+
+After middleware.init executed, Request will contain res and next properties
+See: express/lib/middleware/init.js
+
+#### Inherited from
+
+Request.res
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:646
+
+___
+
+### route
+
+• **route**: `any`
+
+#### Inherited from
+
+Request.route
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:630
+
+___
+
+### secret
+
+• `Optional` **secret**: `string`
+
+This request's secret.
+Optionally set by cookie-parser if secret(s) are provided.  Can be used by other middleware.
+[Declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) can be used to add your own properties.
+
+#### Inherited from
+
+Request.secret
+
+#### Defined in
+
+node_modules/@types/cookie-parser/index.d.ts:19
+
+___
+
+### secure
+
+• **secure**: `boolean`
+
+Short-hand for:
+
+   req.protocol == 'https'
+
+#### Inherited from
+
+Request.secure
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:552
+
+___
+
+### signedCookies
+
+• **signedCookies**: `any`
+
+#### Inherited from
+
+Request.signedCookies
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:632
+
+___
+
+### socket
+
+• **socket**: `Socket`
+
+The `net.Socket` object associated with the connection.
+
+With HTTPS support, use `request.socket.getPeerCertificate()` to obtain the
+client's authentication details.
+
+This property is guaranteed to be an instance of the `net.Socket` class,
+a subclass of `stream.Duplex`, unless the user specified a socket
+type other than `net.Socket`.
+
+**`Since`**
+
+v0.3.0
+
+#### Inherited from
+
+Request.socket
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:917
+
+___
+
+### stale
+
+• **stale**: `boolean`
+
+Check if the request is stale, aka
+"Last-Modified" and / or the "ETag" for the
+resource has changed.
+
+#### Inherited from
+
+Request.stale
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:611
+
+___
+
+### statusCode
+
+• `Optional` **statusCode**: `number`
+
+**Only valid for response obtained from ClientRequest.**
+
+The 3-digit HTTP response status code. E.G. `404`.
+
+**`Since`**
+
+v0.1.1
+
+#### Inherited from
+
+Request.statusCode
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:1037
+
+___
+
+### statusMessage
+
+• `Optional` **statusMessage**: `string`
+
+**Only valid for response obtained from ClientRequest.**
+
+The HTTP response status message (reason phrase). E.G. `OK` or `Internal Server Error`.
+
+**`Since`**
+
+v0.11.10
+
+#### Inherited from
+
+Request.statusMessage
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:1044
+
+___
+
+### subdomains
+
+• **subdomains**: `string`[]
+
+Return subdomains as an array.
+
+Subdomains are the dot-separated parts of the host before the main domain of
+the app. By default, the domain of the app is assumed to be the last two
+parts of the host. This can be changed by setting "subdomain offset".
+
+For example, if the domain is "tobi.ferrets.example.com":
+If "subdomain offset" is not set, req.subdomains is `["ferrets", "tobi"]`.
+If "subdomain offset" is 3, req.subdomains is `["tobi"]`.
+
+#### Inherited from
+
+Request.subdomains
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:582
+
+___
+
+### trailers
+
+• **trailers**: `Dict`<`string`\>
+
+The request/response trailers object. Only populated at the `'end'` event.
+
+**`Since`**
+
+v0.3.0
+
+#### Inherited from
+
+Request.trailers
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:972
+
+___
+
+### url
+
+• **url**: `string`
+
+#### Inherited from
+
+Request.url
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:636
+
+___
+
+### xhr
+
+• **xhr**: `boolean`
+
+Check if the request was an _XMLHttpRequest_.
+
+#### Inherited from
+
+Request.xhr
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:616
+
+## Methods
+
+### [asyncIterator]
+
+▸ **[asyncIterator]**(): `AsyncIterableIterator`<`any`\>
+
+#### Returns
+
+`AsyncIterableIterator`<`any`\>
+
+#### Inherited from
+
+Request.\_\_@asyncIterator@108263
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:480
+
+___
+
+### \_construct
+
+▸ `Optional` **_construct**(`callback`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | (`error?`: ``null`` \| `Error`) => `void` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Request.\_construct
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:118
+
+___
+
+### \_destroy
+
+▸ **_destroy**(`error`, `callback`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `error` | ``null`` \| `Error` |
+| `callback` | (`error?`: ``null`` \| `Error`) => `void` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Request.\_destroy
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:400
+
+___
+
+### \_read
+
+▸ **_read**(`size`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `size` | `number` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Request.\_read
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:119
+
+___
+
+### accepts
+
+▸ **accepts**(): `string`[]
+
+Check if the given `type(s)` is acceptable, returning
+the best match when true, otherwise `undefined`, in which
+case you should respond with 406 "Not Acceptable".
+
+The `type` value may be a single mime type string
+such as "application/json", the extension name
+such as "json", a comma-delimted list such as "json, html, text/plain",
+or an array `["json", "html", "text/plain"]`. When a list
+or array is given the _best_ match, if any is returned.
+
+Examples:
+
+    // Accept: text/html
+    req.accepts('html');
+    // => "html"
+
+    // Accept: text/*, application/json
+    req.accepts('html');
+    // => "html"
+    req.accepts('text/html');
+    // => "text/html"
+    req.accepts('json, text');
+    // => "json"
+    req.accepts('application/json');
+    // => "application/json"
+
+    // Accept: text/*, application/json
+    req.accepts('image/png');
+    req.accepts('png');
+    // => undefined
+
+    // Accept: text/*;q=.5, application/json
+    req.accepts(['html', 'json']);
+    req.accepts('html, json');
+    // => "json"
+
+#### Returns
+
+`string`[]
+
+#### Inherited from
+
+Request.accepts
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:437
+
+▸ **accepts**(`type`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `type` | `string` |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.accepts
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:438
+
+▸ **accepts**(`type`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `type` | `string`[] |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.accepts
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:439
+
+▸ **accepts**(...`type`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...type` | `string`[] |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.accepts
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:440
+
+___
+
+### acceptsCharsets
+
+▸ **acceptsCharsets**(): `string`[]
+
+Returns the first accepted charset of the specified character sets,
+based on the request's Accept-Charset HTTP header field.
+If none of the specified charsets is accepted, returns false.
+
+For more information, or if you have issues or concerns, see accepts.
+
+#### Returns
+
+`string`[]
+
+#### Inherited from
+
+Request.acceptsCharsets
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:449
+
+▸ **acceptsCharsets**(`charset`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `charset` | `string` |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.acceptsCharsets
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:450
+
+▸ **acceptsCharsets**(`charset`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `charset` | `string`[] |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.acceptsCharsets
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:451
+
+▸ **acceptsCharsets**(...`charset`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...charset` | `string`[] |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.acceptsCharsets
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:452
+
+___
+
+### acceptsEncodings
+
+▸ **acceptsEncodings**(): `string`[]
+
+Returns the first accepted encoding of the specified encodings,
+based on the request's Accept-Encoding HTTP header field.
+If none of the specified encodings is accepted, returns false.
+
+For more information, or if you have issues or concerns, see accepts.
+
+#### Returns
+
+`string`[]
+
+#### Inherited from
+
+Request.acceptsEncodings
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:461
+
+▸ **acceptsEncodings**(`encoding`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `encoding` | `string` |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.acceptsEncodings
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:462
+
+▸ **acceptsEncodings**(`encoding`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `encoding` | `string`[] |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.acceptsEncodings
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:463
+
+▸ **acceptsEncodings**(...`encoding`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...encoding` | `string`[] |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.acceptsEncodings
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:464
+
+___
+
+### acceptsLanguages
+
+▸ **acceptsLanguages**(): `string`[]
+
+Returns the first accepted language of the specified languages,
+based on the request's Accept-Language HTTP header field.
+If none of the specified languages is accepted, returns false.
+
+For more information, or if you have issues or concerns, see accepts.
+
+#### Returns
+
+`string`[]
+
+#### Inherited from
+
+Request.acceptsLanguages
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:473
+
+▸ **acceptsLanguages**(`lang`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `lang` | `string` |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.acceptsLanguages
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:474
+
+▸ **acceptsLanguages**(`lang`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `lang` | `string`[] |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.acceptsLanguages
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:475
+
+▸ **acceptsLanguages**(...`lang`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...lang` | `string`[] |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Inherited from
+
+Request.acceptsLanguages
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:476
+
+___
+
+### addListener
+
+▸ **addListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+Event emitter
+The defined events on documents including:
+1. close
+2. data
+3. end
+4. error
+5. pause
+6. readable
+7. resume
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"close"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.addListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:424
+
+▸ **addListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"data"`` |
+| `listener` | (`chunk`: `any`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.addListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:425
+
+▸ **addListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"end"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.addListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:426
+
+▸ **addListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"error"`` |
+| `listener` | (`err`: `Error`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.addListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:427
+
+▸ **addListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"pause"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.addListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:428
+
+▸ **addListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"readable"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.addListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:429
+
+▸ **addListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"resume"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.addListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:430
+
+▸ **addListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.addListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:431
+
+___
+
+### destroy
+
+▸ **destroy**(`error?`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+Calls `destroy()` on the socket that received the `IncomingMessage`. If `error`is provided, an `'error'` event is emitted on the socket and `error` is passed
+as an argument to any listeners on the event.
+
+**`Since`**
+
+v0.3.0
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `error?` | `Error` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.destroy
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:1050
+
+___
+
+### emit
+
+▸ **emit**(`event`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"close"`` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Request.emit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:432
+
+▸ **emit**(`event`, `chunk`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"data"`` |
+| `chunk` | `any` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Request.emit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:433
+
+▸ **emit**(`event`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"end"`` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Request.emit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:434
+
+▸ **emit**(`event`, `err`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"error"`` |
+| `err` | `Error` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Request.emit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:435
+
+▸ **emit**(`event`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"pause"`` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Request.emit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:436
+
+▸ **emit**(`event`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"readable"`` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Request.emit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:437
+
+▸ **emit**(`event`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"resume"`` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Request.emit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:438
+
+▸ **emit**(`event`, ...`args`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `string` \| `symbol` |
+| `...args` | `any`[] |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Request.emit
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:439
+
+___
+
+### eventNames
+
+▸ **eventNames**(): (`string` \| `symbol`)[]
+
+Returns an array listing the events for which the emitter has registered
+listeners. The values in the array are strings or `Symbol`s.
+
+```js
+const EventEmitter = require('events');
+const myEE = new EventEmitter();
+myEE.on('foo', () => {});
+myEE.on('bar', () => {});
+
+const sym = Symbol('symbol');
+myEE.on(sym, () => {});
+
+console.log(myEE.eventNames());
+// Prints: [ 'foo', 'bar', Symbol(symbol) ]
+```
+
+**`Since`**
+
+v6.0.0
+
+#### Returns
+
+(`string` \| `symbol`)[]
+
+#### Inherited from
+
+Request.eventNames
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:632
+
+___
+
+### get
+
+▸ **get**(`name`): `undefined` \| `string`[]
+
+Return request header.
+
+The `Referrer` header field is special-cased,
+both `Referrer` and `Referer` are interchangeable.
+
+Examples:
+
+    req.get('Content-Type');
+    // => "text/plain"
+
+    req.get('content-type');
+    // => "text/plain"
+
+    req.get('Something');
+    // => undefined
+
+Aliased as `req.header()`.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | ``"set-cookie"`` |
+
+#### Returns
+
+`undefined` \| `string`[]
+
+#### Inherited from
+
+Request.get
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:394
+
+▸ **get**(`name`): `undefined` \| `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+
+#### Returns
+
+`undefined` \| `string`
+
+#### Inherited from
+
+Request.get
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:395
+
+___
+
+### getMaxListeners
+
+▸ **getMaxListeners**(): `number`
+
+Returns the current max listener value for the `EventEmitter` which is either
+set by `emitter.setMaxListeners(n)` or defaults to defaultMaxListeners.
+
+**`Since`**
+
+v1.0.0
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+Request.getMaxListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:489
+
+___
+
+### header
+
+▸ **header**(`name`): `undefined` \| `string`[]
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | ``"set-cookie"`` |
+
+#### Returns
+
+`undefined` \| `string`[]
+
+#### Inherited from
+
+Request.header
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:397
+
+▸ **header**(`name`): `undefined` \| `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+
+#### Returns
+
+`undefined` \| `string`
+
+#### Inherited from
+
+Request.header
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:398
+
+___
+
+### is
+
+▸ **is**(`type`): ``null`` \| `string` \| ``false``
+
+Check if the incoming request contains the "Content-Type"
+header field, and it contains the give mime `type`.
+
+Examples:
+
+     // With Content-Type: text/html; charset=utf-8
+     req.is('html');
+     req.is('text/html');
+     req.is('text/*');
+     // => true
+
+     // When Content-Type is application/json
+     req.is('json');
+     req.is('application/json');
+     req.is('application/*');
+     // => true
+
+     req.is('html');
+     // => false
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `type` | `string` \| `string`[] |
+
+#### Returns
+
+``null`` \| `string` \| ``false``
+
+#### Inherited from
+
+Request.is
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:535
+
+___
+
+### isPaused
+
+▸ **isPaused**(): `boolean`
+
+The `readable.isPaused()` method returns the current operating state of the`Readable`. This is used primarily by the mechanism that underlies the`readable.pipe()` method. In most
+typical cases, there will be no reason to
+use this method directly.
+
+```js
+const readable = new stream.Readable();
+
+readable.isPaused(); // === false
+readable.pause();
+readable.isPaused(); // === true
+readable.resume();
+readable.isPaused(); // === false
+```
+
+**`Since`**
+
+v0.11.14
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Request.isPaused
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:279
+
+___
+
+### listenerCount
+
+▸ **listenerCount**(`eventName`): `number`
+
+Returns the number of listeners listening to the event named `eventName`.
+
+**`Since`**
+
+v3.2.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event being listened for |
+
+#### Returns
+
+`number`
+
+#### Inherited from
+
+Request.listenerCount
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:579
+
+___
+
+### listeners
+
+▸ **listeners**(`eventName`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`.
+
+```js
+server.on('connection', (stream) => {
+  console.log('someone connected!');
+});
+console.log(util.inspect(server.listeners('connection')));
+// Prints: [ [Function] ]
+```
+
+**`Since`**
+
+v0.1.26
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+
+#### Returns
+
+`Function`[]
+
+#### Inherited from
+
+Request.listeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:502
+
+___
+
+### off
+
+▸ **off**(`eventName`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+Alias for `emitter.removeListener()`.
+
+**`Since`**
+
+v10.0.0
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.off
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:462
+
+___
+
+### on
+
+▸ **on**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"close"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.on
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:440
+
+▸ **on**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"data"`` |
+| `listener` | (`chunk`: `any`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.on
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:441
+
+▸ **on**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"end"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.on
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:442
+
+▸ **on**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"error"`` |
+| `listener` | (`err`: `Error`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.on
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:443
+
+▸ **on**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"pause"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.on
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:444
+
+▸ **on**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"readable"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.on
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:445
+
+▸ **on**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"resume"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.on
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:446
+
+▸ **on**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.on
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:447
+
+___
+
+### once
+
+▸ **once**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"close"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:448
+
+▸ **once**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"data"`` |
+| `listener` | (`chunk`: `any`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:449
+
+▸ **once**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"end"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:450
+
+▸ **once**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"error"`` |
+| `listener` | (`err`: `Error`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:451
+
+▸ **once**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"pause"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:452
+
+▸ **once**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"readable"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:453
+
+▸ **once**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"resume"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:454
+
+▸ **once**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.once
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:455
+
+___
+
+### param
+
+▸ **param**(`name`, `defaultValue?`): `string`
+
+**`Deprecated`**
+
+since 4.11 Use either req.params, req.body or req.query, as applicable.
+
+Return the value of param `name` when present or `defaultValue`.
+
+ - Checks route placeholders, ex: _/user/:id_
+ - Checks body params, ex: id=12, {"id":12}
+ - Checks query string params, ex: ?id=12
+
+To utilize request bodies, `req.body`
+should be an object. This can be done by using
+the `connect.bodyParser()` middleware.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+| `defaultValue?` | `any` |
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+Request.param
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:512
+
+___
+
+### pause
+
+▸ **pause**(): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+The `readable.pause()` method will cause a stream in flowing mode to stop
+emitting `'data'` events, switching out of flowing mode. Any data that
+becomes available will remain in the internal buffer.
+
+```js
+const readable = getReadableStreamSomehow();
+readable.on('data', (chunk) => {
+  console.log(`Received ${chunk.length} bytes of data.`);
+  readable.pause();
+  console.log('There will be no additional data for 1 second.');
+  setTimeout(() => {
+    console.log('Now data will start flowing again.');
+    readable.resume();
+  }, 1000);
+});
+```
+
+The `readable.pause()` method has no effect if there is a `'readable'`event listener.
+
+**`Since`**
+
+v0.9.4
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.pause
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:243
+
+___
+
+### pipe
+
+▸ **pipe**<`T`\>(`destination`, `options?`): `T`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `WritableStream`<`T`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `destination` | `T` |
+| `options?` | `Object` |
+| `options.end?` | `boolean` |
+
+#### Returns
+
+`T`
+
+#### Inherited from
+
+Request.pipe
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:25
+
+___
+
+### prependListener
+
+▸ **prependListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"close"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:456
+
+▸ **prependListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"data"`` |
+| `listener` | (`chunk`: `any`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:457
+
+▸ **prependListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"end"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:458
+
+▸ **prependListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"error"`` |
+| `listener` | (`err`: `Error`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:459
+
+▸ **prependListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"pause"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:460
+
+▸ **prependListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"readable"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:461
+
+▸ **prependListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"resume"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:462
+
+▸ **prependListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:463
+
+___
+
+### prependOnceListener
+
+▸ **prependOnceListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"close"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependOnceListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:464
+
+▸ **prependOnceListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"data"`` |
+| `listener` | (`chunk`: `any`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependOnceListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:465
+
+▸ **prependOnceListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"end"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependOnceListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:466
+
+▸ **prependOnceListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"error"`` |
+| `listener` | (`err`: `Error`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependOnceListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:467
+
+▸ **prependOnceListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"pause"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependOnceListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:468
+
+▸ **prependOnceListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"readable"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependOnceListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:469
+
+▸ **prependOnceListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"resume"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependOnceListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:470
+
+▸ **prependOnceListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.prependOnceListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:471
+
+___
+
+### push
+
+▸ **push**(`chunk`, `encoding?`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `chunk` | `any` |
+| `encoding?` | `BufferEncoding` |
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+Request.push
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:399
+
+___
+
+### range
+
+▸ **range**(`size`, `options?`): `undefined` \| `Ranges` \| `Result`
+
+Parse Range header field, capping to the given `size`.
+
+Unspecified ranges such as "0-" require knowledge of your resource length. In
+the case of a byte range this is of course the total number of bytes.
+If the Range header field is not given `undefined` is returned.
+If the Range header field is given, return value is a result of range-parser.
+See more ./types/range-parser/index.d.ts
+
+NOTE: remember that ranges are inclusive, so for example "Range: users=0-3"
+should respond with 4 users when available, not 3.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `size` | `number` |
+| `options?` | `Options` |
+
+#### Returns
+
+`undefined` \| `Ranges` \| `Result`
+
+#### Inherited from
+
+Request.range
+
+#### Defined in
+
+node_modules/@types/express-serve-static-core/index.d.ts:491
+
+___
+
+### rawListeners
+
+▸ **rawListeners**(`eventName`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`,
+including any wrappers (such as those created by `.once()`).
+
+```js
+const emitter = new EventEmitter();
+emitter.once('log', () => console.log('log once'));
+
+// Returns a new Array with a function `onceWrapper` which has a property
+// `listener` which contains the original listener bound above
+const listeners = emitter.rawListeners('log');
+const logFnWrapper = listeners[0];
+
+// Logs "log once" to the console and does not unbind the `once` event
+logFnWrapper.listener();
+
+// Logs "log once" to the console and removes the listener
+logFnWrapper();
+
+emitter.on('log', () => console.log('log persistently'));
+// Will return a new Array with a single function bound by `.on()` above
+const newListeners = emitter.rawListeners('log');
+
+// Logs "log persistently" twice
+newListeners[0]();
+emitter.emit('log');
+```
+
+**`Since`**
+
+v9.4.0
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` \| `symbol` |
+
+#### Returns
+
+`Function`[]
+
+#### Inherited from
+
+Request.rawListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:532
+
+___
+
+### read
+
+▸ **read**(`size?`): `any`
+
+The `readable.read()` method pulls some data out of the internal buffer and
+returns it. If no data available to be read, `null` is returned. By default,
+the data will be returned as a `Buffer` object unless an encoding has been
+specified using the `readable.setEncoding()` method or the stream is operating
+in object mode.
+
+The optional `size` argument specifies a specific number of bytes to read. If`size` bytes are not available to be read, `null` will be returned _unless_the stream has ended, in which
+case all of the data remaining in the internal
+buffer will be returned.
+
+If the `size` argument is not specified, all of the data contained in the
+internal buffer will be returned.
+
+The `size` argument must be less than or equal to 1 GiB.
+
+The `readable.read()` method should only be called on `Readable` streams
+operating in paused mode. In flowing mode, `readable.read()` is called
+automatically until the internal buffer is fully drained.
+
+```js
+const readable = getReadableStreamSomehow();
+
+// 'readable' may be triggered multiple times as data is buffered in
+readable.on('readable', () => {
+  let chunk;
+  console.log('Stream is readable (new data received in buffer)');
+  // Use a loop to make sure we read all currently available data
+  while (null !== (chunk = readable.read())) {
+    console.log(`Read ${chunk.length} bytes of data...`);
+  }
+});
+
+// 'end' will be triggered once when there is no more data available
+readable.on('end', () => {
+  console.log('Reached end of stream.');
+});
+```
+
+Each call to `readable.read()` returns a chunk of data, or `null`. The chunks
+are not concatenated. A `while` loop is necessary to consume all data
+currently in the buffer. When reading a large file `.read()` may return `null`,
+having consumed all buffered content so far, but there is still more data to
+come not yet buffered. In this case a new `'readable'` event will be emitted
+when there is more data in the buffer. Finally the `'end'` event will be
+emitted when there is no more data to come.
+
+Therefore to read a file's whole contents from a `readable`, it is necessary
+to collect chunks across multiple `'readable'` events:
+
+```js
+const chunks = [];
+
+readable.on('readable', () => {
+  let chunk;
+  while (null !== (chunk = readable.read())) {
+    chunks.push(chunk);
+  }
+});
+
+readable.on('end', () => {
+  const content = chunks.join('');
+});
+```
+
+A `Readable` stream in object mode will always return a single item from
+a call to `readable.read(size)`, regardless of the value of the`size` argument.
+
+If the `readable.read()` method returns a chunk of data, a `'data'` event will
+also be emitted.
+
+Calling [read](takaro_http.PaginatedRequest.md#read) after the `'end'` event has
+been emitted will return `null`. No runtime error will be raised.
+
+**`Since`**
+
+v0.9.4
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `size?` | `number` | Optional argument to specify how much data to read. |
+
+#### Returns
+
+`any`
+
+#### Inherited from
+
+Request.read
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:196
+
+___
+
+### removeAllListeners
+
+▸ **removeAllListeners**(`event?`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+Removes all listeners, or those of the specified `eventName`.
+
+It is bad practice to remove listeners added elsewhere in the code,
+particularly when the `EventEmitter` instance was created by some other
+component or module (e.g. sockets or file streams).
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v0.1.26
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event?` | `string` \| `symbol` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.removeAllListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:473
+
+___
+
+### removeListener
+
+▸ **removeListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"close"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.removeListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:472
+
+▸ **removeListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"data"`` |
+| `listener` | (`chunk`: `any`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.removeListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:473
+
+▸ **removeListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"end"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.removeListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:474
+
+▸ **removeListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"error"`` |
+| `listener` | (`err`: `Error`) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.removeListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:475
+
+▸ **removeListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"pause"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.removeListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:476
+
+▸ **removeListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"readable"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.removeListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:477
+
+▸ **removeListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | ``"resume"`` |
+| `listener` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.removeListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:478
+
+▸ **removeListener**(`event`, `listener`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `string` \| `symbol` |
+| `listener` | (...`args`: `any`[]) => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.removeListener
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:479
+
+___
+
+### resume
+
+▸ **resume**(): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+The `readable.resume()` method causes an explicitly paused `Readable` stream to
+resume emitting `'data'` events, switching the stream into flowing mode.
+
+The `readable.resume()` method can be used to fully consume the data from a
+stream without actually processing any of that data:
+
+```js
+getReadableStreamSomehow()
+  .resume()
+  .on('end', () => {
+    console.log('Reached the end, but did not read anything.');
+  });
+```
+
+The `readable.resume()` method has no effect if there is a `'readable'`event listener.
+
+**`Since`**
+
+v0.9.4
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.resume
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:262
+
+___
+
+### setEncoding
+
+▸ **setEncoding**(`encoding`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+The `readable.setEncoding()` method sets the character encoding for
+data read from the `Readable` stream.
+
+By default, no encoding is assigned and stream data will be returned as`Buffer` objects. Setting an encoding causes the stream data
+to be returned as strings of the specified encoding rather than as `Buffer`objects. For instance, calling `readable.setEncoding('utf8')` will cause the
+output data to be interpreted as UTF-8 data, and passed as strings. Calling`readable.setEncoding('hex')` will cause the data to be encoded in hexadecimal
+string format.
+
+The `Readable` stream will properly handle multi-byte characters delivered
+through the stream that would otherwise become improperly decoded if simply
+pulled from the stream as `Buffer` objects.
+
+```js
+const readable = getReadableStreamSomehow();
+readable.setEncoding('utf8');
+readable.on('data', (chunk) => {
+  assert.equal(typeof chunk, 'string');
+  console.log('Got %d characters of string data:', chunk.length);
+});
+```
+
+**`Since`**
+
+v0.9.4
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `encoding` | `BufferEncoding` | The encoding to use. |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.setEncoding
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:221
+
+___
+
+### setMaxListeners
+
+▸ **setMaxListeners**(`n`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+By default `EventEmitter`s will print a warning if more than `10` listeners are
+added for a particular event. This is a useful default that helps finding
+memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
+modified for this specific `EventEmitter` instance. The value can be set to`Infinity` (or `0`) to indicate an unlimited number of listeners.
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`Since`**
+
+v0.3.5
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `n` | `number` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.setMaxListeners
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/events.d.ts:483
+
+___
+
+### setTimeout
+
+▸ **setTimeout**(`msecs`, `callback?`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+Calls `message.socket.setTimeout(msecs, callback)`.
+
+**`Since`**
+
+v0.5.9
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `msecs` | `number` |
+| `callback?` | () => `void` |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.setTimeout
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/http.d.ts:983
+
+___
+
+### unpipe
+
+▸ **unpipe**(`destination?`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+The `readable.unpipe()` method detaches a `Writable` stream previously attached
+using the [pipe](takaro_http.PaginatedRequest.md#pipe) method.
+
+If the `destination` is not specified, then _all_ pipes are detached.
+
+If the `destination` is specified, but no pipe is set up for it, then
+the method does nothing.
+
+```js
+const fs = require('fs');
+const readable = getReadableStreamSomehow();
+const writable = fs.createWriteStream('file.txt');
+// All the data from readable goes into 'file.txt',
+// but only for the first second.
+readable.pipe(writable);
+setTimeout(() => {
+  console.log('Stop writing to file.txt.');
+  readable.unpipe(writable);
+  console.log('Manually close the file stream.');
+  writable.end();
+}, 1000);
+```
+
+**`Since`**
+
+v0.9.4
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `destination?` | `WritableStream` | Optional specific stream to unpipe |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.unpipe
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:306
+
+___
+
+### unshift
+
+▸ **unshift**(`chunk`, `encoding?`): `void`
+
+Passing `chunk` as `null` signals the end of the stream (EOF) and behaves the
+same as `readable.push(null)`, after which no more data can be written. The EOF
+signal is put at the end of the buffer and any buffered data will still be
+flushed.
+
+The `readable.unshift()` method pushes a chunk of data back into the internal
+buffer. This is useful in certain situations where a stream is being consumed by
+code that needs to "un-consume" some amount of data that it has optimistically
+pulled out of the source, so that the data can be passed on to some other party.
+
+The `stream.unshift(chunk)` method cannot be called after the `'end'` event
+has been emitted or a runtime error will be thrown.
+
+Developers using `stream.unshift()` often should consider switching to
+use of a `Transform` stream instead. See the `API for stream implementers` section for more information.
+
+```js
+// Pull off a header delimited by \n\n.
+// Use unshift() if we get too much.
+// Call the callback with (error, header, stream).
+const { StringDecoder } = require('string_decoder');
+function parseHeader(stream, callback) {
+  stream.on('error', callback);
+  stream.on('readable', onReadable);
+  const decoder = new StringDecoder('utf8');
+  let header = '';
+  function onReadable() {
+    let chunk;
+    while (null !== (chunk = stream.read())) {
+      const str = decoder.write(chunk);
+      if (str.match(/\n\n/)) {
+        // Found the header boundary.
+        const split = str.split(/\n\n/);
+        header += split.shift();
+        const remaining = split.join('\n\n');
+        const buf = Buffer.from(remaining, 'utf8');
+        stream.removeListener('error', callback);
+        // Remove the 'readable' listener before unshifting.
+        stream.removeListener('readable', onReadable);
+        if (buf.length)
+          stream.unshift(buf);
+        // Now the body of the message can be read from the stream.
+        callback(null, header, stream);
+      } else {
+        // Still reading the header.
+        header += str;
+      }
+    }
+  }
+}
+```
+
+Unlike [push](takaro_http.PaginatedRequest.md#push), `stream.unshift(chunk)` will not
+end the reading process by resetting the internal reading state of the stream.
+This can cause unexpected results if `readable.unshift()` is called during a
+read (i.e. from within a [_read](takaro_http.PaginatedRequest.md#_read) implementation on a
+custom stream). Following the call to `readable.unshift()` with an immediate [push](takaro_http.PaginatedRequest.md#push) will reset the reading state appropriately,
+however it is best to simply avoid calling `readable.unshift()` while in the
+process of performing a read.
+
+**`Since`**
+
+v0.9.11
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `chunk` | `any` | Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array` or `null`. For object mode streams, `chunk` may be any JavaScript value. |
+| `encoding?` | `BufferEncoding` | Encoding of string chunks. Must be a valid `Buffer` encoding, such as `'utf8'` or `'ascii'`. |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Request.unshift
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:372
+
+___
+
+### wrap
+
+▸ **wrap**(`stream`): [`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+Prior to Node.js 0.10, streams did not implement the entire `stream` module API
+as it is currently defined. (See `Compatibility` for more information.)
+
+When using an older Node.js library that emits `'data'` events and has a [pause](takaro_http.PaginatedRequest.md#pause) method that is advisory only, the`readable.wrap()` method can be used to create a `Readable`
+stream that uses
+the old stream as its data source.
+
+It will rarely be necessary to use `readable.wrap()` but the method has been
+provided as a convenience for interacting with older Node.js applications and
+libraries.
+
+```js
+const { OldReader } = require('./old-api-module.js');
+const { Readable } = require('stream');
+const oreader = new OldReader();
+const myReader = new Readable().wrap(oreader);
+
+myReader.on('readable', () => {
+  myReader.read(); // etc.
+});
+```
+
+**`Since`**
+
+v0.9.4
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `stream` | `ReadableStream` | An "old style" readable stream |
+
+#### Returns
+
+[`PaginatedRequest`](takaro_http.PaginatedRequest.md)
+
+#### Inherited from
+
+Request.wrap
+
+#### Defined in
+
+node_modules/@types/node/ts4.8/stream.d.ts:398

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ActionMenuProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ActionMenuProps.md
@@ -1,0 +1,46 @@
+---
+id: "takaro_lib_components.ActionMenuProps"
+title: "Interface: ActionMenuProps"
+sidebar_label: "@takaro/lib-components.ActionMenuProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ActionMenuProps
+
+## Properties
+
+### attributes
+
+• **attributes**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `strategy` | ``"fixed"`` \| ``"absolute"`` |
+| `x` | ``null`` \| `number` |
+| `y` | ``null`` \| `number` |
+
+#### Defined in
+
+[packages/lib-components/src/components/other/ActionMenu/index.tsx:14](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/ActionMenu/index.tsx#L14)
+
+___
+
+### children
+
+• **children**: `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\> \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>[]
+
+#### Defined in
+
+[packages/lib-components/src/components/other/ActionMenu/index.tsx:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/ActionMenu/index.tsx#L20)
+
+___
+
+### selectedState
+
+• **selectedState**: [`number`, `Dispatch`<`SetStateAction`<`number`\>\>]
+
+#### Defined in
+
+[packages/lib-components/src/components/other/ActionMenu/index.tsx:19](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/ActionMenu/index.tsx#L19)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.AlertProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.AlertProps.md
@@ -1,0 +1,58 @@
+---
+id: "takaro_lib_components.AlertProps"
+title: "Interface: AlertProps"
+sidebar_label: "@takaro/lib-components.AlertProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).AlertProps
+
+## Properties
+
+### action
+
+• `Optional` **action**: `Action`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Alert/index.tsx:23](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Alert/index.tsx#L23)
+
+___
+
+### dismiss
+
+• `Optional` **dismiss**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Alert/index.tsx:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Alert/index.tsx#L22)
+
+___
+
+### text
+
+• **text**: `string` \| `string`[]
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Alert/index.tsx:21](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Alert/index.tsx#L21)
+
+___
+
+### title
+
+• **title**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Alert/index.tsx:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Alert/index.tsx#L20)
+
+___
+
+### variant
+
+• **variant**: `AlertVariants`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Alert/index.tsx:19](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Alert/index.tsx#L19)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.AvatarGroupProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.AvatarGroupProps.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.AvatarGroupProps"
+title: "Interface: AvatarGroupProps"
+sidebar_label: "@takaro/lib-components.AvatarGroupProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).AvatarGroupProps
+
+## Properties
+
+### children
+
+• **children**: `ReactNode`[]
+
+#### Defined in
+
+[packages/lib-components/src/components/data/AvatarGroup/index.tsx:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/AvatarGroup/index.tsx#L22)
+
+___
+
+### max
+
+• `Optional` **max**: `number`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/AvatarGroup/index.tsx:21](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/AvatarGroup/index.tsx#L21)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.AvatarProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.AvatarProps.md
@@ -1,0 +1,48 @@
+---
+id: "takaro_lib_components.AvatarProps"
+title: "Interface: AvatarProps"
+sidebar_label: "@takaro/lib-components.AvatarProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).AvatarProps
+
+## Properties
+
+### alt
+
+• **alt**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Avatar/index.tsx:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Avatar/index.tsx#L58)
+
+___
+
+### isCircle
+
+• `Optional` **isCircle**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Avatar/index.tsx:61](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Avatar/index.tsx#L61)
+
+___
+
+### size
+
+• `Optional` **size**: [`Size`](../modules/takaro_lib_components.md#size)
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Avatar/index.tsx:60](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Avatar/index.tsx#L60)
+
+___
+
+### src
+
+• `Optional` **src**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Avatar/index.tsx:59](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Avatar/index.tsx#L59)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ButtonProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ButtonProps.md
@@ -1,0 +1,142 @@
+---
+id: "takaro_lib_components.ButtonProps"
+title: "Interface: ButtonProps"
+sidebar_label: "@takaro/lib-components.ButtonProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ButtonProps
+
+## Properties
+
+### className
+
+• `Optional` **className**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L11)
+
+___
+
+### color
+
+• `Optional` **color**: [`Color`](../modules/takaro_lib_components.md#color) \| [`AlertVariants`](../modules/takaro_lib_components.md#alertvariants) \| ``"background"``
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:15](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L15)
+
+___
+
+### disabled
+
+• `Optional` **disabled**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L7)
+
+___
+
+### form
+
+• `Optional` **form**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L20)
+
+___
+
+### icon
+
+• `Optional` **icon**: `ReactNode`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L10)
+
+___
+
+### isLoading
+
+• `Optional` **isLoading**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L9)
+
+___
+
+### isWhite
+
+• `Optional` **isWhite**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:17](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L17)
+
+___
+
+### onClick
+
+• **onClick**: (`event`: `MouseEvent`<`HTMLButtonElement`, `MouseEvent`\>) => `unknown`
+
+#### Type declaration
+
+▸ (`event`): `unknown`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `MouseEvent`<`HTMLButtonElement`, `MouseEvent`\> |
+
+##### Returns
+
+`unknown`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L8)
+
+___
+
+### size
+
+• `Optional` **size**: [`Size`](../modules/takaro_lib_components.md#size)
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L12)
+
+___
+
+### text
+
+• **text**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L16)
+
+___
+
+### type
+
+• `Optional` **type**: ``"button"`` \| ``"submit"`` \| ``"reset"``
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L13)
+
+___
+
+### variant
+
+• `Optional` **variant**: [`Variant`](../modules/takaro_lib_components.md#variant)
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Button/index.tsx:14](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Button/index.tsx#L14)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.CardProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.CardProps.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.CardProps"
+title: "Interface: CardProps"
+sidebar_label: "@takaro/lib-components.CardProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).CardProps
+
+## Properties
+
+### gradient
+
+• `Optional` **gradient**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/visual/Card/index.tsx:36](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/visual/Card/index.tsx#L36)
+
+___
+
+### size
+
+• `Optional` **size**: ``"small"`` \| ``"medium"`` \| ``"large"``
+
+#### Defined in
+
+[packages/lib-components/src/components/visual/Card/index.tsx:37](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/visual/Card/index.tsx#L37)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.CheckboxProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.CheckboxProps.md
@@ -1,0 +1,102 @@
+---
+id: "takaro_lib_components.CheckboxProps"
+title: "Interface: CheckboxProps"
+sidebar_label: "@takaro/lib-components.CheckboxProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).CheckboxProps
+
+## Properties
+
+### control
+
+• **control**: `Control`<`any`, `any`\>
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Checkbox/index.tsx:17](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Checkbox/index.tsx#L17)
+
+___
+
+### defaultValue
+
+• `Optional` **defaultValue**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Checkbox/index.tsx:19](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Checkbox/index.tsx#L19)
+
+___
+
+### label
+
+• `Optional` **label**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Checkbox/index.tsx:21](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Checkbox/index.tsx#L21)
+
+___
+
+### labelPosition
+
+• `Optional` **labelPosition**: ``"left"`` \| ``"right"``
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Checkbox/index.tsx:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Checkbox/index.tsx#L22)
+
+___
+
+### loading
+
+• `Optional` **loading**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Checkbox/index.tsx:18](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Checkbox/index.tsx#L18)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Checkbox/index.tsx:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Checkbox/index.tsx#L16)
+
+___
+
+### onChange
+
+• `Optional` **onChange**: (`e`: `MouseEvent`<`HTMLDivElement` \| `HTMLLabelElement`, `MouseEvent`\>) => `void`
+
+#### Type declaration
+
+▸ (`e`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `e` | `MouseEvent`<`HTMLDivElement` \| `HTMLLabelElement`, `MouseEvent`\> |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Checkbox/index.tsx:23](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Checkbox/index.tsx#L23)
+
+___
+
+### readOnly
+
+• `Optional` **readOnly**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Checkbox/index.tsx:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Checkbox/index.tsx#L20)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ChipProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ChipProps.md
@@ -1,0 +1,104 @@
+---
+id: "takaro_lib_components.ChipProps"
+title: "Interface: ChipProps"
+sidebar_label: "@takaro/lib-components.ChipProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ChipProps
+
+## Properties
+
+### avatar
+
+• `Optional` **avatar**: `ReactNode`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Chip/index.tsx:14](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Chip/index.tsx#L14)
+
+___
+
+### color
+
+• `Optional` **color**: `ChipColor`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Chip/index.tsx:18](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Chip/index.tsx#L18)
+
+___
+
+### disabled
+
+• `Optional` **disabled**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Chip/index.tsx:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Chip/index.tsx#L13)
+
+___
+
+### dot
+
+• `Optional` **dot**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Chip/index.tsx:15](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Chip/index.tsx#L15)
+
+___
+
+### label
+
+• **label**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Chip/index.tsx:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Chip/index.tsx#L12)
+
+___
+
+### onClick
+
+• `Optional` **onClick**: () => `void`
+
+#### Type declaration
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Chip/index.tsx:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Chip/index.tsx#L16)
+
+___
+
+### onDelete
+
+• `Optional` **onDelete**: () => `void`
+
+#### Type declaration
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Chip/index.tsx:17](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Chip/index.tsx#L17)
+
+___
+
+### variant
+
+• `Optional` **variant**: [`Variant`](../modules/takaro_lib_components.md#variant)
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Chip/index.tsx:19](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Chip/index.tsx#L19)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ClipBoardProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ClipBoardProps.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.ClipBoardProps"
+title: "Interface: ClipBoardProps"
+sidebar_label: "@takaro/lib-components.ClipBoardProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ClipBoardProps
+
+## Properties
+
+### maxWidth
+
+• `Optional` **maxWidth**: `number`
+
+#### Defined in
+
+[packages/lib-components/src/components/other/ClipBoard/index.tsx:41](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/ClipBoard/index.tsx#L41)
+
+___
+
+### text
+
+• **text**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/other/ClipBoard/index.tsx:40](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/ClipBoard/index.tsx#L40)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.CodeFieldProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.CodeFieldProps.md
@@ -1,0 +1,88 @@
+---
+id: "takaro_lib_components.CodeFieldProps"
+title: "Interface: CodeFieldProps"
+sidebar_label: "@takaro/lib-components.CodeFieldProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).CodeFieldProps
+
+## Properties
+
+### allowedCharacters
+
+• `Optional` **allowedCharacters**: `RegExp`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/CodeField/index.tsx:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/CodeField/index.tsx#L9)
+
+___
+
+### autoSubmit
+
+• `Optional` **autoSubmit**: `any`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/CodeField/index.tsx:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/CodeField/index.tsx#L12)
+
+___
+
+### control
+
+• **control**: `Control`<`any`, `any`\>
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/CodeField/index.tsx:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/CodeField/index.tsx#L13)
+
+___
+
+### error
+
+• `Optional` **error**: `FieldError`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/CodeField/index.tsx:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/CodeField/index.tsx#L10)
+
+___
+
+### fields
+
+• **fields**: `number`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/CodeField/index.tsx:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/CodeField/index.tsx#L7)
+
+___
+
+### form
+
+• `Optional` **form**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/CodeField/index.tsx:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/CodeField/index.tsx#L11)
+
+___
+
+### loading
+
+• `Optional` **loading**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/CodeField/index.tsx:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/CodeField/index.tsx#L8)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/CodeField/index.tsx:6](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/CodeField/index.tsx#L6)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.CompanyProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.CompanyProps.md
@@ -1,0 +1,68 @@
+---
+id: "takaro_lib_components.CompanyProps"
+title: "Interface: CompanyProps"
+sidebar_label: "@takaro/lib-components.CompanyProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).CompanyProps
+
+## Properties
+
+### iconColor
+
+• `Optional` **iconColor**: [`Color`](../modules/takaro_lib_components.md#color)
+
+#### Defined in
+
+[packages/lib-components/src/components/other/Company/index.tsx:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/Company/index.tsx#L8)
+
+___
+
+### iconVisible
+
+• `Optional` **iconVisible**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/other/Company/index.tsx:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/Company/index.tsx#L7)
+
+___
+
+### size
+
+• `Optional` **size**: [`Size`](../modules/takaro_lib_components.md#size)
+
+#### Defined in
+
+[packages/lib-components/src/components/other/Company/index.tsx:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/Company/index.tsx#L11)
+
+___
+
+### textColor
+
+• `Optional` **textColor**: [`Color`](../modules/takaro_lib_components.md#color)
+
+#### Defined in
+
+[packages/lib-components/src/components/other/Company/index.tsx:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/Company/index.tsx#L9)
+
+___
+
+### textVisible
+
+• `Optional` **textVisible**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/other/Company/index.tsx:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/Company/index.tsx#L10)
+
+___
+
+### to
+
+• `Optional` **to**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/other/Company/index.tsx:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/Company/index.tsx#L12)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ConfirmationModalProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ConfirmationModalProps.md
@@ -1,0 +1,96 @@
+---
+id: "takaro_lib_components.ConfirmationModalProps"
+title: "Interface: ConfirmationModalProps"
+sidebar_label: "@takaro/lib-components.ConfirmationModalProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ConfirmationModalProps
+
+## Properties
+
+### action
+
+• **action**: `any`
+
+#### Defined in
+
+[packages/lib-components/src/modals/ConfirmationModal/index.tsx:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/modals/ConfirmationModal/index.tsx#L11)
+
+___
+
+### actionText
+
+• **actionText**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/modals/ConfirmationModal/index.tsx:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/modals/ConfirmationModal/index.tsx#L12)
+
+___
+
+### close
+
+• **close**: () => `void`
+
+#### Type declaration
+
+▸ (): `void`
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/modals/ConfirmationModal/index.tsx:14](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/modals/ConfirmationModal/index.tsx#L14)
+
+___
+
+### description
+
+• `Optional` **description**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/modals/ConfirmationModal/index.tsx:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/modals/ConfirmationModal/index.tsx#L10)
+
+___
+
+### icon
+
+• `Optional` **icon**: `ReactNode`
+
+#### Defined in
+
+[packages/lib-components/src/modals/ConfirmationModal/index.tsx:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/modals/ConfirmationModal/index.tsx#L13)
+
+___
+
+### ref
+
+• **ref**: `MutableRefObject`<`HTMLDivElement`\>
+
+#### Defined in
+
+[packages/lib-components/src/modals/ConfirmationModal/index.tsx:15](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/modals/ConfirmationModal/index.tsx#L15)
+
+___
+
+### title
+
+• **title**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/modals/ConfirmationModal/index.tsx:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/modals/ConfirmationModal/index.tsx#L9)
+
+___
+
+### type
+
+• `Optional` **type**: [`AlertVariants`](../modules/takaro_lib_components.md#alertvariants)
+
+#### Defined in
+
+[packages/lib-components/src/modals/ConfirmationModal/index.tsx:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/modals/ConfirmationModal/index.tsx#L16)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ConsoleProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ConsoleProps.md
@@ -1,0 +1,71 @@
+---
+id: "takaro_lib_components.ConsoleProps"
+title: "Interface: ConsoleProps"
+sidebar_label: "@takaro/lib-components.ConsoleProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ConsoleProps
+
+## Properties
+
+### initialMessages
+
+• `Optional` **initialMessages**: [`Message`](takaro_lib_components.Message.md)[]
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Console/index.tsx:30](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Console/index.tsx#L30)
+
+___
+
+### listenerFactory
+
+• **listenerFactory**: (`s`: `Dispatch`<`SetStateAction`<[`Message`](takaro_lib_components.Message.md)[]\>\>) => { `off`: () => `void` ; `on`: () => `void`  }
+
+#### Type declaration
+
+▸ (`s`): `Object`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `s` | `Dispatch`<`SetStateAction`<[`Message`](takaro_lib_components.Message.md)[]\>\> |
+
+##### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `off` | () => `void` |
+| `on` | () => `void` |
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Console/index.tsx:25](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Console/index.tsx#L25)
+
+___
+
+### onExecuteCommand
+
+• **onExecuteCommand**: (`command`: `string`) => `Promise`<[`Message`](takaro_lib_components.Message.md)\>
+
+#### Type declaration
+
+▸ (`command`): `Promise`<[`Message`](takaro_lib_components.Message.md)\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `command` | `string` |
+
+##### Returns
+
+`Promise`<[`Message`](takaro_lib_components.Message.md)\>
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Console/index.tsx:29](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Console/index.tsx#L29)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.DividerProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.DividerProps.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.DividerProps"
+title: "Interface: DividerProps"
+sidebar_label: "@takaro/lib-components.DividerProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).DividerProps
+
+## Properties
+
+### label
+
+• `Optional` **label**: `LabelProps`
+
+#### Defined in
+
+[packages/lib-components/src/components/visual/Divider/index.tsx:68](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/visual/Divider/index.tsx#L68)
+
+___
+
+### spacing
+
+• `Optional` **spacing**: [`Size`](../modules/takaro_lib_components.md#size)
+
+#### Defined in
+
+[packages/lib-components/src/components/visual/Divider/index.tsx:69](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/visual/Divider/index.tsx#L69)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.EmptyProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.EmptyProps.md
@@ -1,0 +1,38 @@
+---
+id: "takaro_lib_components.EmptyProps"
+title: "Interface: EmptyProps"
+sidebar_label: "@takaro/lib-components.EmptyProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).EmptyProps
+
+## Properties
+
+### description
+
+• `Optional` **description**: `ReactNode`
+
+#### Defined in
+
+[packages/lib-components/src/components/other/Empty/index.tsx:26](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/Empty/index.tsx#L26)
+
+___
+
+### image
+
+• `Optional` **image**: `ReactNode`
+
+#### Defined in
+
+[packages/lib-components/src/components/other/Empty/index.tsx:27](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/Empty/index.tsx#L27)
+
+___
+
+### imageStyle
+
+• `Optional` **imageStyle**: `CSSProperties`
+
+#### Defined in
+
+[packages/lib-components/src/components/other/Empty/index.tsx:29](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/Empty/index.tsx#L29)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.Error404Props.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.Error404Props.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.Error404Props"
+title: "Interface: Error404Props"
+sidebar_label: "@takaro/lib-components.Error404Props"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).Error404Props
+
+## Properties
+
+### homeRoute
+
+• **homeRoute**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/views/ErrorPages/Error404.tsx:99](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/views/ErrorPages/Error404.tsx#L99)
+
+___
+
+### pages
+
+• `Optional` **pages**: `Page`[]
+
+#### Defined in
+
+[packages/lib-components/src/views/ErrorPages/Error404.tsx:98](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/views/ErrorPages/Error404.tsx#L98)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ErrorMessageProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ErrorMessageProps.md
@@ -1,0 +1,18 @@
+---
+id: "takaro_lib_components.ErrorMessageProps"
+title: "Interface: ErrorMessageProps"
+sidebar_label: "@takaro/lib-components.ErrorMessageProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ErrorMessageProps
+
+## Properties
+
+### message
+
+• `Optional` **message**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/ErrorMessage/index.tsx:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/ErrorMessage/index.tsx#L13)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ErrorProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ErrorProps.md
@@ -1,0 +1,48 @@
+---
+id: "takaro_lib_components.ErrorProps"
+title: "Interface: ErrorProps"
+sidebar_label: "@takaro/lib-components.ErrorProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ErrorProps
+
+## Properties
+
+### actionMessage
+
+• `Optional` **actionMessage**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Error/index.tsx:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Error/index.tsx#L22)
+
+___
+
+### actionTo
+
+• `Optional` **actionTo**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Error/index.tsx:23](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Error/index.tsx#L23)
+
+___
+
+### message
+
+• `Optional` **message**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Error/index.tsx:21](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Error/index.tsx#L21)
+
+___
+
+### showIcon
+
+• `Optional` **showIcon**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Error/index.tsx:24](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Error/index.tsx#L24)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ErrorTemplateProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ErrorTemplateProps.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.ErrorTemplateProps"
+title: "Interface: ErrorTemplateProps"
+sidebar_label: "@takaro/lib-components.ErrorTemplateProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ErrorTemplateProps
+
+## Properties
+
+### description
+
+• **description**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/ErrorTemplate/index.tsx:41](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/ErrorTemplate/index.tsx#L41)
+
+___
+
+### title
+
+• **title**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/ErrorTemplate/index.tsx:40](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/ErrorTemplate/index.tsx#L40)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.FieldProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.FieldProps.md
@@ -1,0 +1,138 @@
+---
+id: "takaro_lib_components.FieldProps"
+title: "Interface: FieldProps"
+sidebar_label: "@takaro/lib-components.FieldProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).FieldProps
+
+## Properties
+
+### control
+
+• **control**: `Control`<`any`, `object`\>
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:14](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L14)
+
+___
+
+### error
+
+• `Optional` **error**: `FieldError`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L12)
+
+___
+
+### hint
+
+• `Optional` **hint**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:15](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L15)
+
+___
+
+### icon
+
+• `Optional` **icon**: `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:6](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L6)
+
+___
+
+### label
+
+• **label**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L8)
+
+___
+
+### loading
+
+• `Optional` **loading**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L13)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L5)
+
+___
+
+### placeholder
+
+• **placeholder**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L9)
+
+___
+
+### prefix
+
+• `Optional` **prefix**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L10)
+
+___
+
+### readOnly
+
+• `Optional` **readOnly**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L7)
+
+___
+
+### required
+
+• `Optional` **required**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L16)
+
+___
+
+### suffix
+
+• `Optional` **suffix**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L11)
+
+___
+
+### type
+
+• `Optional` **type**: ``"text"`` \| ``"password"``
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Field/index.tsx:17](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Field/index.tsx#L17)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.GetStartedProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.GetStartedProps.md
@@ -1,0 +1,48 @@
+---
+id: "takaro_lib_components.GetStartedProps"
+title: "Interface: GetStartedProps"
+sidebar_label: "@takaro/lib-components.GetStartedProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).GetStartedProps
+
+## Properties
+
+### description
+
+• `Optional` **description**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/views/GetStarted/index.tsx:40](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/views/GetStarted/index.tsx#L40)
+
+___
+
+### title
+
+• `Optional` **title**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/views/GetStarted/index.tsx:38](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/views/GetStarted/index.tsx#L38)
+
+___
+
+### title2
+
+• `Optional` **title2**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/views/GetStarted/index.tsx:39](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/views/GetStarted/index.tsx#L39)
+
+___
+
+### to
+
+• **to**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/views/GetStarted/index.tsx:41](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/views/GetStarted/index.tsx#L41)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.IJsonMap.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.IJsonMap.md
@@ -1,0 +1,12 @@
+---
+id: "takaro_lib_components.IJsonMap"
+title: "Interface: IJsonMap"
+sidebar_label: "@takaro/lib-components.IJsonMap"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).IJsonMap
+
+## Indexable
+
+▪ [key: `string`]: [`AnyJson`](../modules/takaro_lib_components.md#anyjson)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.IconButtonProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.IconButtonProps.md
@@ -1,0 +1,72 @@
+---
+id: "takaro_lib_components.IconButtonProps"
+title: "Interface: IconButtonProps"
+sidebar_label: "@takaro/lib-components.IconButtonProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).IconButtonProps
+
+## Properties
+
+### color
+
+• `Optional` **color**: [`Color`](../modules/takaro_lib_components.md#color)
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/IconButton/index.tsx:75](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/IconButton/index.tsx#L75)
+
+___
+
+### icon
+
+• **icon**: `ReactNode`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/IconButton/index.tsx:77](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/IconButton/index.tsx#L77)
+
+___
+
+### onClick
+
+• **onClick**: (`event`: `MouseEvent`<`HTMLButtonElement`, `MouseEvent`\>) => `any`
+
+#### Type declaration
+
+▸ (`event`): `any`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `MouseEvent`<`HTMLButtonElement`, `MouseEvent`\> |
+
+##### Returns
+
+`any`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/IconButton/index.tsx:76](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/IconButton/index.tsx#L76)
+
+___
+
+### size
+
+• `Optional` **size**: [`Size`](../modules/takaro_lib_components.md#size)
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/IconButton/index.tsx:73](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/IconButton/index.tsx#L73)
+
+___
+
+### variant
+
+• `Optional` **variant**: [`Variant`](../modules/takaro_lib_components.md#variant)
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/IconButton/index.tsx:74](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/IconButton/index.tsx#L74)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.LoadingProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.LoadingProps.md
@@ -1,0 +1,18 @@
+---
+id: "takaro_lib_components.LoadingProps"
+title: "Interface: LoadingProps"
+sidebar_label: "@takaro/lib-components.LoadingProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).LoadingProps
+
+## Properties
+
+### fill
+
+• `Optional` **fill**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Loaders/Loading.tsx:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Loaders/Loading.tsx#L5)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.Message.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.Message.md
@@ -1,0 +1,48 @@
+---
+id: "takaro_lib_components.Message"
+title: "Interface: Message"
+sidebar_label: "@takaro/lib-components.Message"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).Message
+
+## Properties
+
+### data
+
+• **data**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Console/ConsoleInterface.ts:6](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Console/ConsoleInterface.ts#L6)
+
+___
+
+### timestamp
+
+• **timestamp**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Console/ConsoleInterface.ts:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Console/ConsoleInterface.ts#L5)
+
+___
+
+### trace
+
+• `Optional` **trace**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Console/ConsoleInterface.ts:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Console/ConsoleInterface.ts#L7)
+
+___
+
+### type
+
+• **type**: `MessageType`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Console/ConsoleInterface.ts:4](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Console/ConsoleInterface.ts#L4)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.NotificationBannerProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.NotificationBannerProps.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.NotificationBannerProps"
+title: "Interface: NotificationBannerProps"
+sidebar_label: "@takaro/lib-components.NotificationBannerProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).NotificationBannerProps
+
+## Properties
+
+### description
+
+• **description**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/NotificationBanner/index.tsx:44](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/NotificationBanner/index.tsx#L44)
+
+___
+
+### title
+
+• **title**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/NotificationBanner/index.tsx:43](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/NotificationBanner/index.tsx#L43)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ProgressBarProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ProgressBarProps.md
@@ -1,0 +1,48 @@
+---
+id: "takaro_lib_components.ProgressBarProps"
+title: "Interface: ProgressBarProps"
+sidebar_label: "@takaro/lib-components.ProgressBarProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ProgressBarProps
+
+## Properties
+
+### color
+
+• `Optional` **color**: [`Color`](../modules/takaro_lib_components.md#color)
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/ProgressBar/index.tsx:84](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/ProgressBar/index.tsx#L84)
+
+___
+
+### mode
+
+• **mode**: ``"determinate"`` \| ``"indeterminate"``
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/ProgressBar/index.tsx:82](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/ProgressBar/index.tsx#L82)
+
+___
+
+### showValue
+
+• `Optional` **showValue**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/ProgressBar/index.tsx:85](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/ProgressBar/index.tsx#L85)
+
+___
+
+### value
+
+• `Optional` **value**: `number`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/ProgressBar/index.tsx:83](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/ProgressBar/index.tsx#L83)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.RadioGroupProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.RadioGroupProps.md
@@ -1,0 +1,78 @@
+---
+id: "takaro_lib_components.RadioGroupProps"
+title: "Interface: RadioGroupProps"
+sidebar_label: "@takaro/lib-components.RadioGroupProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).RadioGroupProps
+
+## Properties
+
+### control
+
+• **control**: `Control`<`Record`<`string`, `unknown`\>, `any`\>
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/RadioGroup/index.tsx:17](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/RadioGroup/index.tsx#L17)
+
+___
+
+### defaultValue
+
+• `Optional` **defaultValue**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/RadioGroup/index.tsx:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/RadioGroup/index.tsx#L16)
+
+___
+
+### label
+
+• **label**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/RadioGroup/index.tsx:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/RadioGroup/index.tsx#L13)
+
+___
+
+### loading
+
+• `Optional` **loading**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/RadioGroup/index.tsx:14](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/RadioGroup/index.tsx#L14)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/RadioGroup/index.tsx:19](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/RadioGroup/index.tsx#L19)
+
+___
+
+### options
+
+• **options**: `Option`[]
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/RadioGroup/index.tsx:15](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/RadioGroup/index.tsx#L15)
+
+___
+
+### readOnly
+
+• `Optional` **readOnly**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/RadioGroup/index.tsx:18](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/RadioGroup/index.tsx#L18)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SelectProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SelectProps.md
@@ -1,0 +1,122 @@
+---
+id: "takaro_lib_components.SelectProps"
+title: "Interface: SelectProps"
+sidebar_label: "@takaro/lib-components.SelectProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).SelectProps
+
+## Properties
+
+### control
+
+• **control**: `Control`<`any`, `any`\>
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Select/index.tsx:33](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Select/index.tsx#L33)
+
+___
+
+### defaultValue
+
+• `Optional` **defaultValue**: `OptionType`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Select/index.tsx:38](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Select/index.tsx#L38)
+
+___
+
+### error
+
+• `Optional` **error**: `FieldError`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Select/index.tsx:39](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Select/index.tsx#L39)
+
+___
+
+### icon
+
+• `Optional` **icon**: `Element`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Select/index.tsx:34](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Select/index.tsx#L34)
+
+___
+
+### label
+
+• `Optional` **label**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Select/index.tsx:35](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Select/index.tsx#L35)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Select/index.tsx:32](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Select/index.tsx#L32)
+
+___
+
+### onChange
+
+• `Optional` **onChange**: (`value`: `string`) => `void`
+
+#### Type declaration
+
+▸ (`value`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `string` |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Select/index.tsx:40](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Select/index.tsx#L40)
+
+___
+
+### options
+
+• **options**: `OptionType`[]
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Select/index.tsx:31](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Select/index.tsx#L31)
+
+___
+
+### placeholder
+
+• `Optional` **placeholder**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Select/index.tsx:36](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Select/index.tsx#L36)
+
+___
+
+### readOnly
+
+• `Optional` **readOnly**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Select/index.tsx:37](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Select/index.tsx#L37)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SkeletonProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SkeletonProps.md
@@ -1,0 +1,38 @@
+---
+id: "takaro_lib_components.SkeletonProps"
+title: "Interface: SkeletonProps"
+sidebar_label: "@takaro/lib-components.SkeletonProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).SkeletonProps
+
+## Properties
+
+### height
+
+• `Optional` **height**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Skeleton/index.tsx:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Skeleton/index.tsx#L7)
+
+___
+
+### variant
+
+• **variant**: `Variants`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Skeleton/index.tsx:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Skeleton/index.tsx#L8)
+
+___
+
+### width
+
+• `Optional` **width**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Skeleton/index.tsx:6](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Skeleton/index.tsx#L6)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SliderProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SliderProps.md
@@ -1,0 +1,172 @@
+---
+id: "takaro_lib_components.SliderProps"
+title: "Interface: SliderProps"
+sidebar_label: "@takaro/lib-components.SliderProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).SliderProps
+
+## Properties
+
+### color
+
+• `Optional` **color**: [`Color`](../modules/takaro_lib_components.md#color)
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:143](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L143)
+
+___
+
+### control
+
+• **control**: `Control`<`any`, `any`\>
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:139](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L139)
+
+___
+
+### defaultValue
+
+• `Optional` **defaultValue**: `number`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:144](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L144)
+
+___
+
+### label
+
+• `Optional` **label**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:146](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L146)
+
+___
+
+### loading
+
+• `Optional` **loading**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:140](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L140)
+
+___
+
+### marks
+
+• `Optional` **marks**: `Mark`[]
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:148](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L148)
+
+___
+
+### max
+
+• **max**: `number`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:142](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L142)
+
+___
+
+### min
+
+• **min**: `number`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:141](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L141)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:138](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L138)
+
+___
+
+### onChange
+
+• `Optional` **onChange**: (`val`: `number`) => `void`
+
+#### Type declaration
+
+▸ (`val`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `val` | `number` |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:151](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L151)
+
+___
+
+### readOnly
+
+• `Optional` **readOnly**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:145](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L145)
+
+___
+
+### showDots
+
+• **showDots**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:150](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L150)
+
+___
+
+### showTooltip
+
+• `Optional` **showTooltip**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:147](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L147)
+
+___
+
+### size
+
+• `Optional` **size**: [`Size`](../modules/takaro_lib_components.md#size)
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:152](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L152)
+
+___
+
+### step
+
+• `Optional` **step**: `number`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Slider/index.tsx:149](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Slider/index.tsx#L149)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SlimStepperProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SlimStepperProps.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.SlimStepperProps"
+title: "Interface: SlimStepperProps"
+sidebar_label: "@takaro/lib-components.SlimStepperProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).SlimStepperProps
+
+## Properties
+
+### canStepBack
+
+• `Optional` **canStepBack**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/Steppers/SlimStepper/index.tsx:67](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/Steppers/SlimStepper/index.tsx#L67)
+
+___
+
+### showTooltip
+
+• `Optional` **showTooltip**: ``"always"`` \| ``"never"`` \| ``"hover"``
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/Steppers/SlimStepper/index.tsx:68](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/Steppers/SlimStepper/index.tsx#L68)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SpinnerProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SpinnerProps.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.SpinnerProps"
+title: "Interface: SpinnerProps"
+sidebar_label: "@takaro/lib-components.SpinnerProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).SpinnerProps
+
+## Properties
+
+### color
+
+• `Optional` **color**: [`Color`](../modules/takaro_lib_components.md#color) \| [`AlertVariants`](../modules/takaro_lib_components.md#alertvariants) \| ``"background"`` \| ``"white"``
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Loaders/Spinner.tsx:49](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Loaders/Spinner.tsx#L49)
+
+___
+
+### size
+
+• **size**: [`Size`](../modules/takaro_lib_components.md#size)
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Loaders/Spinner.tsx:48](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Loaders/Spinner.tsx#L48)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.StepperProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.StepperProps.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.StepperProps"
+title: "Interface: StepperProps"
+sidebar_label: "@takaro/lib-components.StepperProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).StepperProps
+
+## Properties
+
+### canStepBack
+
+• `Optional` **canStepBack**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/Steppers/Stepper/index.tsx:73](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/Steppers/Stepper/index.tsx#L73)
+
+___
+
+### currentStepIsLoading
+
+• `Optional` **currentStepIsLoading**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/Steppers/Stepper/index.tsx:72](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/Steppers/Stepper/index.tsx#L72)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SupportButtonProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SupportButtonProps.md
@@ -1,0 +1,38 @@
+---
+id: "takaro_lib_components.SupportButtonProps"
+title: "Interface: SupportButtonProps"
+sidebar_label: "@takaro/lib-components.SupportButtonProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).SupportButtonProps
+
+## Properties
+
+### message
+
+• **message**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/SupportButton/index.tsx:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/SupportButton/index.tsx#L10)
+
+___
+
+### placement
+
+• `Optional` **placement**: `Placement`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/SupportButton/index.tsx:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/SupportButton/index.tsx#L11)
+
+___
+
+### size
+
+• `Optional` **size**: [`Size`](../modules/takaro_lib_components.md#size)
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/SupportButton/index.tsx:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/SupportButton/index.tsx#L9)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SwitchProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.SwitchProps.md
@@ -1,0 +1,72 @@
+---
+id: "takaro_lib_components.SwitchProps"
+title: "Interface: SwitchProps"
+sidebar_label: "@takaro/lib-components.SwitchProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).SwitchProps
+
+## Properties
+
+### control
+
+• **control**: `Control`<`any`, `any`\>
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Switch/index.tsx:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Switch/index.tsx#L8)
+
+___
+
+### defaultValue
+
+• `Optional` **defaultValue**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Switch/index.tsx:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Switch/index.tsx#L9)
+
+___
+
+### disabled
+
+• `Optional` **disabled**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Switch/index.tsx:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Switch/index.tsx#L10)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Switch/index.tsx:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Switch/index.tsx#L7)
+
+___
+
+### onChange
+
+• `Optional` **onChange**: (`isChecked`: `boolean`) => `void`
+
+#### Type declaration
+
+▸ (`isChecked`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `isChecked` | `boolean` |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Switch/index.tsx:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Switch/index.tsx#L11)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.TabSwitchProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.TabSwitchProps.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.TabSwitchProps"
+title: "Interface: TabSwitchProps"
+sidebar_label: "@takaro/lib-components.TabSwitchProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).TabSwitchProps
+
+## Properties
+
+### children
+
+• **children**: `ReactElement`<{ `children`: `ReactNode` ; `label`: `string`  }, `string` \| `JSXElementConstructor`<`any`\>\>[]
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/TabSwitch/index.tsx:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/TabSwitch/index.tsx#L8)
+
+___
+
+### color
+
+• `Optional` **color**: ``"primary"`` \| ``"secondary"`` \| ``"white"``
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/TabSwitch/index.tsx:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/TabSwitch/index.tsx#L9)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.TableProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.TableProps.md
@@ -1,0 +1,48 @@
+---
+id: "takaro_lib_components.TableProps"
+title: "Interface: TableProps"
+sidebar_label: "@takaro/lib-components.TableProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).TableProps
+
+## Properties
+
+### columnDefs
+
+• **columnDefs**: `Partial`<`AgGridColumnProps`\>[]
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Table/index.tsx:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Table/index.tsx#L9)
+
+___
+
+### height
+
+• **height**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Table/index.tsx:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Table/index.tsx#L12)
+
+___
+
+### rowData
+
+• **rowData**: `any`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Table/index.tsx:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Table/index.tsx#L10)
+
+___
+
+### width
+
+• **width**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/data/Table/index.tsx:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/data/Table/index.tsx#L11)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.TileProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.TileProps.md
@@ -1,0 +1,82 @@
+---
+id: "takaro_lib_components.TileProps"
+title: "Interface: TileProps"
+sidebar_label: "@takaro/lib-components.TileProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).TileProps
+
+## Properties
+
+### bgColor
+
+• **bgColor**: [`Color`](../modules/takaro_lib_components.md#color) \| [`AlertVariants`](../modules/takaro_lib_components.md#alertvariants) \| ``"white"``
+
+#### Defined in
+
+[packages/lib-components/src/components/visual/Tile/index.tsx:8](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/visual/Tile/index.tsx#L8)
+
+___
+
+### description
+
+• `Optional` **description**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/visual/Tile/index.tsx:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/visual/Tile/index.tsx#L10)
+
+___
+
+### loading
+
+• `Optional` **loading**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/visual/Tile/index.tsx:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/visual/Tile/index.tsx#L7)
+
+___
+
+### onClick
+
+• `Optional` **onClick**: (`event`: `MouseEvent`<`HTMLDivElement`, `MouseEvent`\>) => `any`
+
+#### Type declaration
+
+▸ (`event`): `any`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `MouseEvent`<`HTMLDivElement`, `MouseEvent`\> |
+
+##### Returns
+
+`any`
+
+#### Defined in
+
+[packages/lib-components/src/components/visual/Tile/index.tsx:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/visual/Tile/index.tsx#L12)
+
+___
+
+### textColor
+
+• **textColor**: [`Color`](../modules/takaro_lib_components.md#color) \| [`AlertVariants`](../modules/takaro_lib_components.md#alertvariants) \| ``"white"``
+
+#### Defined in
+
+[packages/lib-components/src/components/visual/Tile/index.tsx:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/visual/Tile/index.tsx#L11)
+
+___
+
+### title
+
+• `Optional` **title**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/visual/Tile/index.tsx:9](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/visual/Tile/index.tsx#L9)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ToggleButtonGroupProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ToggleButtonGroupProps.md
@@ -1,0 +1,82 @@
+---
+id: "takaro_lib_components.ToggleButtonGroupProps"
+title: "Interface: ToggleButtonGroupProps"
+sidebar_label: "@takaro/lib-components.ToggleButtonGroupProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ToggleButtonGroupProps
+
+## Properties
+
+### children
+
+• **children**: `ReactNode` \| `FunctionComponentElement`<[`ToggleButtonProps`](takaro_lib_components.ToggleButtonProps.md)\>
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx:61](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx#L61)
+
+___
+
+### defaultValue
+
+• `Optional` **defaultValue**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx:63](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx#L63)
+
+___
+
+### exclusive
+
+• `Optional` **exclusive**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx:60](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx#L60)
+
+___
+
+### fullWidth
+
+• `Optional` **fullWidth**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx:64](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx#L64)
+
+___
+
+### onChange
+
+• `Optional` **onChange**: (`value`: `string` \| `Map`<`string`, `boolean`\>) => `void`
+
+#### Type declaration
+
+▸ (`value`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `string` \| `Map`<`string`, `boolean`\> |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx:57](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx#L57)
+
+___
+
+### orientation
+
+• `Optional` **orientation**: `orientation`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx:58](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButtonGroup.tsx#L58)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ToggleButtonProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.ToggleButtonProps.md
@@ -1,0 +1,91 @@
+---
+id: "takaro_lib_components.ToggleButtonProps"
+title: "Interface: ToggleButtonProps"
+sidebar_label: "@takaro/lib-components.ToggleButtonProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).ToggleButtonProps
+
+## Properties
+
+### children
+
+• `Optional` **children**: `ReactNode`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx:19](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx#L19)
+
+___
+
+### disabled
+
+• `Optional` **disabled**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx:20](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx#L20)
+
+___
+
+### onChange
+
+• `Optional` **onChange**: (`event`: `MouseEvent`<`HTMLElement`, `MouseEvent`\>, `value`: `unknown`) => `void`
+
+#### Type declaration
+
+▸ (`event`, `value`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `MouseEvent`<`HTMLElement`, `MouseEvent`\> |
+| `value` | `unknown` |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx:21](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx#L21)
+
+___
+
+### onClick
+
+• `Optional` **onClick**: () => `unknown`
+
+#### Type declaration
+
+▸ (): `unknown`
+
+##### Returns
+
+`unknown`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx:23](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx#L23)
+
+___
+
+### selected
+
+• `Optional` **selected**: `boolean`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx#L22)
+
+___
+
+### value
+
+• **value**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx:24](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/inputs/Toggle/ToggleButton.tsx#L24)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.TooltipProps.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.TooltipProps.md
@@ -1,0 +1,38 @@
+---
+id: "takaro_lib_components.TooltipProps"
+title: "Interface: TooltipProps"
+sidebar_label: "@takaro/lib-components.TooltipProps"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).TooltipProps
+
+## Properties
+
+### children
+
+• **children**: `Element`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Tooltip/index.tsx:24](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Tooltip/index.tsx#L24)
+
+___
+
+### label
+
+• **label**: `string`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Tooltip/index.tsx:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Tooltip/index.tsx#L22)
+
+___
+
+### placement
+
+• `Optional` **placement**: `Placement`
+
+#### Defined in
+
+[packages/lib-components/src/components/feedback/Tooltip/index.tsx:23](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/feedback/Tooltip/index.tsx#L23)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.ByRoleOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.ByRoleOptions.md
@@ -1,0 +1,219 @@
+---
+id: "takaro_lib_components.testing.ByRoleOptions"
+title: "Interface: ByRoleOptions"
+sidebar_label: "@takaro/lib-components.testing.ByRoleOptions"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).ByRoleOptions
+
+## Hierarchy
+
+- [`MatcherOptions`](takaro_lib_components.testing.MatcherOptions.md)
+
+  ↳ **`ByRoleOptions`**
+
+## Properties
+
+### checked
+
+• `Optional` **checked**: `boolean`
+
+If true only includes elements in the query set that are marked as
+checked in the accessibility tree, i.e., `aria-checked="true"`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:85
+
+___
+
+### collapseWhitespace
+
+• `Optional` **collapseWhitespace**: `boolean`
+
+Use normalizer with getDefaultNormalizer instead
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[collapseWhitespace](takaro_lib_components.testing.MatcherOptions.md#collapsewhitespace)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:24
+
+___
+
+### current
+
+• `Optional` **current**: `string` \| `boolean`
+
+Filters elements by their `aria-current` state. `true` and `false` match `aria-current="true"` and `aria-current="false"` (as well as a missing `aria-current` attribute) respectively.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:94
+
+___
+
+### description
+
+• `Optional` **description**: `string` \| `RegExp` \| (`accessibleDescription`: `string`, `element`: `Element`) => `boolean`
+
+Only considers elements with the specified accessible description.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:121
+
+___
+
+### exact
+
+• `Optional` **exact**: `boolean`
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[exact](takaro_lib_components.testing.MatcherOptions.md#exact)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:20
+
+___
+
+### expanded
+
+• `Optional` **expanded**: `boolean`
+
+If true only includes elements in the query set that are marked as
+expanded in the accessibility tree, i.e., `aria-expanded="true"`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:99
+
+___
+
+### hidden
+
+• `Optional` **hidden**: `boolean`
+
+If true includes elements in the query set that are usually excluded from
+the accessibility tree. `role="none"` or `role="presentation"` are included
+in either case.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:75
+
+___
+
+### level
+
+• `Optional` **level**: `number`
+
+Includes elements with the `"heading"` role matching the indicated level,
+either by the semantic HTML heading elements `<h1>-<h6>` or matching
+the `aria-level` attribute.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:105
+
+___
+
+### name
+
+• `Optional` **name**: `string` \| `RegExp` \| (`accessibleName`: `string`, `element`: `Element`) => `boolean`
+
+Only considers elements with the specified accessible name.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:114
+
+___
+
+### normalizer
+
+• `Optional` **normalizer**: [`NormalizerFn`](../namespaces/takaro_lib_components.testing.md#normalizerfn)
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[normalizer](takaro_lib_components.testing.MatcherOptions.md#normalizer)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:25
+
+___
+
+### pressed
+
+• `Optional` **pressed**: `boolean`
+
+If true only includes elements in the query set that are marked as
+pressed in the accessibility tree, i.e., `aria-pressed="true"`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:90
+
+___
+
+### queryFallbacks
+
+• `Optional` **queryFallbacks**: `boolean`
+
+Includes every role used in the `role` attribute
+For example *ByRole('progressbar', {queryFallbacks: true})` will find <div role="meter progressbar">`.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:110
+
+___
+
+### selected
+
+• `Optional` **selected**: `boolean`
+
+If true only includes elements in the query set that are marked as
+selected in the accessibility tree, i.e., `aria-selected="true"`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:80
+
+___
+
+### suggest
+
+• `Optional` **suggest**: `boolean`
+
+suppress suggestions for a specific query
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[suggest](takaro_lib_components.testing.MatcherOptions.md#suggest)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:27
+
+___
+
+### trim
+
+• `Optional` **trim**: `boolean`
+
+Use normalizer with getDefaultNormalizer instead
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[trim](takaro_lib_components.testing.MatcherOptions.md#trim)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:22

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.Config.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.Config.md
@@ -1,0 +1,167 @@
+---
+id: "takaro_lib_components.testing.Config"
+title: "Interface: Config"
+sidebar_label: "@takaro/lib-components.testing.Config"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).Config
+
+## Properties
+
+### asyncUtilTimeout
+
+• **asyncUtilTimeout**: `number`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:12
+
+___
+
+### computedStyleSupportsPseudoElements
+
+• **computedStyleSupportsPseudoElements**: `boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:13
+
+___
+
+### defaultHidden
+
+• **defaultHidden**: `boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:14
+
+___
+
+### defaultIgnore
+
+• **defaultIgnore**: `string`
+
+default value for the `ignore` option in `ByText` queries
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:16
+
+___
+
+### getElementError
+
+• **getElementError**: (`message`: ``null`` \| `string`, `container`: `Element`) => `Error`
+
+#### Type declaration
+
+▸ (`message`, `container`): `Error`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | ``null`` \| `string` |
+| `container` | `Element` |
+
+##### Returns
+
+`Error`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:19
+
+___
+
+### showOriginalStackTrace
+
+• **showOriginalStackTrace**: `boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:17
+
+___
+
+### testIdAttribute
+
+• **testIdAttribute**: `string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:2
+
+___
+
+### throwSuggestions
+
+• **throwSuggestions**: `boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:18
+
+## Methods
+
+### asyncWrapper
+
+▸ **asyncWrapper**(`cb`): `Promise`<`any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `cb` | (...`args`: `any`[]) => `any` |
+
+#### Returns
+
+`Promise`<`any`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:9
+
+___
+
+### eventWrapper
+
+▸ **eventWrapper**(`cb`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `cb` | (...`args`: `any`[]) => `any` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:11
+
+___
+
+### unstable\_advanceTimersWrapper
+
+▸ **unstable_advanceTimersWrapper**(`cb`): `unknown`
+
+WARNING: `unstable` prefix means this API may change in patch and minor releases.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `cb` | (...`args`: `unknown`[]) => `unknown` |
+
+#### Returns
+
+`unknown`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:7

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.ConfigFn.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.ConfigFn.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.testing.ConfigFn"
+title: "Interface: ConfigFn"
+sidebar_label: "@takaro/lib-components.testing.ConfigFn"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).ConfigFn
+
+## Callable
+
+### ConfigFn
+
+▸ **ConfigFn**(`existingConfig`): `Partial`<[`Config`](takaro_lib_components.testing.Config.md)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `existingConfig` | [`Config`](takaro_lib_components.testing.Config.md) |
+
+#### Returns
+
+`Partial`<[`Config`](takaro_lib_components.testing.Config.md)\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:23

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.DefaultNormalizerOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.DefaultNormalizerOptions.md
@@ -1,0 +1,34 @@
+---
+id: "takaro_lib_components.testing.DefaultNormalizerOptions"
+title: "Interface: DefaultNormalizerOptions"
+sidebar_label: "@takaro/lib-components.testing.DefaultNormalizerOptions"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).DefaultNormalizerOptions
+
+## Hierarchy
+
+- **`DefaultNormalizerOptions`**
+
+  ↳ [`NormalizerOptions`](takaro_lib_components.testing.NormalizerOptions.md)
+
+## Properties
+
+### collapseWhitespace
+
+• `Optional` **collapseWhitespace**: `boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:39
+
+___
+
+### trim
+
+• `Optional` **trim**: `boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:38

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.MatcherOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.MatcherOptions.md
@@ -1,0 +1,76 @@
+---
+id: "takaro_lib_components.testing.MatcherOptions"
+title: "Interface: MatcherOptions"
+sidebar_label: "@takaro/lib-components.testing.MatcherOptions"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).MatcherOptions
+
+## Hierarchy
+
+- **`MatcherOptions`**
+
+  ↳ [`ByRoleOptions`](takaro_lib_components.testing.queries.ByRoleOptions.md)
+
+  ↳ [`SelectorMatcherOptions`](takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md)
+
+  ↳ [`ByRoleOptions`](takaro_lib_components.testing.ByRoleOptions.md)
+
+  ↳ [`SelectorMatcherOptions`](takaro_lib_components.testing.SelectorMatcherOptions.md)
+
+## Properties
+
+### collapseWhitespace
+
+• `Optional` **collapseWhitespace**: `boolean`
+
+Use normalizer with getDefaultNormalizer instead
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:24
+
+___
+
+### exact
+
+• `Optional` **exact**: `boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:20
+
+___
+
+### normalizer
+
+• `Optional` **normalizer**: [`NormalizerFn`](../namespaces/takaro_lib_components.testing.md#normalizerfn)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:25
+
+___
+
+### suggest
+
+• `Optional` **suggest**: `boolean`
+
+suppress suggestions for a specific query
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:27
+
+___
+
+### trim
+
+• `Optional` **trim**: `boolean`
+
+Use normalizer with getDefaultNormalizer instead
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:22

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.NormalizerOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.NormalizerOptions.md
@@ -1,0 +1,52 @@
+---
+id: "takaro_lib_components.testing.NormalizerOptions"
+title: "Interface: NormalizerOptions"
+sidebar_label: "@takaro/lib-components.testing.NormalizerOptions"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).NormalizerOptions
+
+## Hierarchy
+
+- [`DefaultNormalizerOptions`](takaro_lib_components.testing.DefaultNormalizerOptions.md)
+
+  ↳ **`NormalizerOptions`**
+
+## Properties
+
+### collapseWhitespace
+
+• `Optional` **collapseWhitespace**: `boolean`
+
+#### Inherited from
+
+[DefaultNormalizerOptions](takaro_lib_components.testing.DefaultNormalizerOptions.md).[collapseWhitespace](takaro_lib_components.testing.DefaultNormalizerOptions.md#collapsewhitespace)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:39
+
+___
+
+### normalizer
+
+• `Optional` **normalizer**: [`NormalizerFn`](../namespaces/takaro_lib_components.testing.md#normalizerfn)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:16
+
+___
+
+### trim
+
+• `Optional` **trim**: `boolean`
+
+#### Inherited from
+
+[DefaultNormalizerOptions](takaro_lib_components.testing.DefaultNormalizerOptions.md).[trim](takaro_lib_components.testing.DefaultNormalizerOptions.md#trim)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:38

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.PrettyDOMOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.PrettyDOMOptions.md
@@ -1,0 +1,209 @@
+---
+id: "takaro_lib_components.testing.PrettyDOMOptions"
+title: "Interface: PrettyDOMOptions"
+sidebar_label: "@takaro/lib-components.testing.PrettyDOMOptions"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).PrettyDOMOptions
+
+## Hierarchy
+
+- [`OptionsReceived`](../namespaces/takaro_lib_components.testing.prettyFormat.md#optionsreceived)
+
+  ↳ **`PrettyDOMOptions`**
+
+## Properties
+
+### callToJSON
+
+• `Optional` **callToJSON**: `boolean`
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.callToJSON
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:62
+
+___
+
+### compareKeys
+
+• `Optional` **compareKeys**: [`CompareKeys`](../namespaces/takaro_lib_components.testing.prettyFormat.md#comparekeys)
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.compareKeys
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:63
+
+___
+
+### escapeRegex
+
+• `Optional` **escapeRegex**: `boolean`
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.escapeRegex
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:64
+
+___
+
+### escapeString
+
+• `Optional` **escapeString**: `boolean`
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.escapeString
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:65
+
+___
+
+### filterNode
+
+• `Optional` **filterNode**: (`node`: `Node`) => `boolean`
+
+#### Type declaration
+
+▸ (`node`): `boolean`
+
+Given a `Node` return `false` if you wish to ignore that node in the output.
+By default, ignores `<style />`, `<script />` and comment nodes.
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `node` | `Node` |
+
+##### Returns
+
+`boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/pretty-dom.d.ts:8
+
+___
+
+### highlight
+
+• `Optional` **highlight**: `boolean`
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.highlight
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:66
+
+___
+
+### indent
+
+• `Optional` **indent**: `number`
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.indent
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:67
+
+___
+
+### maxDepth
+
+• `Optional` **maxDepth**: `number`
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.maxDepth
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:68
+
+___
+
+### min
+
+• `Optional` **min**: `boolean`
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.min
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:69
+
+___
+
+### plugins
+
+• `Optional` **plugins**: [`Plugins`](../namespaces/takaro_lib_components.testing.prettyFormat.md#plugins)
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.plugins
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:70
+
+___
+
+### printBasicPrototype
+
+• `Optional` **printBasicPrototype**: `boolean`
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.printBasicPrototype
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:71
+
+___
+
+### printFunctionName
+
+• `Optional` **printFunctionName**: `boolean`
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.printFunctionName
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:72
+
+___
+
+### theme
+
+• `Optional` **theme**: `ThemeReceived`
+
+#### Inherited from
+
+prettyFormat.OptionsReceived.theme
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:73

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.Queries-1.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.Queries-1.md
@@ -1,0 +1,12 @@
+---
+id: "takaro_lib_components.testing.Queries-1"
+title: "Interface: Queries"
+sidebar_label: "@takaro/lib-components.testing.Queries"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).Queries
+
+## Indexable
+
+▪ [T: `string`]: [`Query`](../namespaces/takaro_lib_components.testing.md#query)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.QueryOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.QueryOptions.md
@@ -1,0 +1,12 @@
+---
+id: "takaro_lib_components.testing.QueryOptions"
+title: "Interface: QueryOptions"
+sidebar_label: "@takaro/lib-components.testing.QueryOptions"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).QueryOptions
+
+## Indexable
+
+▪ [key: `string`]: `RegExp` \| `boolean`

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.RenderHookOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.RenderHookOptions.md
@@ -1,0 +1,160 @@
+---
+id: "takaro_lib_components.testing.RenderHookOptions"
+title: "Interface: RenderHookOptions<Props, Q, Container, BaseElement>"
+sidebar_label: "@takaro/lib-components.testing.RenderHookOptions"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).RenderHookOptions
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Props` | `Props` |
+| `Q` | extends [`Queries`](takaro_lib_components.testing.Queries-1.md) = typeof [`queries`](../namespaces/takaro_lib_components.testing.queries.md) |
+| `Container` | extends `Element` \| `DocumentFragment` = `HTMLElement` |
+| `BaseElement` | extends `Element` \| `DocumentFragment` = `Container` |
+
+## Hierarchy
+
+- [`RenderOptions`](takaro_lib_components.testing.RenderOptions.md)<`Q`, `Container`, `BaseElement`\>
+
+  ↳ **`RenderHookOptions`**
+
+## Properties
+
+### baseElement
+
+• `Optional` **baseElement**: `BaseElement`
+
+Defaults to the container if the container is specified. Otherwise `document.body` is used for the default. This is used as
+ the base element for the queries as well as what is printed when you use `debug()`.
+
+**`See`**
+
+https://testing-library.com/docs/react-testing-library/api/#baseelement
+
+#### Inherited from
+
+[RenderOptions](takaro_lib_components.testing.RenderOptions.md).[baseElement](takaro_lib_components.testing.RenderOptions.md#baseelement)
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:55
+
+___
+
+### container
+
+• `Optional` **container**: `Container`
+
+By default, React Testing Library will create a div and append that div to the document.body. Your React component will be rendered in the created div. If you provide your own HTMLElement container via this option,
+ it will not be appended to the document.body automatically.
+
+ For example: If you are unit testing a `<tbody>` element, it cannot be a child of a div. In this case, you can
+ specify a table as the render container.
+
+**`See`**
+
+https://testing-library.com/docs/react-testing-library/api/#container
+
+#### Inherited from
+
+[RenderOptions](takaro_lib_components.testing.RenderOptions.md).[container](takaro_lib_components.testing.RenderOptions.md#container)
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:48
+
+___
+
+### hydrate
+
+• `Optional` **hydrate**: `boolean`
+
+If `hydrate` is set to `true`, then it will render with `ReactDOM.hydrate`. This may be useful if you are using server-side
+ rendering and use ReactDOM.hydrate to mount your components.
+
+**`See`**
+
+https://testing-library.com/docs/react-testing-library/api/#hydrate)
+
+#### Inherited from
+
+[RenderOptions](takaro_lib_components.testing.RenderOptions.md).[hydrate](takaro_lib_components.testing.RenderOptions.md#hydrate)
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:62
+
+___
+
+### initialProps
+
+• `Optional` **initialProps**: `Props`
+
+The argument passed to the renderHook callback. Can be useful if you plan
+to use the rerender utility to change the values passed to your hook.
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:133
+
+___
+
+### legacyRoot
+
+• `Optional` **legacyRoot**: `boolean`
+
+Set to `true` if you want to force synchronous `ReactDOM.render`.
+Otherwise `render` will default to concurrent React if available.
+
+#### Inherited from
+
+[RenderOptions](takaro_lib_components.testing.RenderOptions.md).[legacyRoot](takaro_lib_components.testing.RenderOptions.md#legacyroot)
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:67
+
+___
+
+### queries
+
+• `Optional` **queries**: `Q`
+
+Queries to bind. Overrides the default set from DOM Testing Library unless merged.
+
+**`See`**
+
+https://testing-library.com/docs/react-testing-library/api/#queries
+
+#### Inherited from
+
+[RenderOptions](takaro_lib_components.testing.RenderOptions.md).[queries](takaro_lib_components.testing.RenderOptions.md#queries)
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:73
+
+___
+
+### wrapper
+
+• `Optional` **wrapper**: `JSXElementConstructor`<{ `children`: `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>  }\>
+
+Pass a React Component as the wrapper option to have it rendered around the inner element. This is most useful for creating
+ reusable custom render functions for common data providers. See setup for examples.
+
+**`See`**
+
+https://testing-library.com/docs/react-testing-library/api/#wrapper
+
+#### Inherited from
+
+[RenderOptions](takaro_lib_components.testing.RenderOptions.md).[wrapper](takaro_lib_components.testing.RenderOptions.md#wrapper)
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:80

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.RenderHookResult.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.RenderHookResult.md
@@ -1,0 +1,81 @@
+---
+id: "takaro_lib_components.testing.RenderHookResult"
+title: "Interface: RenderHookResult<Result, Props>"
+sidebar_label: "@takaro/lib-components.testing.RenderHookResult"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).RenderHookResult
+
+## Type parameters
+
+| Name |
+| :------ |
+| `Result` |
+| `Props` |
+
+## Properties
+
+### rerender
+
+• **rerender**: (`props?`: `Props`) => `void`
+
+#### Type declaration
+
+▸ (`props?`): `void`
+
+Triggers a re-render. The props will be passed to your renderHook callback.
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props?` | `Props` |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:105
+
+___
+
+### result
+
+• **result**: `Object`
+
+This is a stable reference to the latest value returned by your renderHook
+callback
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `current` | `Result` | The value returned by your renderHook callback |
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:110
+
+___
+
+### unmount
+
+• **unmount**: () => `void`
+
+#### Type declaration
+
+▸ (): `void`
+
+Unmounts the test component. This is useful for when you need to test
+any cleanup your useEffects have.
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:120

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.RenderOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.RenderOptions.md
@@ -1,0 +1,122 @@
+---
+id: "takaro_lib_components.testing.RenderOptions"
+title: "Interface: RenderOptions<Q, Container, BaseElement>"
+sidebar_label: "@takaro/lib-components.testing.RenderOptions"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).RenderOptions
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Q` | extends [`Queries`](takaro_lib_components.testing.Queries-1.md) = typeof [`queries`](../namespaces/takaro_lib_components.testing.queries.md) |
+| `Container` | extends `Element` \| `DocumentFragment` = `HTMLElement` |
+| `BaseElement` | extends `Element` \| `DocumentFragment` = `Container` |
+
+## Hierarchy
+
+- **`RenderOptions`**
+
+  ↳ [`RenderHookOptions`](takaro_lib_components.testing.RenderHookOptions.md)
+
+## Properties
+
+### baseElement
+
+• `Optional` **baseElement**: `BaseElement`
+
+Defaults to the container if the container is specified. Otherwise `document.body` is used for the default. This is used as
+ the base element for the queries as well as what is printed when you use `debug()`.
+
+**`See`**
+
+https://testing-library.com/docs/react-testing-library/api/#baseelement
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:55
+
+___
+
+### container
+
+• `Optional` **container**: `Container`
+
+By default, React Testing Library will create a div and append that div to the document.body. Your React component will be rendered in the created div. If you provide your own HTMLElement container via this option,
+ it will not be appended to the document.body automatically.
+
+ For example: If you are unit testing a `<tbody>` element, it cannot be a child of a div. In this case, you can
+ specify a table as the render container.
+
+**`See`**
+
+https://testing-library.com/docs/react-testing-library/api/#container
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:48
+
+___
+
+### hydrate
+
+• `Optional` **hydrate**: `boolean`
+
+If `hydrate` is set to `true`, then it will render with `ReactDOM.hydrate`. This may be useful if you are using server-side
+ rendering and use ReactDOM.hydrate to mount your components.
+
+**`See`**
+
+https://testing-library.com/docs/react-testing-library/api/#hydrate)
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:62
+
+___
+
+### legacyRoot
+
+• `Optional` **legacyRoot**: `boolean`
+
+Set to `true` if you want to force synchronous `ReactDOM.render`.
+Otherwise `render` will default to concurrent React if available.
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:67
+
+___
+
+### queries
+
+• `Optional` **queries**: `Q`
+
+Queries to bind. Overrides the default set from DOM Testing Library unless merged.
+
+**`See`**
+
+https://testing-library.com/docs/react-testing-library/api/#queries
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:73
+
+___
+
+### wrapper
+
+• `Optional` **wrapper**: `JSXElementConstructor`<{ `children`: `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>  }\>
+
+Pass a React Component as the wrapper option to have it rendered around the inner element. This is most useful for creating
+ reusable custom render functions for common data providers. See setup for examples.
+
+**`See`**
+
+https://testing-library.com/docs/react-testing-library/api/#wrapper
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:80

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.SelectorMatcherOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.SelectorMatcherOptions.md
@@ -1,0 +1,110 @@
+---
+id: "takaro_lib_components.testing.SelectorMatcherOptions"
+title: "Interface: SelectorMatcherOptions"
+sidebar_label: "@takaro/lib-components.testing.SelectorMatcherOptions"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).SelectorMatcherOptions
+
+## Hierarchy
+
+- [`MatcherOptions`](takaro_lib_components.testing.MatcherOptions.md)
+
+  ↳ **`SelectorMatcherOptions`**
+
+## Properties
+
+### collapseWhitespace
+
+• `Optional` **collapseWhitespace**: `boolean`
+
+Use normalizer with getDefaultNormalizer instead
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[collapseWhitespace](takaro_lib_components.testing.MatcherOptions.md#collapsewhitespace)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:24
+
+___
+
+### exact
+
+• `Optional` **exact**: `boolean`
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[exact](takaro_lib_components.testing.MatcherOptions.md#exact)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:20
+
+___
+
+### ignore
+
+• `Optional` **ignore**: `string` \| `boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:13
+
+___
+
+### normalizer
+
+• `Optional` **normalizer**: [`NormalizerFn`](../namespaces/takaro_lib_components.testing.md#normalizerfn)
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[normalizer](takaro_lib_components.testing.MatcherOptions.md#normalizer)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:25
+
+___
+
+### selector
+
+• `Optional` **selector**: `string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:12
+
+___
+
+### suggest
+
+• `Optional` **suggest**: `boolean`
+
+suppress suggestions for a specific query
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[suggest](takaro_lib_components.testing.MatcherOptions.md#suggest)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:27
+
+___
+
+### trim
+
+• `Optional` **trim**: `boolean`
+
+Use normalizer with getDefaultNormalizer instead
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[trim](takaro_lib_components.testing.MatcherOptions.md#trim)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:22

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.Suggestion.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.Suggestion.md
@@ -1,0 +1,72 @@
+---
+id: "takaro_lib_components.testing.Suggestion"
+title: "Interface: Suggestion"
+sidebar_label: "@takaro/lib-components.testing.Suggestion"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).Suggestion
+
+## Properties
+
+### queryArgs
+
+• **queryArgs**: [`QueryArgs`](../namespaces/takaro_lib_components.testing.md#queryargs)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/suggestions.d.ts:10
+
+___
+
+### queryMethod
+
+• **queryMethod**: `string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/suggestions.d.ts:9
+
+___
+
+### queryName
+
+• **queryName**: `string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/suggestions.d.ts:8
+
+___
+
+### variant
+
+• **variant**: `string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/suggestions.d.ts:11
+
+___
+
+### warning
+
+• `Optional` **warning**: `string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/suggestions.d.ts:12
+
+## Methods
+
+### toString
+
+▸ **toString**(): `string`
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/suggestions.d.ts:13

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.prettyFormat.PrettyFormatOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.prettyFormat.PrettyFormatOptions.md
@@ -1,0 +1,128 @@
+---
+id: "takaro_lib_components.testing.prettyFormat.PrettyFormatOptions"
+title: "Interface: PrettyFormatOptions"
+sidebar_label: "@takaro/lib-components.testing.prettyFormat.PrettyFormatOptions"
+custom_edit_url: null
+---
+
+[testing](../namespaces/takaro_lib_components.testing.md).[prettyFormat](../namespaces/takaro_lib_components.testing.prettyFormat.md).PrettyFormatOptions
+
+## Properties
+
+### callToJSON
+
+• `Optional` **callToJSON**: `boolean`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:62
+
+___
+
+### compareKeys
+
+• `Optional` **compareKeys**: [`CompareKeys`](../namespaces/takaro_lib_components.testing.prettyFormat.md#comparekeys)
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:63
+
+___
+
+### escapeRegex
+
+• `Optional` **escapeRegex**: `boolean`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:64
+
+___
+
+### escapeString
+
+• `Optional` **escapeString**: `boolean`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:65
+
+___
+
+### highlight
+
+• `Optional` **highlight**: `boolean`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:66
+
+___
+
+### indent
+
+• `Optional` **indent**: `number`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:67
+
+___
+
+### maxDepth
+
+• `Optional` **maxDepth**: `number`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:68
+
+___
+
+### min
+
+• `Optional` **min**: `boolean`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:69
+
+___
+
+### plugins
+
+• `Optional` **plugins**: [`Plugins`](../namespaces/takaro_lib_components.testing.prettyFormat.md#plugins)
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:70
+
+___
+
+### printBasicPrototype
+
+• `Optional` **printBasicPrototype**: `boolean`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:71
+
+___
+
+### printFunctionName
+
+• `Optional` **printFunctionName**: `boolean`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:72
+
+___
+
+### theme
+
+• `Optional` **theme**: `ThemeReceived`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:73

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md
@@ -1,0 +1,219 @@
+---
+id: "takaro_lib_components.testing.queries.ByRoleOptions"
+title: "Interface: ByRoleOptions"
+sidebar_label: "@takaro/lib-components.testing.queries.ByRoleOptions"
+custom_edit_url: null
+---
+
+[testing](../namespaces/takaro_lib_components.testing.md).[queries](../namespaces/takaro_lib_components.testing.queries.md).ByRoleOptions
+
+## Hierarchy
+
+- [`MatcherOptions`](takaro_lib_components.testing.MatcherOptions.md)
+
+  ↳ **`ByRoleOptions`**
+
+## Properties
+
+### checked
+
+• `Optional` **checked**: `boolean`
+
+If true only includes elements in the query set that are marked as
+checked in the accessibility tree, i.e., `aria-checked="true"`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:85
+
+___
+
+### collapseWhitespace
+
+• `Optional` **collapseWhitespace**: `boolean`
+
+Use normalizer with getDefaultNormalizer instead
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[collapseWhitespace](takaro_lib_components.testing.MatcherOptions.md#collapsewhitespace)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:24
+
+___
+
+### current
+
+• `Optional` **current**: `string` \| `boolean`
+
+Filters elements by their `aria-current` state. `true` and `false` match `aria-current="true"` and `aria-current="false"` (as well as a missing `aria-current` attribute) respectively.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:94
+
+___
+
+### description
+
+• `Optional` **description**: `string` \| `RegExp` \| (`accessibleDescription`: `string`, `element`: `Element`) => `boolean`
+
+Only considers elements with the specified accessible description.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:121
+
+___
+
+### exact
+
+• `Optional` **exact**: `boolean`
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[exact](takaro_lib_components.testing.MatcherOptions.md#exact)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:20
+
+___
+
+### expanded
+
+• `Optional` **expanded**: `boolean`
+
+If true only includes elements in the query set that are marked as
+expanded in the accessibility tree, i.e., `aria-expanded="true"`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:99
+
+___
+
+### hidden
+
+• `Optional` **hidden**: `boolean`
+
+If true includes elements in the query set that are usually excluded from
+the accessibility tree. `role="none"` or `role="presentation"` are included
+in either case.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:75
+
+___
+
+### level
+
+• `Optional` **level**: `number`
+
+Includes elements with the `"heading"` role matching the indicated level,
+either by the semantic HTML heading elements `<h1>-<h6>` or matching
+the `aria-level` attribute.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:105
+
+___
+
+### name
+
+• `Optional` **name**: `string` \| `RegExp` \| (`accessibleName`: `string`, `element`: `Element`) => `boolean`
+
+Only considers elements with the specified accessible name.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:114
+
+___
+
+### normalizer
+
+• `Optional` **normalizer**: [`NormalizerFn`](../namespaces/takaro_lib_components.testing.md#normalizerfn)
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[normalizer](takaro_lib_components.testing.MatcherOptions.md#normalizer)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:25
+
+___
+
+### pressed
+
+• `Optional` **pressed**: `boolean`
+
+If true only includes elements in the query set that are marked as
+pressed in the accessibility tree, i.e., `aria-pressed="true"`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:90
+
+___
+
+### queryFallbacks
+
+• `Optional` **queryFallbacks**: `boolean`
+
+Includes every role used in the `role` attribute
+For example *ByRole('progressbar', {queryFallbacks: true})` will find <div role="meter progressbar">`.
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:110
+
+___
+
+### selected
+
+• `Optional` **selected**: `boolean`
+
+If true only includes elements in the query set that are marked as
+selected in the accessibility tree, i.e., `aria-selected="true"`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:80
+
+___
+
+### suggest
+
+• `Optional` **suggest**: `boolean`
+
+suppress suggestions for a specific query
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[suggest](takaro_lib_components.testing.MatcherOptions.md#suggest)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:27
+
+___
+
+### trim
+
+• `Optional` **trim**: `boolean`
+
+Use normalizer with getDefaultNormalizer instead
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[trim](takaro_lib_components.testing.MatcherOptions.md#trim)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:22

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md
@@ -1,0 +1,110 @@
+---
+id: "takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions"
+title: "Interface: SelectorMatcherOptions"
+sidebar_label: "@takaro/lib-components.testing.queryHelpers.SelectorMatcherOptions"
+custom_edit_url: null
+---
+
+[testing](../namespaces/takaro_lib_components.testing.md).[queryHelpers](../namespaces/takaro_lib_components.testing.queryHelpers.md).SelectorMatcherOptions
+
+## Hierarchy
+
+- [`MatcherOptions`](takaro_lib_components.testing.MatcherOptions.md)
+
+  ↳ **`SelectorMatcherOptions`**
+
+## Properties
+
+### collapseWhitespace
+
+• `Optional` **collapseWhitespace**: `boolean`
+
+Use normalizer with getDefaultNormalizer instead
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[collapseWhitespace](takaro_lib_components.testing.MatcherOptions.md#collapsewhitespace)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:24
+
+___
+
+### exact
+
+• `Optional` **exact**: `boolean`
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[exact](takaro_lib_components.testing.MatcherOptions.md#exact)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:20
+
+___
+
+### ignore
+
+• `Optional` **ignore**: `string` \| `boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:13
+
+___
+
+### normalizer
+
+• `Optional` **normalizer**: [`NormalizerFn`](../namespaces/takaro_lib_components.testing.md#normalizerfn)
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[normalizer](takaro_lib_components.testing.MatcherOptions.md#normalizer)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:25
+
+___
+
+### selector
+
+• `Optional` **selector**: `string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:12
+
+___
+
+### suggest
+
+• `Optional` **suggest**: `boolean`
+
+suppress suggestions for a specific query
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[suggest](takaro_lib_components.testing.MatcherOptions.md#suggest)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:27
+
+___
+
+### trim
+
+• `Optional` **trim**: `boolean`
+
+Use normalizer with getDefaultNormalizer instead
+
+#### Inherited from
+
+[MatcherOptions](takaro_lib_components.testing.MatcherOptions.md).[trim](takaro_lib_components.testing.MatcherOptions.md#trim)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:22

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.waitForOptions.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_lib_components.testing.waitForOptions.md
@@ -1,0 +1,72 @@
+---
+id: "takaro_lib_components.testing.waitForOptions"
+title: "Interface: waitForOptions"
+sidebar_label: "@takaro/lib-components.testing.waitForOptions"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](../namespaces/takaro_lib_components.testing.md).waitForOptions
+
+## Properties
+
+### container
+
+• `Optional` **container**: `HTMLElement`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/wait-for.d.ts:2
+
+___
+
+### interval
+
+• `Optional` **interval**: `number`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/wait-for.d.ts:4
+
+___
+
+### mutationObserverOptions
+
+• `Optional` **mutationObserverOptions**: `MutationObserverInit`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/wait-for.d.ts:6
+
+___
+
+### onTimeout
+
+• `Optional` **onTimeout**: (`error`: `Error`) => `Error`
+
+#### Type declaration
+
+▸ (`error`): `Error`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `error` | `Error` |
+
+##### Returns
+
+`Error`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/wait-for.d.ts:5
+
+___
+
+### timeout
+
+• `Optional` **timeout**: `number`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/wait-for.d.ts:3

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_queues.IEventQueueData.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_queues.IEventQueueData.md
@@ -1,0 +1,48 @@
+---
+id: "takaro_queues.IEventQueueData"
+title: "Interface: IEventQueueData"
+sidebar_label: "@takaro/queues.IEventQueueData"
+custom_edit_url: null
+---
+
+[@takaro/queues](../modules/takaro_queues.md).IEventQueueData
+
+## Properties
+
+### domainId
+
+• **domainId**: `string`
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:54](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L54)
+
+___
+
+### event
+
+• **event**: `EventLogLine` \| `EventPlayerConnected` \| `EventPlayerDisconnected` \| `EventChatMessage`
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:56](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L56)
+
+___
+
+### gameServerId
+
+• **gameServerId**: `string`
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L55)
+
+___
+
+### type
+
+• **type**: `GameEvents`
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:53](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L53)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_queues.IJobData.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_queues.IJobData.md
@@ -1,0 +1,63 @@
+---
+id: "takaro_queues.IJobData"
+title: "Interface: IJobData"
+sidebar_label: "@takaro/queues.IJobData"
+custom_edit_url: null
+---
+
+[@takaro/queues](../modules/takaro_queues.md).IJobData
+
+## Properties
+
+### data
+
+• `Optional` **data**: `EventLogLine` \| `EventPlayerConnected` \| `EventPlayerDisconnected` \| `EventChatMessage`
+
+Additional data that can be passed to the job
+Typically, this depends on what triggered the job
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:49](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L49)
+
+___
+
+### domainId
+
+• **domainId**: `string`
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:39](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L39)
+
+___
+
+### function
+
+• **function**: `string`
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:38](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L38)
+
+___
+
+### itemId
+
+• **itemId**: `string`
+
+The id of the item that triggered this job (cronjobId, commandId or hookId)
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:44](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L44)
+
+___
+
+### token
+
+• **token**: `string`
+
+#### Defined in
+
+[packages/lib-queues/src/queues.ts:40](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/queues.ts#L40)

--- a/packages/web-docs/docs/development/packages/interfaces/takaro_queues.IQueuesConfig.md
+++ b/packages/web-docs/docs/development/packages/interfaces/takaro_queues.IQueuesConfig.md
@@ -1,0 +1,95 @@
+---
+id: "takaro_queues.IQueuesConfig"
+title: "Interface: IQueuesConfig"
+sidebar_label: "@takaro/queues.IQueuesConfig"
+custom_edit_url: null
+---
+
+[@takaro/queues](../modules/takaro_queues.md).IQueuesConfig
+
+## Hierarchy
+
+- `IBaseConfig`
+
+  ↳ **`IQueuesConfig`**
+
+## Properties
+
+### app
+
+• **app**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+
+#### Inherited from
+
+IBaseConfig.app
+
+#### Defined in
+
+node_modules/@takaro/config/dist/main.d.ts:3
+
+___
+
+### mode
+
+• **mode**: ``"development"`` \| ``"production"`` \| ``"test"``
+
+#### Inherited from
+
+IBaseConfig.mode
+
+#### Defined in
+
+node_modules/@takaro/config/dist/main.d.ts:6
+
+___
+
+### queues
+
+• **queues**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `commands` | { `concurrency`: `number` ; `name`: `string`  } |
+| `commands.concurrency` | `number` |
+| `commands.name` | `string` |
+| `cronjobs` | { `concurrency`: `number` ; `name`: `string`  } |
+| `cronjobs.concurrency` | `number` |
+| `cronjobs.name` | `string` |
+| `events` | { `concurrency`: `number` ; `name`: `string`  } |
+| `events.concurrency` | `number` |
+| `events.name` | `string` |
+| `hooks` | { `concurrency`: `number` ; `name`: `string`  } |
+| `hooks.concurrency` | `number` |
+| `hooks.name` | `string` |
+
+#### Defined in
+
+[packages/lib-queues/src/config.ts:4](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/config.ts#L4)
+
+___
+
+### redis
+
+• **redis**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `host` | `string` |
+| `password` | `string` |
+| `port` | `number` |
+| `tlsCa` | `string` |
+| `username` | `string` |
+
+#### Defined in
+
+[packages/lib-queues/src/config.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/config.ts#L22)

--- a/packages/web-docs/docs/development/packages/modules.md
+++ b/packages/web-docs/docs/development/packages/modules.md
@@ -1,0 +1,21 @@
+---
+id: "modules"
+title: "Documentation"
+sidebar_label: "Exports"
+sidebar_position: 0.5
+custom_edit_url: null
+---
+
+## Modules
+
+- [@takaro/agent](modules/takaro_agent.md)
+- [@takaro/api](modules/takaro_api.md)
+- [@takaro/apiclient](modules/takaro_apiclient.md)
+- [@takaro/config](modules/takaro_config.md)
+- [@takaro/db](modules/takaro_db.md)
+- [@takaro/gameserver](modules/takaro_gameserver.md)
+- [@takaro/http](modules/takaro_http.md)
+- [@takaro/lib-components](modules/takaro_lib_components.md)
+- [@takaro/queues](modules/takaro_queues.md)
+- [@takaro/test](modules/takaro_test.md)
+- [@takaro/util](modules/takaro_util.md)

--- a/packages/web-docs/docs/development/packages/modules/_category_.yml
+++ b/packages/web-docs/docs/development/packages/modules/_category_.yml
@@ -1,0 +1,2 @@
+label: "Modules"
+position: 1

--- a/packages/web-docs/docs/development/packages/modules/takaro_agent.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_agent.md
@@ -1,0 +1,17 @@
+---
+id: "takaro_agent"
+title: "Module: @takaro/agent"
+sidebar_label: "@takaro/agent"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Variables
+
+### server
+
+• `Const` **server**: `HTTP`
+
+#### Defined in
+
+[packages/app-agent/src/main.ts:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/app-agent/src/main.ts#L7)

--- a/packages/web-docs/docs/development/packages/modules/takaro_api.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_api.md
@@ -1,0 +1,17 @@
+---
+id: "takaro_api"
+title: "Module: @takaro/api"
+sidebar_label: "@takaro/api"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Variables
+
+### server
+
+• `Const` **server**: `HTTP`
+
+#### Defined in
+
+[packages/app-api/src/main.ts:25](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/app-api/src/main.ts#L25)

--- a/packages/web-docs/docs/development/packages/modules/takaro_apiclient.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_apiclient.md
@@ -1,0 +1,2284 @@
+---
+id: "takaro_apiclient"
+title: "Module: @takaro/apiclient"
+sidebar_label: "@takaro/apiclient"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Classes
+
+- [AdminClient](../classes/takaro_apiclient.AdminClient.md)
+- [Client](../classes/takaro_apiclient.Client.md)
+- [CommandApi](../classes/takaro_apiclient.CommandApi.md)
+- [CronJobApi](../classes/takaro_apiclient.CronJobApi.md)
+- [DomainApi](../classes/takaro_apiclient.DomainApi.md)
+- [FunctionApi](../classes/takaro_apiclient.FunctionApi.md)
+- [GameServerApi](../classes/takaro_apiclient.GameServerApi.md)
+- [HookApi](../classes/takaro_apiclient.HookApi.md)
+- [MetaApi](../classes/takaro_apiclient.MetaApi.md)
+- [ModuleApi](../classes/takaro_apiclient.ModuleApi.md)
+- [PlayerApi](../classes/takaro_apiclient.PlayerApi.md)
+- [RoleApi](../classes/takaro_apiclient.RoleApi.md)
+- [SettingsApi](../classes/takaro_apiclient.SettingsApi.md)
+- [UserApi](../classes/takaro_apiclient.UserApi.md)
+
+## Interfaces
+
+- [APIOutput](../interfaces/takaro_apiclient.APIOutput.md)
+- [AxiosError](../interfaces/takaro_apiclient.AxiosError.md)
+- [AxiosResponse](../interfaces/takaro_apiclient.AxiosResponse.md)
+- [BaseEvent](../interfaces/takaro_apiclient.BaseEvent.md)
+- [CapabilityOutputDTO](../interfaces/takaro_apiclient.CapabilityOutputDTO.md)
+- [CommandCreateDTO](../interfaces/takaro_apiclient.CommandCreateDTO.md)
+- [CommandOutputArrayDTOAPI](../interfaces/takaro_apiclient.CommandOutputArrayDTOAPI.md)
+- [CommandOutputDTO](../interfaces/takaro_apiclient.CommandOutputDTO.md)
+- [CommandOutputDTOAPI](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md)
+- [CommandSearchInputAllowedFilters](../interfaces/takaro_apiclient.CommandSearchInputAllowedFilters.md)
+- [CommandSearchInputDTO](../interfaces/takaro_apiclient.CommandSearchInputDTO.md)
+- [CommandUpdateDTO](../interfaces/takaro_apiclient.CommandUpdateDTO.md)
+- [CronJobCreateDTO](../interfaces/takaro_apiclient.CronJobCreateDTO.md)
+- [CronJobOutputArrayDTOAPI](../interfaces/takaro_apiclient.CronJobOutputArrayDTOAPI.md)
+- [CronJobOutputDTO](../interfaces/takaro_apiclient.CronJobOutputDTO.md)
+- [CronJobOutputDTOAPI](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md)
+- [CronJobSearchInputAllowedFilters](../interfaces/takaro_apiclient.CronJobSearchInputAllowedFilters.md)
+- [CronJobSearchInputDTO](../interfaces/takaro_apiclient.CronJobSearchInputDTO.md)
+- [CronJobUpdateDTO](../interfaces/takaro_apiclient.CronJobUpdateDTO.md)
+- [DomainCreateInputDTO](../interfaces/takaro_apiclient.DomainCreateInputDTO.md)
+- [DomainCreateOutputDTO](../interfaces/takaro_apiclient.DomainCreateOutputDTO.md)
+- [DomainCreateOutputDTOAPI](../interfaces/takaro_apiclient.DomainCreateOutputDTOAPI.md)
+- [DomainOutputArrayDTOAPI](../interfaces/takaro_apiclient.DomainOutputArrayDTOAPI.md)
+- [DomainOutputDTO](../interfaces/takaro_apiclient.DomainOutputDTO.md)
+- [DomainOutputDTOAPI](../interfaces/takaro_apiclient.DomainOutputDTOAPI.md)
+- [DomainSearchInputAllowedFilters](../interfaces/takaro_apiclient.DomainSearchInputAllowedFilters.md)
+- [DomainSearchInputDTO](../interfaces/takaro_apiclient.DomainSearchInputDTO.md)
+- [DomainUpdateInputDTO](../interfaces/takaro_apiclient.DomainUpdateInputDTO.md)
+- [ErrorOutput](../interfaces/takaro_apiclient.ErrorOutput.md)
+- [EventChatMessage](../interfaces/takaro_apiclient.EventChatMessage.md)
+- [EventPlayerConnected](../interfaces/takaro_apiclient.EventPlayerConnected.md)
+- [EventPlayerDisconnected](../interfaces/takaro_apiclient.EventPlayerDisconnected.md)
+- [FunctionCreateDTO](../interfaces/takaro_apiclient.FunctionCreateDTO.md)
+- [FunctionOutputArrayDTOAPI](../interfaces/takaro_apiclient.FunctionOutputArrayDTOAPI.md)
+- [FunctionOutputDTO](../interfaces/takaro_apiclient.FunctionOutputDTO.md)
+- [FunctionOutputDTOAPI](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md)
+- [FunctionSearchInputAllowedFilters](../interfaces/takaro_apiclient.FunctionSearchInputAllowedFilters.md)
+- [FunctionSearchInputDTO](../interfaces/takaro_apiclient.FunctionSearchInputDTO.md)
+- [FunctionUpdateDTO](../interfaces/takaro_apiclient.FunctionUpdateDTO.md)
+- [GameServerCreateDTO](../interfaces/takaro_apiclient.GameServerCreateDTO.md)
+- [GameServerOutputArrayDTOAPI](../interfaces/takaro_apiclient.GameServerOutputArrayDTOAPI.md)
+- [GameServerOutputDTO](../interfaces/takaro_apiclient.GameServerOutputDTO.md)
+- [GameServerOutputDTOAPI](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md)
+- [GameServerSearchInputAllowedFilters](../interfaces/takaro_apiclient.GameServerSearchInputAllowedFilters.md)
+- [GameServerSearchInputDTO](../interfaces/takaro_apiclient.GameServerSearchInputDTO.md)
+- [GameServerTestReachabilityDTOAPI](../interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md)
+- [GameServerTestReachabilityInputDTO](../interfaces/takaro_apiclient.GameServerTestReachabilityInputDTO.md)
+- [GameServerUpdateDTO](../interfaces/takaro_apiclient.GameServerUpdateDTO.md)
+- [GetSettingsInput](../interfaces/takaro_apiclient.GetSettingsInput.md)
+- [GetSettingsOneInput](../interfaces/takaro_apiclient.GetSettingsOneInput.md)
+- [GetUserDTO](../interfaces/takaro_apiclient.GetUserDTO.md)
+- [HealthOutputDTO](../interfaces/takaro_apiclient.HealthOutputDTO.md)
+- [HookCreateDTO](../interfaces/takaro_apiclient.HookCreateDTO.md)
+- [HookOutputArrayDTOAPI](../interfaces/takaro_apiclient.HookOutputArrayDTOAPI.md)
+- [HookOutputDTO](../interfaces/takaro_apiclient.HookOutputDTO.md)
+- [HookOutputDTOAPI](../interfaces/takaro_apiclient.HookOutputDTOAPI.md)
+- [HookSearchInputAllowedFilters](../interfaces/takaro_apiclient.HookSearchInputAllowedFilters.md)
+- [HookSearchInputDTO](../interfaces/takaro_apiclient.HookSearchInputDTO.md)
+- [HookUpdateDTO](../interfaces/takaro_apiclient.HookUpdateDTO.md)
+- [IGamePlayer](../interfaces/takaro_apiclient.IGamePlayer.md)
+- [ITakaroQuery](../interfaces/takaro_apiclient.ITakaroQuery.md)
+- [LoginCreateDTO](../interfaces/takaro_apiclient.LoginCreateDTO.md)
+- [LoginDTO](../interfaces/takaro_apiclient.LoginDTO.md)
+- [LoginOutputDTO](../interfaces/takaro_apiclient.LoginOutputDTO.md)
+- [LoginOutputDTOAPI](../interfaces/takaro_apiclient.LoginOutputDTOAPI.md)
+- [LoginUpdateDTO](../interfaces/takaro_apiclient.LoginUpdateDTO.md)
+- [MetadataOutput](../interfaces/takaro_apiclient.MetadataOutput.md)
+- [MockConnectionInfo](../interfaces/takaro_apiclient.MockConnectionInfo.md)
+- [ModuleCreateDTO](../interfaces/takaro_apiclient.ModuleCreateDTO.md)
+- [ModuleOutputArrayDTOAPI](../interfaces/takaro_apiclient.ModuleOutputArrayDTOAPI.md)
+- [ModuleOutputDTO](../interfaces/takaro_apiclient.ModuleOutputDTO.md)
+- [ModuleOutputDTOAPI](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md)
+- [ModuleSearchInputAllowedFilters](../interfaces/takaro_apiclient.ModuleSearchInputAllowedFilters.md)
+- [ModuleSearchInputDTO](../interfaces/takaro_apiclient.ModuleSearchInputDTO.md)
+- [ModuleUpdateDTO](../interfaces/takaro_apiclient.ModuleUpdateDTO.md)
+- [ParamId](../interfaces/takaro_apiclient.ParamId.md)
+- [ParamIdAndRoleId](../interfaces/takaro_apiclient.ParamIdAndRoleId.md)
+- [ParamKey](../interfaces/takaro_apiclient.ParamKey.md)
+- [PlayerCreateDTO](../interfaces/takaro_apiclient.PlayerCreateDTO.md)
+- [PlayerOutputArrayDTOAPI](../interfaces/takaro_apiclient.PlayerOutputArrayDTOAPI.md)
+- [PlayerOutputDTO](../interfaces/takaro_apiclient.PlayerOutputDTO.md)
+- [PlayerOutputDTOAPI](../interfaces/takaro_apiclient.PlayerOutputDTOAPI.md)
+- [PlayerSearchInputAllowedFilters](../interfaces/takaro_apiclient.PlayerSearchInputAllowedFilters.md)
+- [PlayerSearchInputDTO](../interfaces/takaro_apiclient.PlayerSearchInputDTO.md)
+- [PlayerUpdateDTO](../interfaces/takaro_apiclient.PlayerUpdateDTO.md)
+- [RoleCreateInputDTO](../interfaces/takaro_apiclient.RoleCreateInputDTO.md)
+- [RoleOutputArrayDTOAPI](../interfaces/takaro_apiclient.RoleOutputArrayDTOAPI.md)
+- [RoleOutputDTO](../interfaces/takaro_apiclient.RoleOutputDTO.md)
+- [RoleOutputDTOAPI](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md)
+- [RoleSearchInputAllowedFilters](../interfaces/takaro_apiclient.RoleSearchInputAllowedFilters.md)
+- [RoleSearchInputDTO](../interfaces/takaro_apiclient.RoleSearchInputDTO.md)
+- [RoleUpdateInputDTO](../interfaces/takaro_apiclient.RoleUpdateInputDTO.md)
+- [RustConfig](../interfaces/takaro_apiclient.RustConfig.md)
+- [RustConnectionInfo](../interfaces/takaro_apiclient.RustConnectionInfo.md)
+- [SdtdConnectionInfo](../interfaces/takaro_apiclient.SdtdConnectionInfo.md)
+- [SearchRoleInputDTO](../interfaces/takaro_apiclient.SearchRoleInputDTO.md)
+- [Settings](../interfaces/takaro_apiclient.Settings.md)
+- [SettingsOutputDTOAPI](../interfaces/takaro_apiclient.SettingsOutputDTOAPI.md)
+- [SettingsOutputObjectDTOAPI](../interfaces/takaro_apiclient.SettingsOutputObjectDTOAPI.md)
+- [SettingsSetDTO](../interfaces/takaro_apiclient.SettingsSetDTO.md)
+- [TestReachabilityOutput](../interfaces/takaro_apiclient.TestReachabilityOutput.md)
+- [UserCreateInputDTO](../interfaces/takaro_apiclient.UserCreateInputDTO.md)
+- [UserOutputArrayDTOAPI](../interfaces/takaro_apiclient.UserOutputArrayDTOAPI.md)
+- [UserOutputDTO](../interfaces/takaro_apiclient.UserOutputDTO.md)
+- [UserOutputDTOAPI](../interfaces/takaro_apiclient.UserOutputDTOAPI.md)
+- [UserOutputWithRolesDTO](../interfaces/takaro_apiclient.UserOutputWithRolesDTO.md)
+- [UserSearchInputAllowedFilters](../interfaces/takaro_apiclient.UserSearchInputAllowedFilters.md)
+- [UserSearchInputDTO](../interfaces/takaro_apiclient.UserSearchInputDTO.md)
+- [UserUpdateDTO](../interfaces/takaro_apiclient.UserUpdateDTO.md)
+
+## Type Aliases
+
+### BaseEventTimestamp
+
+Ƭ **BaseEventTimestamp**: `string`
+
+**`Export`**
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:97](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L97)
+
+___
+
+### BaseEventTypeEnum
+
+Ƭ **BaseEventTypeEnum**: typeof [`BaseEventTypeEnum`](takaro_apiclient.md#baseeventtypeenum-1)[keyof typeof [`BaseEventTypeEnum`](takaro_apiclient.md#baseeventtypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:83](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L83)
+
+[packages/lib-apiclient/src/generated/api.ts:90](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L90)
+
+___
+
+### CapabilityOutputDTOCapabilityEnum
+
+Ƭ **CapabilityOutputDTOCapabilityEnum**: typeof [`CapabilityOutputDTOCapabilityEnum`](takaro_apiclient.md#capabilityoutputdtocapabilityenum-1)[keyof typeof [`CapabilityOutputDTOCapabilityEnum`](takaro_apiclient.md#capabilityoutputdtocapabilityenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:119](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L119)
+
+[packages/lib-apiclient/src/generated/api.ts:143](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L143)
+
+___
+
+### CommandSearchInputDTOSortDirectionEnum
+
+Ƭ **CommandSearchInputDTOSortDirectionEnum**: typeof [`CommandSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#commandsearchinputdtosortdirectionenum-1)[keyof typeof [`CommandSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#commandsearchinputdtosortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:339](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L339)
+
+[packages/lib-apiclient/src/generated/api.ts:344](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L344)
+
+___
+
+### CronJobSearchInputDTOSortDirectionEnum
+
+Ƭ **CronJobSearchInputDTOSortDirectionEnum**: typeof [`CronJobSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#cronjobsearchinputdtosortdirectionenum-1)[keyof typeof [`CronJobSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#cronjobsearchinputdtosortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:559](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L559)
+
+[packages/lib-apiclient/src/generated/api.ts:564](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L564)
+
+___
+
+### DomainSearchInputDTOSortDirectionEnum
+
+Ƭ **DomainSearchInputDTOSortDirectionEnum**: typeof [`DomainSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#domainsearchinputdtosortdirectionenum-1)[keyof typeof [`DomainSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#domainsearchinputdtosortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:781](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L781)
+
+[packages/lib-apiclient/src/generated/api.ts:786](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L786)
+
+___
+
+### EventChatMessageTypeEnum
+
+Ƭ **EventChatMessageTypeEnum**: typeof [`EventChatMessageTypeEnum`](takaro_apiclient.md#eventchatmessagetypeenum-1)[keyof typeof [`EventChatMessageTypeEnum`](takaro_apiclient.md#eventchatmessagetypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:847](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L847)
+
+[packages/lib-apiclient/src/generated/api.ts:854](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L854)
+
+___
+
+### EventPlayerConnectedTypeEnum
+
+Ƭ **EventPlayerConnectedTypeEnum**: typeof [`EventPlayerConnectedTypeEnum`](takaro_apiclient.md#eventplayerconnectedtypeenum-1)[keyof typeof [`EventPlayerConnectedTypeEnum`](takaro_apiclient.md#eventplayerconnectedtypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:889](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L889)
+
+[packages/lib-apiclient/src/generated/api.ts:896](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L896)
+
+___
+
+### EventPlayerDisconnectedTypeEnum
+
+Ƭ **EventPlayerDisconnectedTypeEnum**: typeof [`EventPlayerDisconnectedTypeEnum`](takaro_apiclient.md#eventplayerdisconnectedtypeenum-1)[keyof typeof [`EventPlayerDisconnectedTypeEnum`](takaro_apiclient.md#eventplayerdisconnectedtypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:931](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L931)
+
+[packages/lib-apiclient/src/generated/api.ts:938](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L938)
+
+___
+
+### FunctionSearchInputDTOSortDirectionEnum
+
+Ƭ **FunctionSearchInputDTOSortDirectionEnum**: typeof [`FunctionSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#functionsearchinputdtosortdirectionenum-1)[keyof typeof [`FunctionSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#functionsearchinputdtosortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1068](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1068)
+
+[packages/lib-apiclient/src/generated/api.ts:1073](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1073)
+
+___
+
+### GameServerCreateDTOTypeEnum
+
+Ƭ **GameServerCreateDTOTypeEnum**: typeof [`GameServerCreateDTOTypeEnum`](takaro_apiclient.md#gameservercreatedtotypeenum-1)[keyof typeof [`GameServerCreateDTOTypeEnum`](takaro_apiclient.md#gameservercreatedtotypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1115](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1115)
+
+[packages/lib-apiclient/src/generated/api.ts:1121](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1121)
+
+___
+
+### GameServerOutputDTOTypeEnum
+
+Ƭ **GameServerOutputDTOTypeEnum**: typeof [`GameServerOutputDTOTypeEnum`](takaro_apiclient.md#gameserveroutputdtotypeenum-1)[keyof typeof [`GameServerOutputDTOTypeEnum`](takaro_apiclient.md#gameserveroutputdtotypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1175](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1175)
+
+[packages/lib-apiclient/src/generated/api.ts:1181](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1181)
+
+___
+
+### GameServerSearchInputDTOSortDirectionEnum
+
+Ƭ **GameServerSearchInputDTOSortDirectionEnum**: typeof [`GameServerSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#gameserversearchinputdtosortdirectionenum-1)[keyof typeof [`GameServerSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#gameserversearchinputdtosortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1260](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1260)
+
+[packages/lib-apiclient/src/generated/api.ts:1265](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1265)
+
+___
+
+### GameServerTestReachabilityInputDTOTypeEnum
+
+Ƭ **GameServerTestReachabilityInputDTOTypeEnum**: typeof [`GameServerTestReachabilityInputDTOTypeEnum`](takaro_apiclient.md#gameservertestreachabilityinputdtotypeenum-1)[keyof typeof [`GameServerTestReachabilityInputDTOTypeEnum`](takaro_apiclient.md#gameservertestreachabilityinputdtotypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1307](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1307)
+
+[packages/lib-apiclient/src/generated/api.ts:1313](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1313)
+
+___
+
+### GameServerUpdateDTOTypeEnum
+
+Ƭ **GameServerUpdateDTOTypeEnum**: typeof [`GameServerUpdateDTOTypeEnum`](takaro_apiclient.md#gameserverupdatedtotypeenum-1)[keyof typeof [`GameServerUpdateDTOTypeEnum`](takaro_apiclient.md#gameserverupdatedtotypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1342](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1342)
+
+[packages/lib-apiclient/src/generated/api.ts:1348](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1348)
+
+___
+
+### GetSettingsInputKeysEnum
+
+Ƭ **GetSettingsInputKeysEnum**: typeof [`GetSettingsInputKeysEnum`](takaro_apiclient.md#getsettingsinputkeysenum-1)[keyof typeof [`GetSettingsInputKeysEnum`](takaro_apiclient.md#getsettingsinputkeysenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1371](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1371)
+
+[packages/lib-apiclient/src/generated/api.ts:1376](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1376)
+
+___
+
+### HookCreateDTOEventTypeEnum
+
+Ƭ **HookCreateDTOEventTypeEnum**: typeof [`HookCreateDTOEventTypeEnum`](takaro_apiclient.md#hookcreatedtoeventtypeenum-1)[keyof typeof [`HookCreateDTOEventTypeEnum`](takaro_apiclient.md#hookcreatedtoeventtypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1462](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1462)
+
+[packages/lib-apiclient/src/generated/api.ts:1469](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1469)
+
+___
+
+### HookOutputDTOEventTypeEnum
+
+Ƭ **HookOutputDTOEventTypeEnum**: typeof [`HookOutputDTOEventTypeEnum`](takaro_apiclient.md#hookoutputdtoeventtypeenum-1)[keyof typeof [`HookOutputDTOEventTypeEnum`](takaro_apiclient.md#hookoutputdtoeventtypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1535](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1535)
+
+[packages/lib-apiclient/src/generated/api.ts:1542](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1542)
+
+___
+
+### HookSearchInputAllowedFiltersEventTypeEnum
+
+Ƭ **HookSearchInputAllowedFiltersEventTypeEnum**: typeof [`HookSearchInputAllowedFiltersEventTypeEnum`](takaro_apiclient.md#hooksearchinputallowedfilterseventtypeenum-1)[keyof typeof [`HookSearchInputAllowedFiltersEventTypeEnum`](takaro_apiclient.md#hooksearchinputallowedfilterseventtypeenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1596](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1596)
+
+[packages/lib-apiclient/src/generated/api.ts:1603](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1603)
+
+___
+
+### HookSearchInputDTOSortDirectionEnum
+
+Ƭ **HookSearchInputDTOSortDirectionEnum**: typeof [`HookSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#hooksearchinputdtosortdirectionenum-1)[keyof typeof [`HookSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#hooksearchinputdtosortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1650](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1650)
+
+[packages/lib-apiclient/src/generated/api.ts:1655](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1655)
+
+___
+
+### ITakaroAPIAxiosResponse
+
+Ƭ **ITakaroAPIAxiosResponse**<`T`\>: [`AxiosResponse`](../interfaces/takaro_apiclient.AxiosResponse.md)<`T`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/main.ts:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/main.ts#L10)
+
+___
+
+### ITakaroQuerySortDirectionEnum
+
+Ƭ **ITakaroQuerySortDirectionEnum**: typeof [`ITakaroQuerySortDirectionEnum`](takaro_apiclient.md#itakaroquerysortdirectionenum-1)[keyof typeof [`ITakaroQuerySortDirectionEnum`](takaro_apiclient.md#itakaroquerysortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1788](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1788)
+
+[packages/lib-apiclient/src/generated/api.ts:1793](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1793)
+
+___
+
+### MetadataOutputServerTime
+
+Ƭ **MetadataOutputServerTime**: `string`
+
+**`Export`**
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1932](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1932)
+
+___
+
+### ModuleSearchInputDTOSortDirectionEnum
+
+Ƭ **ModuleSearchInputDTOSortDirectionEnum**: typeof [`ModuleSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#modulesearchinputdtosortdirectionenum-1)[keyof typeof [`ModuleSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#modulesearchinputdtosortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2128](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2128)
+
+[packages/lib-apiclient/src/generated/api.ts:2133](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2133)
+
+___
+
+### ParamKeyKeyEnum
+
+Ƭ **ParamKeyKeyEnum**: typeof [`ParamKeyKeyEnum`](takaro_apiclient.md#paramkeykeyenum-1)[keyof typeof [`ParamKeyKeyEnum`](takaro_apiclient.md#paramkeykeyenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2207](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2207)
+
+[packages/lib-apiclient/src/generated/api.ts:2212](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2212)
+
+___
+
+### PlayerSearchInputDTOSortDirectionEnum
+
+Ƭ **PlayerSearchInputDTOSortDirectionEnum**: typeof [`PlayerSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#playersearchinputdtosortdirectionenum-1)[keyof typeof [`PlayerSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#playersearchinputdtosortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2402](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2402)
+
+[packages/lib-apiclient/src/generated/api.ts:2407](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2407)
+
+___
+
+### RoleCreateInputDTOCapabilitiesEnum
+
+Ƭ **RoleCreateInputDTOCapabilitiesEnum**: typeof [`RoleCreateInputDTOCapabilitiesEnum`](takaro_apiclient.md#rolecreateinputdtocapabilitiesenum-1)[keyof typeof [`RoleCreateInputDTOCapabilitiesEnum`](takaro_apiclient.md#rolecreateinputdtocapabilitiesenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2443](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2443)
+
+[packages/lib-apiclient/src/generated/api.ts:2467](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2467)
+
+___
+
+### RoleSearchInputDTOSortDirectionEnum
+
+Ƭ **RoleSearchInputDTOSortDirectionEnum**: typeof [`RoleSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#rolesearchinputdtosortdirectionenum-1)[keyof typeof [`RoleSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#rolesearchinputdtosortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2590](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2590)
+
+[packages/lib-apiclient/src/generated/api.ts:2595](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2595)
+
+___
+
+### RoleUpdateInputDTOCapabilitiesEnum
+
+Ƭ **RoleUpdateInputDTOCapabilitiesEnum**: typeof [`RoleUpdateInputDTOCapabilitiesEnum`](takaro_apiclient.md#roleupdateinputdtocapabilitiesenum-1)[keyof typeof [`RoleUpdateInputDTOCapabilitiesEnum`](takaro_apiclient.md#roleupdateinputdtocapabilitiesenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2618](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2618)
+
+[packages/lib-apiclient/src/generated/api.ts:2642](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2642)
+
+___
+
+### UserSearchInputDTOSortDirectionEnum
+
+Ƭ **UserSearchInputDTOSortDirectionEnum**: typeof [`UserSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#usersearchinputdtosortdirectionenum-1)[keyof typeof [`UserSearchInputDTOSortDirectionEnum`](takaro_apiclient.md#usersearchinputdtosortdirectionenum-1)]
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3010](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3010)
+
+[packages/lib-apiclient/src/generated/api.ts:3015](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3015)
+
+## Variables
+
+### BaseEventTypeEnum
+
+• `Const` **BaseEventTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `ChatMessage` | ``"chat-message"`` |
+| `Log` | ``"log"`` |
+| `PlayerConnected` | ``"player-connected"`` |
+| `PlayerDisconnected` | ``"player-disconnected"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:83](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L83)
+
+[packages/lib-apiclient/src/generated/api.ts:90](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L90)
+
+___
+
+### CapabilityOutputDTOCapabilityEnum
+
+• `Const` **CapabilityOutputDTOCapabilityEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `ManageCommands` | ``"MANAGE_COMMANDS"`` |
+| `ManageCronjobs` | ``"MANAGE_CRONJOBS"`` |
+| `ManageFunctions` | ``"MANAGE_FUNCTIONS"`` |
+| `ManageGameservers` | ``"MANAGE_GAMESERVERS"`` |
+| `ManageHooks` | ``"MANAGE_HOOKS"`` |
+| `ManageModules` | ``"MANAGE_MODULES"`` |
+| `ManagePlayers` | ``"MANAGE_PLAYERS"`` |
+| `ManageRoles` | ``"MANAGE_ROLES"`` |
+| `ManageSettings` | ``"MANAGE_SETTINGS"`` |
+| `ManageUsers` | ``"MANAGE_USERS"`` |
+| `ReadCommands` | ``"READ_COMMANDS"`` |
+| `ReadCronjobs` | ``"READ_CRONJOBS"`` |
+| `ReadFunctions` | ``"READ_FUNCTIONS"`` |
+| `ReadGameservers` | ``"READ_GAMESERVERS"`` |
+| `ReadHooks` | ``"READ_HOOKS"`` |
+| `ReadModules` | ``"READ_MODULES"`` |
+| `ReadPlayers` | ``"READ_PLAYERS"`` |
+| `ReadRoles` | ``"READ_ROLES"`` |
+| `ReadSettings` | ``"READ_SETTINGS"`` |
+| `ReadUsers` | ``"READ_USERS"`` |
+| `Root` | ``"ROOT"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:119](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L119)
+
+[packages/lib-apiclient/src/generated/api.ts:143](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L143)
+
+___
+
+### CommandSearchInputDTOSortDirectionEnum
+
+• `Const` **CommandSearchInputDTOSortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:339](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L339)
+
+[packages/lib-apiclient/src/generated/api.ts:344](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L344)
+
+___
+
+### CronJobSearchInputDTOSortDirectionEnum
+
+• `Const` **CronJobSearchInputDTOSortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:559](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L559)
+
+[packages/lib-apiclient/src/generated/api.ts:564](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L564)
+
+___
+
+### DomainSearchInputDTOSortDirectionEnum
+
+• `Const` **DomainSearchInputDTOSortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:781](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L781)
+
+[packages/lib-apiclient/src/generated/api.ts:786](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L786)
+
+___
+
+### EventChatMessageTypeEnum
+
+• `Const` **EventChatMessageTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `ChatMessage` | ``"chat-message"`` |
+| `Log` | ``"log"`` |
+| `PlayerConnected` | ``"player-connected"`` |
+| `PlayerDisconnected` | ``"player-disconnected"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:847](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L847)
+
+[packages/lib-apiclient/src/generated/api.ts:854](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L854)
+
+___
+
+### EventPlayerConnectedTypeEnum
+
+• `Const` **EventPlayerConnectedTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `ChatMessage` | ``"chat-message"`` |
+| `Log` | ``"log"`` |
+| `PlayerConnected` | ``"player-connected"`` |
+| `PlayerDisconnected` | ``"player-disconnected"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:889](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L889)
+
+[packages/lib-apiclient/src/generated/api.ts:896](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L896)
+
+___
+
+### EventPlayerDisconnectedTypeEnum
+
+• `Const` **EventPlayerDisconnectedTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `ChatMessage` | ``"chat-message"`` |
+| `Log` | ``"log"`` |
+| `PlayerConnected` | ``"player-connected"`` |
+| `PlayerDisconnected` | ``"player-disconnected"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:931](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L931)
+
+[packages/lib-apiclient/src/generated/api.ts:938](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L938)
+
+___
+
+### FunctionSearchInputDTOSortDirectionEnum
+
+• `Const` **FunctionSearchInputDTOSortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1068](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1068)
+
+[packages/lib-apiclient/src/generated/api.ts:1073](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1073)
+
+___
+
+### GameServerCreateDTOTypeEnum
+
+• `Const` **GameServerCreateDTOTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Mock` | ``"MOCK"`` |
+| `Rust` | ``"RUST"`` |
+| `Sevendaystodie` | ``"SEVENDAYSTODIE"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1115](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1115)
+
+[packages/lib-apiclient/src/generated/api.ts:1121](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1121)
+
+___
+
+### GameServerOutputDTOTypeEnum
+
+• `Const` **GameServerOutputDTOTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Mock` | ``"MOCK"`` |
+| `Rust` | ``"RUST"`` |
+| `Sevendaystodie` | ``"SEVENDAYSTODIE"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1175](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1175)
+
+[packages/lib-apiclient/src/generated/api.ts:1181](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1181)
+
+___
+
+### GameServerSearchInputDTOSortDirectionEnum
+
+• `Const` **GameServerSearchInputDTOSortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1260](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1260)
+
+[packages/lib-apiclient/src/generated/api.ts:1265](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1265)
+
+___
+
+### GameServerTestReachabilityInputDTOTypeEnum
+
+• `Const` **GameServerTestReachabilityInputDTOTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Mock` | ``"MOCK"`` |
+| `Rust` | ``"RUST"`` |
+| `Sevendaystodie` | ``"SEVENDAYSTODIE"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1307](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1307)
+
+[packages/lib-apiclient/src/generated/api.ts:1313](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1313)
+
+___
+
+### GameServerUpdateDTOTypeEnum
+
+• `Const` **GameServerUpdateDTOTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Mock` | ``"MOCK"`` |
+| `Rust` | ``"RUST"`` |
+| `Sevendaystodie` | ``"SEVENDAYSTODIE"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1342](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1342)
+
+[packages/lib-apiclient/src/generated/api.ts:1348](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1348)
+
+___
+
+### GetSettingsInputKeysEnum
+
+• `Const` **GetSettingsInputKeysEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `CommandPrefix` | ``"commandPrefix"`` |
+| `ServerChatName` | ``"serverChatName"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1371](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1371)
+
+[packages/lib-apiclient/src/generated/api.ts:1376](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1376)
+
+___
+
+### HookCreateDTOEventTypeEnum
+
+• `Const` **HookCreateDTOEventTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `ChatMessage` | ``"chat-message"`` |
+| `Log` | ``"log"`` |
+| `PlayerConnected` | ``"player-connected"`` |
+| `PlayerDisconnected` | ``"player-disconnected"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1462](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1462)
+
+[packages/lib-apiclient/src/generated/api.ts:1469](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1469)
+
+___
+
+### HookOutputDTOEventTypeEnum
+
+• `Const` **HookOutputDTOEventTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `ChatMessage` | ``"chat-message"`` |
+| `Log` | ``"log"`` |
+| `PlayerConnected` | ``"player-connected"`` |
+| `PlayerDisconnected` | ``"player-disconnected"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1535](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1535)
+
+[packages/lib-apiclient/src/generated/api.ts:1542](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1542)
+
+___
+
+### HookSearchInputAllowedFiltersEventTypeEnum
+
+• `Const` **HookSearchInputAllowedFiltersEventTypeEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `ChatMessage` | ``"chat-message"`` |
+| `Log` | ``"log"`` |
+| `PlayerConnected` | ``"player-connected"`` |
+| `PlayerDisconnected` | ``"player-disconnected"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1596](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1596)
+
+[packages/lib-apiclient/src/generated/api.ts:1603](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1603)
+
+___
+
+### HookSearchInputDTOSortDirectionEnum
+
+• `Const` **HookSearchInputDTOSortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1650](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1650)
+
+[packages/lib-apiclient/src/generated/api.ts:1655](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1655)
+
+___
+
+### ITakaroQuerySortDirectionEnum
+
+• `Const` **ITakaroQuerySortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:1788](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1788)
+
+[packages/lib-apiclient/src/generated/api.ts:1793](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L1793)
+
+___
+
+### ModuleSearchInputDTOSortDirectionEnum
+
+• `Const` **ModuleSearchInputDTOSortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2128](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2128)
+
+[packages/lib-apiclient/src/generated/api.ts:2133](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2133)
+
+___
+
+### ParamKeyKeyEnum
+
+• `Const` **ParamKeyKeyEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `CommandPrefix` | ``"commandPrefix"`` |
+| `ServerChatName` | ``"serverChatName"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2207](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2207)
+
+[packages/lib-apiclient/src/generated/api.ts:2212](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2212)
+
+___
+
+### PlayerSearchInputDTOSortDirectionEnum
+
+• `Const` **PlayerSearchInputDTOSortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2402](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2402)
+
+[packages/lib-apiclient/src/generated/api.ts:2407](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2407)
+
+___
+
+### RoleCreateInputDTOCapabilitiesEnum
+
+• `Const` **RoleCreateInputDTOCapabilitiesEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `ManageCommands` | ``"MANAGE_COMMANDS"`` |
+| `ManageCronjobs` | ``"MANAGE_CRONJOBS"`` |
+| `ManageFunctions` | ``"MANAGE_FUNCTIONS"`` |
+| `ManageGameservers` | ``"MANAGE_GAMESERVERS"`` |
+| `ManageHooks` | ``"MANAGE_HOOKS"`` |
+| `ManageModules` | ``"MANAGE_MODULES"`` |
+| `ManagePlayers` | ``"MANAGE_PLAYERS"`` |
+| `ManageRoles` | ``"MANAGE_ROLES"`` |
+| `ManageSettings` | ``"MANAGE_SETTINGS"`` |
+| `ManageUsers` | ``"MANAGE_USERS"`` |
+| `ReadCommands` | ``"READ_COMMANDS"`` |
+| `ReadCronjobs` | ``"READ_CRONJOBS"`` |
+| `ReadFunctions` | ``"READ_FUNCTIONS"`` |
+| `ReadGameservers` | ``"READ_GAMESERVERS"`` |
+| `ReadHooks` | ``"READ_HOOKS"`` |
+| `ReadModules` | ``"READ_MODULES"`` |
+| `ReadPlayers` | ``"READ_PLAYERS"`` |
+| `ReadRoles` | ``"READ_ROLES"`` |
+| `ReadSettings` | ``"READ_SETTINGS"`` |
+| `ReadUsers` | ``"READ_USERS"`` |
+| `Root` | ``"ROOT"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2443](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2443)
+
+[packages/lib-apiclient/src/generated/api.ts:2467](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2467)
+
+___
+
+### RoleSearchInputDTOSortDirectionEnum
+
+• `Const` **RoleSearchInputDTOSortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2590](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2590)
+
+[packages/lib-apiclient/src/generated/api.ts:2595](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2595)
+
+___
+
+### RoleUpdateInputDTOCapabilitiesEnum
+
+• `Const` **RoleUpdateInputDTOCapabilitiesEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `ManageCommands` | ``"MANAGE_COMMANDS"`` |
+| `ManageCronjobs` | ``"MANAGE_CRONJOBS"`` |
+| `ManageFunctions` | ``"MANAGE_FUNCTIONS"`` |
+| `ManageGameservers` | ``"MANAGE_GAMESERVERS"`` |
+| `ManageHooks` | ``"MANAGE_HOOKS"`` |
+| `ManageModules` | ``"MANAGE_MODULES"`` |
+| `ManagePlayers` | ``"MANAGE_PLAYERS"`` |
+| `ManageRoles` | ``"MANAGE_ROLES"`` |
+| `ManageSettings` | ``"MANAGE_SETTINGS"`` |
+| `ManageUsers` | ``"MANAGE_USERS"`` |
+| `ReadCommands` | ``"READ_COMMANDS"`` |
+| `ReadCronjobs` | ``"READ_CRONJOBS"`` |
+| `ReadFunctions` | ``"READ_FUNCTIONS"`` |
+| `ReadGameservers` | ``"READ_GAMESERVERS"`` |
+| `ReadHooks` | ``"READ_HOOKS"`` |
+| `ReadModules` | ``"READ_MODULES"`` |
+| `ReadPlayers` | ``"READ_PLAYERS"`` |
+| `ReadRoles` | ``"READ_ROLES"`` |
+| `ReadSettings` | ``"READ_SETTINGS"`` |
+| `ReadUsers` | ``"READ_USERS"`` |
+| `Root` | ``"ROOT"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:2618](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2618)
+
+[packages/lib-apiclient/src/generated/api.ts:2642](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L2642)
+
+___
+
+### UserSearchInputDTOSortDirectionEnum
+
+• `Const` **UserSearchInputDTOSortDirectionEnum**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `Asc` | ``"asc"`` |
+| `Desc` | ``"desc"`` |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3010](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3010)
+
+[packages/lib-apiclient/src/generated/api.ts:3015](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3015)
+
+## Functions
+
+### CommandApiAxiosParamCreator
+
+▸ **CommandApiAxiosParamCreator**(`configuration?`): `Object`
+
+CommandApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `commandControllerCreate` | (`commandCreateDTO?`: [`CommandCreateDTO`](../interfaces/takaro_apiclient.CommandCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `commandControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `commandControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `commandControllerSearch` | (`commandSearchInputDTO?`: [`CommandSearchInputDTO`](../interfaces/takaro_apiclient.CommandSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `commandControllerUpdate` | (`id`: `string`, `commandUpdateDTO?`: [`CommandUpdateDTO`](../interfaces/takaro_apiclient.CommandUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3036](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3036)
+
+___
+
+### CommandApiFactory
+
+▸ **CommandApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+CommandApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `commandControllerCreate` | (`commandCreateDTO?`: [`CommandCreateDTO`](../interfaces/takaro_apiclient.CommandCreateDTO.md), `options?`: `any`) => `AxiosPromise`<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md)\> |
+| `commandControllerGetOne` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md)\> |
+| `commandControllerRemove` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `commandControllerSearch` | (`commandSearchInputDTO?`: [`CommandSearchInputDTO`](../interfaces/takaro_apiclient.CommandSearchInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`CommandOutputArrayDTOAPI`](../interfaces/takaro_apiclient.CommandOutputArrayDTOAPI.md)\> |
+| `commandControllerUpdate` | (`id`: `string`, `commandUpdateDTO?`: [`CommandUpdateDTO`](../interfaces/takaro_apiclient.CommandUpdateDTO.md), `options?`: `any`) => `AxiosPromise`<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3444](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3444)
+
+___
+
+### CommandApiFp
+
+▸ **CommandApiFp**(`configuration?`): `Object`
+
+CommandApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `commandControllerCreate` | (`commandCreateDTO?`: [`CommandCreateDTO`](../interfaces/takaro_apiclient.CommandCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md)\>\> |
+| `commandControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md)\>\> |
+| `commandControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `commandControllerSearch` | (`commandSearchInputDTO?`: [`CommandSearchInputDTO`](../interfaces/takaro_apiclient.CommandSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`CommandOutputArrayDTOAPI`](../interfaces/takaro_apiclient.CommandOutputArrayDTOAPI.md)\>\> |
+| `commandControllerUpdate` | (`id`: `string`, `commandUpdateDTO?`: [`CommandUpdateDTO`](../interfaces/takaro_apiclient.CommandUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`CommandOutputDTOAPI`](../interfaces/takaro_apiclient.CommandOutputDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3300](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3300)
+
+___
+
+### CronJobApiAxiosParamCreator
+
+▸ **CronJobApiAxiosParamCreator**(`configuration?`): `Object`
+
+CronJobApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `cronJobControllerCreate` | (`cronJobCreateDTO?`: [`CronJobCreateDTO`](../interfaces/takaro_apiclient.CronJobCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `cronJobControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `cronJobControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `cronJobControllerSearch` | (`cronJobSearchInputDTO?`: [`CronJobSearchInputDTO`](../interfaces/takaro_apiclient.CronJobSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `cronJobControllerUpdate` | (`id`: `string`, `cronJobUpdateDTO?`: [`CronJobUpdateDTO`](../interfaces/takaro_apiclient.CronJobUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3624](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3624)
+
+___
+
+### CronJobApiFactory
+
+▸ **CronJobApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+CronJobApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `cronJobControllerCreate` | (`cronJobCreateDTO?`: [`CronJobCreateDTO`](../interfaces/takaro_apiclient.CronJobCreateDTO.md), `options?`: `any`) => `AxiosPromise`<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md)\> |
+| `cronJobControllerGetOne` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md)\> |
+| `cronJobControllerRemove` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `cronJobControllerSearch` | (`cronJobSearchInputDTO?`: [`CronJobSearchInputDTO`](../interfaces/takaro_apiclient.CronJobSearchInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`CronJobOutputArrayDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputArrayDTOAPI.md)\> |
+| `cronJobControllerUpdate` | (`id`: `string`, `cronJobUpdateDTO?`: [`CronJobUpdateDTO`](../interfaces/takaro_apiclient.CronJobUpdateDTO.md), `options?`: `any`) => `AxiosPromise`<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4032](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4032)
+
+___
+
+### CronJobApiFp
+
+▸ **CronJobApiFp**(`configuration?`): `Object`
+
+CronJobApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `cronJobControllerCreate` | (`cronJobCreateDTO?`: [`CronJobCreateDTO`](../interfaces/takaro_apiclient.CronJobCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md)\>\> |
+| `cronJobControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md)\>\> |
+| `cronJobControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `cronJobControllerSearch` | (`cronJobSearchInputDTO?`: [`CronJobSearchInputDTO`](../interfaces/takaro_apiclient.CronJobSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`CronJobOutputArrayDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputArrayDTOAPI.md)\>\> |
+| `cronJobControllerUpdate` | (`id`: `string`, `cronJobUpdateDTO?`: [`CronJobUpdateDTO`](../interfaces/takaro_apiclient.CronJobUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`CronJobOutputDTOAPI`](../interfaces/takaro_apiclient.CronJobOutputDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:3888](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L3888)
+
+___
+
+### DomainApiAxiosParamCreator
+
+▸ **DomainApiAxiosParamCreator**(`configuration?`): `Object`
+
+DomainApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `domainControllerCreate` | (`body?`: `any`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `domainControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `domainControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `domainControllerSearch` | (`domainSearchInputDTO?`: [`DomainSearchInputDTO`](../interfaces/takaro_apiclient.DomainSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `domainControllerUpdate` | (`id`: `string`, `domainUpdateInputDTO?`: [`DomainUpdateInputDTO`](../interfaces/takaro_apiclient.DomainUpdateInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4212](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4212)
+
+___
+
+### DomainApiFactory
+
+▸ **DomainApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+DomainApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `domainControllerCreate` | (`body?`: `any`, `options?`: `any`) => `AxiosPromise`<[`DomainCreateOutputDTOAPI`](../interfaces/takaro_apiclient.DomainCreateOutputDTOAPI.md)\> |
+| `domainControllerGetOne` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`DomainOutputDTOAPI`](../interfaces/takaro_apiclient.DomainOutputDTOAPI.md)\> |
+| `domainControllerRemove` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `domainControllerSearch` | (`domainSearchInputDTO?`: [`DomainSearchInputDTO`](../interfaces/takaro_apiclient.DomainSearchInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`DomainOutputArrayDTOAPI`](../interfaces/takaro_apiclient.DomainOutputArrayDTOAPI.md)\> |
+| `domainControllerUpdate` | (`id`: `string`, `domainUpdateInputDTO?`: [`DomainUpdateInputDTO`](../interfaces/takaro_apiclient.DomainUpdateInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`DomainOutputDTOAPI`](../interfaces/takaro_apiclient.DomainOutputDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4627](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4627)
+
+___
+
+### DomainApiFp
+
+▸ **DomainApiFp**(`configuration?`): `Object`
+
+DomainApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `domainControllerCreate` | (`body?`: `any`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`DomainCreateOutputDTOAPI`](../interfaces/takaro_apiclient.DomainCreateOutputDTOAPI.md)\>\> |
+| `domainControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`DomainOutputDTOAPI`](../interfaces/takaro_apiclient.DomainOutputDTOAPI.md)\>\> |
+| `domainControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `domainControllerSearch` | (`domainSearchInputDTO?`: [`DomainSearchInputDTO`](../interfaces/takaro_apiclient.DomainSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`DomainOutputArrayDTOAPI`](../interfaces/takaro_apiclient.DomainOutputArrayDTOAPI.md)\>\> |
+| `domainControllerUpdate` | (`id`: `string`, `domainUpdateInputDTO?`: [`DomainUpdateInputDTO`](../interfaces/takaro_apiclient.DomainUpdateInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`DomainOutputDTOAPI`](../interfaces/takaro_apiclient.DomainOutputDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4486](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4486)
+
+___
+
+### FunctionApiAxiosParamCreator
+
+▸ **FunctionApiAxiosParamCreator**(`configuration?`): `Object`
+
+FunctionApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `functionControllerCreate` | (`functionCreateDTO?`: [`FunctionCreateDTO`](../interfaces/takaro_apiclient.FunctionCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `functionControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `functionControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `functionControllerSearch` | (`functionSearchInputDTO?`: [`FunctionSearchInputDTO`](../interfaces/takaro_apiclient.FunctionSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `functionControllerUpdate` | (`id`: `string`, `functionUpdateDTO?`: [`FunctionUpdateDTO`](../interfaces/takaro_apiclient.FunctionUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:4801](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L4801)
+
+___
+
+### FunctionApiFactory
+
+▸ **FunctionApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+FunctionApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `functionControllerCreate` | (`functionCreateDTO?`: [`FunctionCreateDTO`](../interfaces/takaro_apiclient.FunctionCreateDTO.md), `options?`: `any`) => `AxiosPromise`<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md)\> |
+| `functionControllerGetOne` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md)\> |
+| `functionControllerRemove` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `functionControllerSearch` | (`functionSearchInputDTO?`: [`FunctionSearchInputDTO`](../interfaces/takaro_apiclient.FunctionSearchInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`FunctionOutputArrayDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputArrayDTOAPI.md)\> |
+| `functionControllerUpdate` | (`id`: `string`, `functionUpdateDTO?`: [`FunctionUpdateDTO`](../interfaces/takaro_apiclient.FunctionUpdateDTO.md), `options?`: `any`) => `AxiosPromise`<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:5209](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L5209)
+
+___
+
+### FunctionApiFp
+
+▸ **FunctionApiFp**(`configuration?`): `Object`
+
+FunctionApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `functionControllerCreate` | (`functionCreateDTO?`: [`FunctionCreateDTO`](../interfaces/takaro_apiclient.FunctionCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md)\>\> |
+| `functionControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md)\>\> |
+| `functionControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `functionControllerSearch` | (`functionSearchInputDTO?`: [`FunctionSearchInputDTO`](../interfaces/takaro_apiclient.FunctionSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`FunctionOutputArrayDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputArrayDTOAPI.md)\>\> |
+| `functionControllerUpdate` | (`id`: `string`, `functionUpdateDTO?`: [`FunctionUpdateDTO`](../interfaces/takaro_apiclient.FunctionUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`FunctionOutputDTOAPI`](../interfaces/takaro_apiclient.FunctionOutputDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:5065](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L5065)
+
+___
+
+### GameServerApiAxiosParamCreator
+
+▸ **GameServerApiAxiosParamCreator**(`configuration?`): `Object`
+
+GameServerApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `gameServerControllerCreate` | (`gameServerCreateDTO?`: [`GameServerCreateDTO`](../interfaces/takaro_apiclient.GameServerCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `gameServerControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `gameServerControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `gameServerControllerSearch` | (`gameServerSearchInputDTO?`: [`GameServerSearchInputDTO`](../interfaces/takaro_apiclient.GameServerSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `gameServerControllerTestReachability` | (`gameServerTestReachabilityInputDTO?`: [`GameServerTestReachabilityInputDTO`](../interfaces/takaro_apiclient.GameServerTestReachabilityInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `gameServerControllerTestReachabilityForId` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `gameServerControllerUpdate` | (`id`: `string`, `gameServerUpdateDTO?`: [`GameServerUpdateDTO`](../interfaces/takaro_apiclient.GameServerUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:5389](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L5389)
+
+___
+
+### GameServerApiFactory
+
+▸ **GameServerApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+GameServerApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `gameServerControllerCreate` | (`gameServerCreateDTO?`: [`GameServerCreateDTO`](../interfaces/takaro_apiclient.GameServerCreateDTO.md), `options?`: `any`) => `AxiosPromise`<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md)\> |
+| `gameServerControllerGetOne` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md)\> |
+| `gameServerControllerRemove` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `gameServerControllerSearch` | (`gameServerSearchInputDTO?`: [`GameServerSearchInputDTO`](../interfaces/takaro_apiclient.GameServerSearchInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`GameServerOutputArrayDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputArrayDTOAPI.md)\> |
+| `gameServerControllerTestReachability` | (`gameServerTestReachabilityInputDTO?`: [`GameServerTestReachabilityInputDTO`](../interfaces/takaro_apiclient.GameServerTestReachabilityInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`GameServerTestReachabilityDTOAPI`](../interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md)\> |
+| `gameServerControllerTestReachabilityForId` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`GameServerTestReachabilityDTOAPI`](../interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md)\> |
+| `gameServerControllerUpdate` | (`id`: `string`, `gameServerUpdateDTO?`: [`GameServerUpdateDTO`](../interfaces/takaro_apiclient.GameServerUpdateDTO.md), `options?`: `any`) => `AxiosPromise`<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:5952](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L5952)
+
+___
+
+### GameServerApiFp
+
+▸ **GameServerApiFp**(`configuration?`): `Object`
+
+GameServerApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `gameServerControllerCreate` | (`gameServerCreateDTO?`: [`GameServerCreateDTO`](../interfaces/takaro_apiclient.GameServerCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md)\>\> |
+| `gameServerControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md)\>\> |
+| `gameServerControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `gameServerControllerSearch` | (`gameServerSearchInputDTO?`: [`GameServerSearchInputDTO`](../interfaces/takaro_apiclient.GameServerSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`GameServerOutputArrayDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputArrayDTOAPI.md)\>\> |
+| `gameServerControllerTestReachability` | (`gameServerTestReachabilityInputDTO?`: [`GameServerTestReachabilityInputDTO`](../interfaces/takaro_apiclient.GameServerTestReachabilityInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`GameServerTestReachabilityDTOAPI`](../interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md)\>\> |
+| `gameServerControllerTestReachabilityForId` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`GameServerTestReachabilityDTOAPI`](../interfaces/takaro_apiclient.GameServerTestReachabilityDTOAPI.md)\>\> |
+| `gameServerControllerUpdate` | (`id`: `string`, `gameServerUpdateDTO?`: [`GameServerUpdateDTO`](../interfaces/takaro_apiclient.GameServerUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`GameServerOutputDTOAPI`](../interfaces/takaro_apiclient.GameServerOutputDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:5751](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L5751)
+
+___
+
+### HookApiAxiosParamCreator
+
+▸ **HookApiAxiosParamCreator**(`configuration?`): `Object`
+
+HookApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `hookControllerCreate` | (`hookCreateDTO?`: [`HookCreateDTO`](../interfaces/takaro_apiclient.HookCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `hookControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `hookControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `hookControllerSearch` | (`hookSearchInputDTO?`: [`HookSearchInputDTO`](../interfaces/takaro_apiclient.HookSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `hookControllerUpdate` | (`id`: `string`, `hookUpdateDTO?`: [`HookUpdateDTO`](../interfaces/takaro_apiclient.HookUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6202](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6202)
+
+___
+
+### HookApiFactory
+
+▸ **HookApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+HookApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `hookControllerCreate` | (`hookCreateDTO?`: [`HookCreateDTO`](../interfaces/takaro_apiclient.HookCreateDTO.md), `options?`: `any`) => `AxiosPromise`<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md)\> |
+| `hookControllerGetOne` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md)\> |
+| `hookControllerRemove` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `hookControllerSearch` | (`hookSearchInputDTO?`: [`HookSearchInputDTO`](../interfaces/takaro_apiclient.HookSearchInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`HookOutputArrayDTOAPI`](../interfaces/takaro_apiclient.HookOutputArrayDTOAPI.md)\> |
+| `hookControllerUpdate` | (`id`: `string`, `hookUpdateDTO?`: [`HookUpdateDTO`](../interfaces/takaro_apiclient.HookUpdateDTO.md), `options?`: `any`) => `AxiosPromise`<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6610](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6610)
+
+___
+
+### HookApiFp
+
+▸ **HookApiFp**(`configuration?`): `Object`
+
+HookApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `hookControllerCreate` | (`hookCreateDTO?`: [`HookCreateDTO`](../interfaces/takaro_apiclient.HookCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md)\>\> |
+| `hookControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md)\>\> |
+| `hookControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `hookControllerSearch` | (`hookSearchInputDTO?`: [`HookSearchInputDTO`](../interfaces/takaro_apiclient.HookSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`HookOutputArrayDTOAPI`](../interfaces/takaro_apiclient.HookOutputArrayDTOAPI.md)\>\> |
+| `hookControllerUpdate` | (`id`: `string`, `hookUpdateDTO?`: [`HookUpdateDTO`](../interfaces/takaro_apiclient.HookUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`HookOutputDTOAPI`](../interfaces/takaro_apiclient.HookOutputDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6466](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6466)
+
+___
+
+### MetaApiAxiosParamCreator
+
+▸ **MetaApiAxiosParamCreator**(`configuration?`): `Object`
+
+MetaApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `metaGetHealth` | (`options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `metaGetOpenApi` | (`options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `metaGetOpenApiHtml` | (`options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6787](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6787)
+
+___
+
+### MetaApiFactory
+
+▸ **MetaApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+MetaApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `metaGetHealth` | (`options?`: `any`) => `AxiosPromise`<[`HealthOutputDTO`](../interfaces/takaro_apiclient.HealthOutputDTO.md)\> |
+| `metaGetOpenApi` | (`options?`: `any`) => `AxiosPromise`<`void`\> |
+| `metaGetOpenApiHtml` | (`options?`: `any`) => `AxiosPromise`<`void`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6990](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6990)
+
+___
+
+### MetaApiFp
+
+▸ **MetaApiFp**(`configuration?`): `Object`
+
+MetaApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `metaGetHealth` | (`options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`HealthOutputDTO`](../interfaces/takaro_apiclient.HealthOutputDTO.md)\>\> |
+| `metaGetOpenApi` | (`options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<`void`\>\> |
+| `metaGetOpenApiHtml` | (`options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<`void`\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:6915](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L6915)
+
+___
+
+### ModuleApiAxiosParamCreator
+
+▸ **ModuleApiAxiosParamCreator**(`configuration?`): `Object`
+
+ModuleApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `moduleControllerCreate` | (`moduleCreateDTO?`: [`ModuleCreateDTO`](../interfaces/takaro_apiclient.ModuleCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `moduleControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `moduleControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `moduleControllerSearch` | (`moduleSearchInputDTO?`: [`ModuleSearchInputDTO`](../interfaces/takaro_apiclient.ModuleSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `moduleControllerUpdate` | (`id`: `string`, `moduleUpdateDTO?`: [`ModuleUpdateDTO`](../interfaces/takaro_apiclient.ModuleUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7084](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7084)
+
+___
+
+### ModuleApiFactory
+
+▸ **ModuleApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+ModuleApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `moduleControllerCreate` | (`moduleCreateDTO?`: [`ModuleCreateDTO`](../interfaces/takaro_apiclient.ModuleCreateDTO.md), `options?`: `any`) => `AxiosPromise`<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md)\> |
+| `moduleControllerGetOne` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md)\> |
+| `moduleControllerRemove` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `moduleControllerSearch` | (`moduleSearchInputDTO?`: [`ModuleSearchInputDTO`](../interfaces/takaro_apiclient.ModuleSearchInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`ModuleOutputArrayDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputArrayDTOAPI.md)\> |
+| `moduleControllerUpdate` | (`id`: `string`, `moduleUpdateDTO?`: [`ModuleUpdateDTO`](../interfaces/takaro_apiclient.ModuleUpdateDTO.md), `options?`: `any`) => `AxiosPromise`<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7492](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7492)
+
+___
+
+### ModuleApiFp
+
+▸ **ModuleApiFp**(`configuration?`): `Object`
+
+ModuleApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `moduleControllerCreate` | (`moduleCreateDTO?`: [`ModuleCreateDTO`](../interfaces/takaro_apiclient.ModuleCreateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md)\>\> |
+| `moduleControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md)\>\> |
+| `moduleControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `moduleControllerSearch` | (`moduleSearchInputDTO?`: [`ModuleSearchInputDTO`](../interfaces/takaro_apiclient.ModuleSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`ModuleOutputArrayDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputArrayDTOAPI.md)\>\> |
+| `moduleControllerUpdate` | (`id`: `string`, `moduleUpdateDTO?`: [`ModuleUpdateDTO`](../interfaces/takaro_apiclient.ModuleUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`ModuleOutputDTOAPI`](../interfaces/takaro_apiclient.ModuleOutputDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7348](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7348)
+
+___
+
+### PlayerApiAxiosParamCreator
+
+▸ **PlayerApiAxiosParamCreator**(`configuration?`): `Object`
+
+PlayerApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `playerControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `playerControllerSearch` | (`playerSearchInputDTO?`: [`PlayerSearchInputDTO`](../interfaces/takaro_apiclient.PlayerSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7669](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7669)
+
+___
+
+### PlayerApiFactory
+
+▸ **PlayerApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+PlayerApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `playerControllerGetOne` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`PlayerOutputDTOAPI`](../interfaces/takaro_apiclient.PlayerOutputDTOAPI.md)\> |
+| `playerControllerSearch` | (`playerSearchInputDTO?`: [`PlayerSearchInputDTO`](../interfaces/takaro_apiclient.PlayerSearchInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`PlayerOutputArrayDTOAPI`](../interfaces/takaro_apiclient.PlayerOutputArrayDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7841](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7841)
+
+___
+
+### PlayerApiFp
+
+▸ **PlayerApiFp**(`configuration?`): `Object`
+
+PlayerApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `playerControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`PlayerOutputDTOAPI`](../interfaces/takaro_apiclient.PlayerOutputDTOAPI.md)\>\> |
+| `playerControllerSearch` | (`playerSearchInputDTO?`: [`PlayerSearchInputDTO`](../interfaces/takaro_apiclient.PlayerSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`PlayerOutputArrayDTOAPI`](../interfaces/takaro_apiclient.PlayerOutputArrayDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7778](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7778)
+
+___
+
+### RoleApiAxiosParamCreator
+
+▸ **RoleApiAxiosParamCreator**(`configuration?`): `Object`
+
+RoleApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `roleControllerCreate` | (`roleCreateInputDTO?`: [`RoleCreateInputDTO`](../interfaces/takaro_apiclient.RoleCreateInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `roleControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `roleControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `roleControllerSearch` | (`roleSearchInputDTO?`: [`RoleSearchInputDTO`](../interfaces/takaro_apiclient.RoleSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `roleControllerUpdate` | (`id`: `string`, `roleUpdateInputDTO?`: [`RoleUpdateInputDTO`](../interfaces/takaro_apiclient.RoleUpdateInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:7924](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L7924)
+
+___
+
+### RoleApiFactory
+
+▸ **RoleApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+RoleApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `roleControllerCreate` | (`roleCreateInputDTO?`: [`RoleCreateInputDTO`](../interfaces/takaro_apiclient.RoleCreateInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md)\> |
+| `roleControllerGetOne` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md)\> |
+| `roleControllerRemove` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `roleControllerSearch` | (`roleSearchInputDTO?`: [`RoleSearchInputDTO`](../interfaces/takaro_apiclient.RoleSearchInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`RoleOutputArrayDTOAPI`](../interfaces/takaro_apiclient.RoleOutputArrayDTOAPI.md)\> |
+| `roleControllerUpdate` | (`id`: `string`, `roleUpdateInputDTO?`: [`RoleUpdateInputDTO`](../interfaces/takaro_apiclient.RoleUpdateInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8332](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8332)
+
+___
+
+### RoleApiFp
+
+▸ **RoleApiFp**(`configuration?`): `Object`
+
+RoleApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `roleControllerCreate` | (`roleCreateInputDTO?`: [`RoleCreateInputDTO`](../interfaces/takaro_apiclient.RoleCreateInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md)\>\> |
+| `roleControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md)\>\> |
+| `roleControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `roleControllerSearch` | (`roleSearchInputDTO?`: [`RoleSearchInputDTO`](../interfaces/takaro_apiclient.RoleSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`RoleOutputArrayDTOAPI`](../interfaces/takaro_apiclient.RoleOutputArrayDTOAPI.md)\>\> |
+| `roleControllerUpdate` | (`id`: `string`, `roleUpdateInputDTO?`: [`RoleUpdateInputDTO`](../interfaces/takaro_apiclient.RoleUpdateInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`RoleOutputDTOAPI`](../interfaces/takaro_apiclient.RoleOutputDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8188](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8188)
+
+___
+
+### SettingsApiAxiosParamCreator
+
+▸ **SettingsApiAxiosParamCreator**(`configuration?`): `Object`
+
+SettingsApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `settingsControllerGet` | (`keys?`: (``"commandPrefix"`` \| ``"serverChatName"``)[], `gameServerId?`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `settingsControllerGetOne` | (`key`: `string`, `gameServerId?`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `settingsControllerSet` | (`key`: `string`, `settingsSetDTO?`: [`SettingsSetDTO`](../interfaces/takaro_apiclient.SettingsSetDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8509](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8509)
+
+___
+
+### SettingsApiFactory
+
+▸ **SettingsApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+SettingsApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `settingsControllerGet` | (`keys?`: (``"commandPrefix"`` \| ``"serverChatName"``)[], `gameServerId?`: `string`, `options?`: `any`) => `AxiosPromise`<[`SettingsOutputObjectDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputObjectDTOAPI.md)\> |
+| `settingsControllerGetOne` | (`key`: `string`, `gameServerId?`: `string`, `options?`: `any`) => `AxiosPromise`<[`SettingsOutputDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputDTOAPI.md)\> |
+| `settingsControllerSet` | (`key`: `string`, `settingsSetDTO?`: [`SettingsSetDTO`](../interfaces/takaro_apiclient.SettingsSetDTO.md), `options?`: `any`) => `AxiosPromise`<[`SettingsOutputDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8787](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8787)
+
+___
+
+### SettingsApiFp
+
+▸ **SettingsApiFp**(`configuration?`): `Object`
+
+SettingsApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `settingsControllerGet` | (`keys?`: (``"commandPrefix"`` \| ``"serverChatName"``)[], `gameServerId?`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`SettingsOutputObjectDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputObjectDTOAPI.md)\>\> |
+| `settingsControllerGetOne` | (`key`: `string`, `gameServerId?`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`SettingsOutputDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputDTOAPI.md)\>\> |
+| `settingsControllerSet` | (`key`: `string`, `settingsSetDTO?`: [`SettingsSetDTO`](../interfaces/takaro_apiclient.SettingsSetDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`SettingsOutputDTOAPI`](../interfaces/takaro_apiclient.SettingsOutputDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8684](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8684)
+
+___
+
+### UserApiAxiosParamCreator
+
+▸ **UserApiAxiosParamCreator**(`configuration?`): `Object`
+
+UserApi - axios parameter creator
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `userControllerAssignRole` | (`id`: `string`, `roleId`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `userControllerCreate` | (`userCreateInputDTO?`: [`UserCreateInputDTO`](../interfaces/takaro_apiclient.UserCreateInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `userControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `userControllerLogin` | (`loginDTO?`: [`LoginDTO`](../interfaces/takaro_apiclient.LoginDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `userControllerLogout` | (`options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `userControllerMe` | (`options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `userControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `userControllerRemoveRole` | (`id`: `string`, `roleId`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `userControllerSearch` | (`userSearchInputDTO?`: [`UserSearchInputDTO`](../interfaces/takaro_apiclient.UserSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+| `userControllerUpdate` | (`id`: `string`, `userUpdateDTO?`: [`UserUpdateDTO`](../interfaces/takaro_apiclient.UserUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<`RequestArgs`\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:8917](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L8917)
+
+___
+
+### UserApiFactory
+
+▸ **UserApiFactory**(`configuration?`, `basePath?`, `axios?`): `Object`
+
+UserApi - factory interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+| `basePath?` | `string` |
+| `axios?` | `AxiosInstance` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `userControllerAssignRole` | (`id`: `string`, `roleId`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `userControllerCreate` | (`userCreateInputDTO?`: [`UserCreateInputDTO`](../interfaces/takaro_apiclient.UserCreateInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md)\> |
+| `userControllerGetOne` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md)\> |
+| `userControllerLogin` | (`loginDTO?`: [`LoginDTO`](../interfaces/takaro_apiclient.LoginDTO.md), `options?`: `any`) => `AxiosPromise`<[`LoginOutputDTOAPI`](../interfaces/takaro_apiclient.LoginOutputDTOAPI.md)\> |
+| `userControllerLogout` | (`options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `userControllerMe` | (`options?`: `any`) => `AxiosPromise`<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md)\> |
+| `userControllerRemove` | (`id`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `userControllerRemoveRole` | (`id`: `string`, `roleId`: `string`, `options?`: `any`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\> |
+| `userControllerSearch` | (`userSearchInputDTO?`: [`UserSearchInputDTO`](../interfaces/takaro_apiclient.UserSearchInputDTO.md), `options?`: `any`) => `AxiosPromise`<[`UserOutputArrayDTOAPI`](../interfaces/takaro_apiclient.UserOutputArrayDTOAPI.md)\> |
+| `userControllerUpdate` | (`id`: `string`, `userUpdateDTO?`: [`UserUpdateDTO`](../interfaces/takaro_apiclient.UserUpdateDTO.md), `options?`: `any`) => `AxiosPromise`<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md)\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9683](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9683)
+
+___
+
+### UserApiFp
+
+▸ **UserApiFp**(`configuration?`): `Object`
+
+UserApi - functional programming interface
+
+**`Export`**
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configuration?` | `Configuration` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `userControllerAssignRole` | (`id`: `string`, `roleId`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `userControllerCreate` | (`userCreateInputDTO?`: [`UserCreateInputDTO`](../interfaces/takaro_apiclient.UserCreateInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md)\>\> |
+| `userControllerGetOne` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md)\>\> |
+| `userControllerLogin` | (`loginDTO?`: [`LoginDTO`](../interfaces/takaro_apiclient.LoginDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`LoginOutputDTOAPI`](../interfaces/takaro_apiclient.LoginOutputDTOAPI.md)\>\> |
+| `userControllerLogout` | (`options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `userControllerMe` | (`options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md)\>\> |
+| `userControllerRemove` | (`id`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `userControllerRemoveRole` | (`id`: `string`, `roleId`: `string`, `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`APIOutput`](../interfaces/takaro_apiclient.APIOutput.md)\>\> |
+| `userControllerSearch` | (`userSearchInputDTO?`: [`UserSearchInputDTO`](../interfaces/takaro_apiclient.UserSearchInputDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`UserOutputArrayDTOAPI`](../interfaces/takaro_apiclient.UserOutputArrayDTOAPI.md)\>\> |
+| `userControllerUpdate` | (`id`: `string`, `userUpdateDTO?`: [`UserUpdateDTO`](../interfaces/takaro_apiclient.UserUpdateDTO.md), `options?`: `AxiosRequestConfig`<`any`\>) => `Promise`<(`axios?`: `AxiosInstance`, `basePath?`: `string`) => `AxiosPromise`<[`UserOutputDTOAPI`](../interfaces/takaro_apiclient.UserOutputDTOAPI.md)\>\> |
+
+#### Defined in
+
+[packages/lib-apiclient/src/generated/api.ts:9415](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-apiclient/src/generated/api.ts#L9415)
+
+___
+
+### isAxiosError
+
+▸ **isAxiosError**(`payload`): payload is AxiosError<any, any\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `payload` | `any` |
+
+#### Returns
+
+payload is AxiosError<any, any\>
+
+#### Defined in
+
+node_modules/axios/index.d.ts:216

--- a/packages/web-docs/docs/development/packages/modules/takaro_config.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_config.md
@@ -1,0 +1,25 @@
+---
+id: "takaro_config"
+title: "Module: @takaro/config"
+sidebar_label: "@takaro/config"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Classes
+
+- [Config](../classes/takaro_config.Config.md)
+
+## Interfaces
+
+- [IBaseConfig](../interfaces/takaro_config.IBaseConfig.md)
+
+## Variables
+
+### baseConfigConvict
+
+• `Const` **baseConfigConvict**: `Schema`<[`IBaseConfig`](../interfaces/takaro_config.IBaseConfig.md)\>
+
+#### Defined in
+
+[packages/lib-config/src/main.ts:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-config/src/main.ts#L10)

--- a/packages/web-docs/docs/development/packages/modules/takaro_db.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_db.md
@@ -1,0 +1,268 @@
+---
+id: "takaro_db"
+title: "Module: @takaro/db"
+sidebar_label: "@takaro/db"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Classes
+
+- [ITakaroQuery](../classes/takaro_db.ITakaroQuery.md)
+- [QueryBuilder](../classes/takaro_db.QueryBuilder.md)
+- [TakaroModel](../classes/takaro_db.TakaroModel.md)
+
+## Interfaces
+
+- [IDbConfig](../interfaces/takaro_db.IDbConfig.md)
+
+## Variables
+
+### configSchema
+
+• `Const` **configSchema**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `baseDomainSchema` | { `default`: `string` = 'domain\_'; `doc`: `string` = 'String used as base for creating name of domain-scoped schemas'; `env`: `string` = 'POSTGRES\_BASE\_DOMAIN\_SCHEMA'; `format`: `StringConstructor` = String } |
+| `baseDomainSchema.default` | `string` |
+| `baseDomainSchema.doc` | `string` |
+| `baseDomainSchema.env` | `string` |
+| `baseDomainSchema.format` | `StringConstructor` |
+| `encryptionKey` | { `default`: ``null`` = null; `doc`: `string` = 'Encryption key used for encrypting sensitive data'; `env`: `string` = 'POSTGRES\_ENCRYPTION\_KEY'; `format`: `StringConstructor` = String } |
+| `encryptionKey.default` | ``null`` |
+| `encryptionKey.doc` | `string` |
+| `encryptionKey.env` | `string` |
+| `encryptionKey.format` | `StringConstructor` |
+| `postgres` | { `database`: { `default`: `string` = 'postgres'; `doc`: `string` = 'The Postgres database to use'; `env`: `string` = 'POSTGRES\_DB'; `format`: `StringConstructor` = String } ; `host`: { `default`: `string` = 'localhost'; `doc`: `string` = 'The Postgres host to connect to'; `env`: `string` = 'POSTGRES\_HOST'; `format`: `StringConstructor` = String } ; `password`: { `default`: `string` = 'postgres'; `doc`: `string` = 'The Postgres password to use'; `env`: `string` = 'POSTGRES\_PASSWORD'; `format`: `StringConstructor` = String } ; `port`: { `default`: `number` = 5432; `doc`: `string` = 'The Postgres port to connect to'; `env`: `string` = 'POSTGRES\_PORT'; `format`: `NumberConstructor` = Number } ; `user`: { `default`: `string` = 'postgres'; `doc`: `string` = 'The Postgres user to connect as'; `env`: `string` = 'POSTGRES\_USER'; `format`: `StringConstructor` = String }  } |
+| `postgres.database` | { `default`: `string` = 'postgres'; `doc`: `string` = 'The Postgres database to use'; `env`: `string` = 'POSTGRES\_DB'; `format`: `StringConstructor` = String } |
+| `postgres.database.default` | `string` |
+| `postgres.database.doc` | `string` |
+| `postgres.database.env` | `string` |
+| `postgres.database.format` | `StringConstructor` |
+| `postgres.host` | { `default`: `string` = 'localhost'; `doc`: `string` = 'The Postgres host to connect to'; `env`: `string` = 'POSTGRES\_HOST'; `format`: `StringConstructor` = String } |
+| `postgres.host.default` | `string` |
+| `postgres.host.doc` | `string` |
+| `postgres.host.env` | `string` |
+| `postgres.host.format` | `StringConstructor` |
+| `postgres.password` | { `default`: `string` = 'postgres'; `doc`: `string` = 'The Postgres password to use'; `env`: `string` = 'POSTGRES\_PASSWORD'; `format`: `StringConstructor` = String } |
+| `postgres.password.default` | `string` |
+| `postgres.password.doc` | `string` |
+| `postgres.password.env` | `string` |
+| `postgres.password.format` | `StringConstructor` |
+| `postgres.port` | { `default`: `number` = 5432; `doc`: `string` = 'The Postgres port to connect to'; `env`: `string` = 'POSTGRES\_PORT'; `format`: `NumberConstructor` = Number } |
+| `postgres.port.default` | `number` |
+| `postgres.port.doc` | `string` |
+| `postgres.port.env` | `string` |
+| `postgres.port.format` | `NumberConstructor` |
+| `postgres.user` | { `default`: `string` = 'postgres'; `doc`: `string` = 'The Postgres user to connect as'; `env`: `string` = 'POSTGRES\_USER'; `format`: `StringConstructor` = String } |
+| `postgres.user.default` | `string` |
+| `postgres.user.doc` | `string` |
+| `postgres.user.env` | `string` |
+| `postgres.user.format` | `StringConstructor` |
+| `systemSchema` | { `default`: `string` = 'takaro'; `doc`: `string` = 'The Postgres schema to use for system-related actions (like domain management)'; `env`: `string` = 'POSTGRES\_SYSTEM\_SCHEMA'; `format`: `StringConstructor` = String } |
+| `systemSchema.default` | `string` |
+| `systemSchema.doc` | `string` |
+| `systemSchema.env` | `string` |
+| `systemSchema.format` | `StringConstructor` |
+
+#### Defined in
+
+[packages/lib-db/src/config.ts:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/config.ts#L16)
+
+## Functions
+
+### NOT\_DOMAIN\_SCOPED\_getKnex
+
+▸ **NOT_DOMAIN_SCOPED_getKnex**(`alternateSearchPath?`): `Promise`<`IKnex`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `alternateSearchPath?` | `string` |
+
+#### Returns
+
+`Promise`<`IKnex`\>
+
+#### Defined in
+
+[packages/lib-db/src/knex.ts:29](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/knex.ts#L29)
+
+___
+
+### compareHashed
+
+▸ **compareHashed**(`value`, `hash`): `Promise`<`boolean`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `string` |
+| `hash` | `string` |
+
+#### Returns
+
+`Promise`<`boolean`\>
+
+#### Defined in
+
+[packages/lib-db/src/encryption.ts:31](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/encryption.ts#L31)
+
+___
+
+### decrypt
+
+▸ **decrypt**(`value`): `Promise`<`string`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `string` |
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Defined in
+
+[packages/lib-db/src/encryption.ts:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/encryption.ts#L13)
+
+___
+
+### disconnectKnex
+
+▸ **disconnectKnex**(`domainId`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `domainId` | `string` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-db/src/knex.ts:72](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/knex.ts#L72)
+
+___
+
+### encrypt
+
+▸ **encrypt**(`value`): `Promise`<`string`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `string` |
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Defined in
+
+[packages/lib-db/src/encryption.ts:4](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/encryption.ts#L4)
+
+___
+
+### getDomainSchemaName
+
+▸ **getDomainSchemaName**(`domainId`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `domainId` | `string` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[packages/lib-db/src/knex.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/knex.ts#L22)
+
+___
+
+### getKnex
+
+▸ **getKnex**(`domainId`): `Promise`<`IKnex`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `domainId` | `string` |
+
+#### Returns
+
+`Promise`<`IKnex`\>
+
+#### Defined in
+
+[packages/lib-db/src/knex.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/knex.ts#L55)
+
+___
+
+### hash
+
+▸ **hash**(`value`): `Promise`<`string`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `string` |
+
+#### Returns
+
+`Promise`<`string`\>
+
+#### Defined in
+
+[packages/lib-db/src/encryption.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/encryption.ts#L22)
+
+___
+
+### migrateDomain
+
+▸ **migrateDomain**(`domainId`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `domainId` | `string` |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-db/src/migrations/index.ts:55](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/migrations/index.ts#L55)
+
+___
+
+### migrateSystem
+
+▸ **migrateSystem**(): `Promise`<`void`\>
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/lib-db/src/migrations/index.ts:47](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-db/src/migrations/index.ts#L47)

--- a/packages/web-docs/docs/development/packages/modules/takaro_gameserver.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_gameserver.md
@@ -1,0 +1,48 @@
+---
+id: "takaro_gameserver"
+title: "Module: @takaro/gameserver"
+sidebar_label: "@takaro/gameserver"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Enumerations
+
+- [GameEvents](../enums/takaro_gameserver.GameEvents.md)
+
+## Classes
+
+- [BaseEvent](../classes/takaro_gameserver.BaseEvent.md)
+- [EventChatMessage](../classes/takaro_gameserver.EventChatMessage.md)
+- [EventLogLine](../classes/takaro_gameserver.EventLogLine.md)
+- [EventPlayerConnected](../classes/takaro_gameserver.EventPlayerConnected.md)
+- [EventPlayerDisconnected](../classes/takaro_gameserver.EventPlayerDisconnected.md)
+- [IGamePlayer](../classes/takaro_gameserver.IGamePlayer.md)
+- [Mock](../classes/takaro_gameserver.Mock.md)
+- [Rust](../classes/takaro_gameserver.Rust.md)
+- [SevenDaysToDie](../classes/takaro_gameserver.SevenDaysToDie.md)
+- [TakaroEmitter](../classes/takaro_gameserver.TakaroEmitter.md)
+- [TestReachabilityOutput](../classes/takaro_gameserver.TestReachabilityOutput.md)
+
+## Interfaces
+
+- [IGameServer](../interfaces/takaro_gameserver.IGameServer.md)
+
+## Type Aliases
+
+### EventMapping
+
+Ƭ **EventMapping**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `chat-message` | [`EventChatMessage`](../classes/takaro_gameserver.EventChatMessage.md) |
+| `log` | [`EventLogLine`](../classes/takaro_gameserver.EventLogLine.md) |
+| `player-connected` | [`EventPlayerConnected`](../classes/takaro_gameserver.EventPlayerConnected.md) |
+| `player-disconnected` | [`EventPlayerDisconnected`](../classes/takaro_gameserver.EventPlayerDisconnected.md) |
+
+#### Defined in
+
+[packages/lib-gameserver/src/interfaces/events.ts:13](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-gameserver/src/interfaces/events.ts#L13)

--- a/packages/web-docs/docs/development/packages/modules/takaro_http.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_http.md
@@ -1,0 +1,79 @@
+---
+id: "takaro_http"
+title: "Module: @takaro/http"
+sidebar_label: "@takaro/http"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Classes
+
+- [APIOutput](../classes/takaro_http.APIOutput.md)
+- [HTTP](../classes/takaro_http.HTTP.md)
+- [PaginationMiddleware](../classes/takaro_http.PaginationMiddleware.md)
+
+## Interfaces
+
+- [PaginatedRequest](../interfaces/takaro_http.PaginatedRequest.md)
+
+## Functions
+
+### apiResponse
+
+▸ **apiResponse**(`data?`, `opts?`): `Object`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `unknown` |
+| `opts?` | `IApiResponseOptions` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `unknown` |
+| `meta` | { `error`: `undefined` \| { `code`: `undefined` \| `string` = opts.error.name; `details`: `any`  } ; `serverTime`: `string`  } |
+| `meta.error` | `undefined` \| { `code`: `undefined` \| `string` = opts.error.name; `details`: `any`  } |
+| `meta.serverTime` | `string` |
+
+#### Defined in
+
+[packages/lib-http/src/util/apiResponse.ts:11](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/util/apiResponse.ts#L11)
+
+___
+
+### createAdminAuthMiddleware
+
+▸ **createAdminAuthMiddleware**(`adminSecret`): (`request`: `Request`<`ParamsDictionary`, `any`, `any`, `ParsedQs`, `Record`<`string`, `any`\>\>, `response`: `Response`<`any`, `Record`<`string`, `any`\>\>, `next`: `NextFunction`) => `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `adminSecret` | `string` |
+
+#### Returns
+
+`fn`
+
+▸ (`request`, `response`, `next`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `request` | `Request`<`ParamsDictionary`, `any`, `any`, `ParsedQs`, `Record`<`string`, `any`\>\> |
+| `response` | `Response`<`any`, `Record`<`string`, `any`\>\> |
+| `next` | `NextFunction` |
+
+##### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-http/src/middleware/adminAuth.ts:7](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-http/src/middleware/adminAuth.ts#L7)

--- a/packages/web-docs/docs/development/packages/modules/takaro_lib_components.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_lib_components.md
@@ -1,0 +1,1741 @@
+---
+id: "takaro_lib_components"
+title: "Module: @takaro/lib-components"
+sidebar_label: "@takaro/lib-components"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Namespaces
+
+- [CollapseList](../namespaces/takaro_lib_components.CollapseList.md)
+- [SlimStepper](../namespaces/takaro_lib_components.SlimStepper.md)
+- [Stepper](../namespaces/takaro_lib_components.Stepper.md)
+- [errors](../namespaces/takaro_lib_components.errors.md)
+- [testing](../namespaces/takaro_lib_components.testing.md)
+
+## Interfaces
+
+- [ActionMenuProps](../interfaces/takaro_lib_components.ActionMenuProps.md)
+- [AlertProps](../interfaces/takaro_lib_components.AlertProps.md)
+- [AvatarGroupProps](../interfaces/takaro_lib_components.AvatarGroupProps.md)
+- [AvatarProps](../interfaces/takaro_lib_components.AvatarProps.md)
+- [ButtonProps](../interfaces/takaro_lib_components.ButtonProps.md)
+- [CardProps](../interfaces/takaro_lib_components.CardProps.md)
+- [CheckboxProps](../interfaces/takaro_lib_components.CheckboxProps.md)
+- [ChipProps](../interfaces/takaro_lib_components.ChipProps.md)
+- [ClipBoardProps](../interfaces/takaro_lib_components.ClipBoardProps.md)
+- [CodeFieldProps](../interfaces/takaro_lib_components.CodeFieldProps.md)
+- [CompanyProps](../interfaces/takaro_lib_components.CompanyProps.md)
+- [ConfirmationModalProps](../interfaces/takaro_lib_components.ConfirmationModalProps.md)
+- [ConsoleProps](../interfaces/takaro_lib_components.ConsoleProps.md)
+- [DividerProps](../interfaces/takaro_lib_components.DividerProps.md)
+- [EmptyProps](../interfaces/takaro_lib_components.EmptyProps.md)
+- [Error404Props](../interfaces/takaro_lib_components.Error404Props.md)
+- [ErrorMessageProps](../interfaces/takaro_lib_components.ErrorMessageProps.md)
+- [ErrorProps](../interfaces/takaro_lib_components.ErrorProps.md)
+- [ErrorTemplateProps](../interfaces/takaro_lib_components.ErrorTemplateProps.md)
+- [FieldProps](../interfaces/takaro_lib_components.FieldProps.md)
+- [GetStartedProps](../interfaces/takaro_lib_components.GetStartedProps.md)
+- [IJsonMap](../interfaces/takaro_lib_components.IJsonMap.md)
+- [IconButtonProps](../interfaces/takaro_lib_components.IconButtonProps.md)
+- [LoadingProps](../interfaces/takaro_lib_components.LoadingProps.md)
+- [Message](../interfaces/takaro_lib_components.Message.md)
+- [NotificationBannerProps](../interfaces/takaro_lib_components.NotificationBannerProps.md)
+- [ProgressBarProps](../interfaces/takaro_lib_components.ProgressBarProps.md)
+- [RadioGroupProps](../interfaces/takaro_lib_components.RadioGroupProps.md)
+- [SelectProps](../interfaces/takaro_lib_components.SelectProps.md)
+- [SkeletonProps](../interfaces/takaro_lib_components.SkeletonProps.md)
+- [SliderProps](../interfaces/takaro_lib_components.SliderProps.md)
+- [SlimStepperProps](../interfaces/takaro_lib_components.SlimStepperProps.md)
+- [SpinnerProps](../interfaces/takaro_lib_components.SpinnerProps.md)
+- [StepperProps](../interfaces/takaro_lib_components.StepperProps.md)
+- [SupportButtonProps](../interfaces/takaro_lib_components.SupportButtonProps.md)
+- [SwitchProps](../interfaces/takaro_lib_components.SwitchProps.md)
+- [TabSwitchProps](../interfaces/takaro_lib_components.TabSwitchProps.md)
+- [TableProps](../interfaces/takaro_lib_components.TableProps.md)
+- [TileProps](../interfaces/takaro_lib_components.TileProps.md)
+- [ToggleButtonGroupProps](../interfaces/takaro_lib_components.ToggleButtonGroupProps.md)
+- [ToggleButtonProps](../interfaces/takaro_lib_components.ToggleButtonProps.md)
+- [TooltipProps](../interfaces/takaro_lib_components.TooltipProps.md)
+
+## References
+
+### CompanyIconQuaternary
+
+Renames and re-exports [CompanyIconPrimary](takaro_lib_components.md#companyiconprimary)
+
+___
+
+### CompanyIconSecondary
+
+Renames and re-exports [CompanyIconPrimary](takaro_lib_components.md#companyiconprimary)
+
+___
+
+### CompanyIconTertiary
+
+Renames and re-exports [CompanyIconPrimary](takaro_lib_components.md#companyiconprimary)
+
+## Type Aliases
+
+### AlertVariants
+
+Ƭ **AlertVariants**: ``"info"`` \| ``"warning"`` \| ``"error"`` \| ``"success"``
+
+#### Defined in
+
+[packages/lib-components/src/styled/types.ts:4](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/styled/types.ts#L4)
+
+___
+
+### AnyJson
+
+Ƭ **AnyJson**: `boolean` \| `number` \| `string` \| ``null`` \| [`JsonArray`](takaro_lib_components.md#jsonarray) \| [`IJsonMap`](../interfaces/takaro_lib_components.IJsonMap.md) \| `Date`
+
+#### Defined in
+
+[packages/lib-components/src/types/json.ts:1](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/types/json.ts#L1)
+
+___
+
+### Color
+
+Ƭ **Color**: ``"primary"`` \| ``"secondary"`` \| ``"tertiary"`` \| ``"quaternary"``
+
+#### Defined in
+
+[packages/lib-components/src/styled/types.ts:2](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/styled/types.ts#L2)
+
+___
+
+### JsonArray
+
+Ƭ **JsonArray**: [`AnyJson`](takaro_lib_components.md#anyjson)[]
+
+#### Defined in
+
+[packages/lib-components/src/types/json.ts:12](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/types/json.ts#L12)
+
+___
+
+### Size
+
+Ƭ **Size**: ``"tiny"`` \| ``"small"`` \| ``"medium"`` \| ``"large"`` \| ``"huge"``
+
+#### Defined in
+
+[packages/lib-components/src/styled/types.ts:1](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/styled/types.ts#L1)
+
+___
+
+### ThemeType
+
+Ƭ **ThemeType**: typeof [`theme`](takaro_lib_components.md#theme)
+
+#### Defined in
+
+[packages/lib-components/src/styled/theme.ts:41](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/styled/theme.ts#L41)
+
+___
+
+### Variant
+
+Ƭ **Variant**: ``"default"`` \| ``"outline"`` \| ``"clear"``
+
+#### Defined in
+
+[packages/lib-components/src/styled/types.ts:3](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/styled/types.ts#L3)
+
+## Variables
+
+### CompanyIconPrimary
+
+• `Const` **CompanyIconPrimary**: `string`
+
+#### Defined in
+
+[packages/lib-components/@types/files.d.ts:2](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/@types/files.d.ts#L2)
+
+___
+
+### GlobalStyle
+
+• `Const` **GlobalStyle**: `GlobalStyleComponent`<{ `theme`: { `colors`: { `background`: `string` = '#e8edf5'; `error`: `string` = '#FF4252'; `gray`: `string` = '#d3d3d3'; `info`: `string` = '#664DE5'; `lightGray`: `string` = '#748BA7'; `placeholder`: `string` = '#f5f5f5'; `placeholderHighlight`: `string` = '#ffffff'; `primary`: `string` = '#664DE5'; `quaternary`: `string` = '#e5cc4d'; `secondary`: `string` = '#030917'; `shade`: `string` = '#EAF8F0'; `success`: `string` = '#3CCD6A'; `tertiary`: `string` = '#be81f6'; `text`: `string` = '#030917'; `warning`: `string` = '#f57c00'; `white`: `string` = '#ffffff' } ; `fontSize`: { `huge`: `string` = '6rem'; `large`: `string` = '4.25rem'; `medium`: `string` = '1.825rem'; `mediumLarge`: `string` = '2.825rem'; `small`: `string` = '1.3rem'; `tiny`: `string` = '1rem' } ; `shadows`: { `default`: `string` = 'rgb(0 0 0 / 5%) 0px 15px 30px 0px' } ; `spacing`: { `large`: `string` = '2rem'; `medium`: `string` = '1.5rem'; `small`: `string` = '1rem' }  }  }, `DefaultTheme`\>
+
+#### Defined in
+
+[packages/lib-components/src/styled/GlobalStyle.ts:10](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/styled/GlobalStyle.ts#L10)
+
+___
+
+### REGEXPR\_STEAM\_API\_KEY
+
+• `Const` **REGEXPR\_STEAM\_API\_KEY**: `RegExp`
+
+#### Defined in
+
+[packages/lib-components/src/helpers/regexprs.ts:1](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/helpers/regexprs.ts#L1)
+
+___
+
+### device
+
+• `Const` **device**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `lg` | `string` |
+| `md` | `string` |
+| `sm` | `string` |
+| `xl` | `string` |
+| `xs` | `string` |
+| `xxl` | `string` |
+| `xxs` | `string` |
+
+#### Defined in
+
+[packages/lib-components/src/styled/device.ts:1](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/styled/device.ts#L1)
+
+___
+
+### shakeAnimation
+
+• `Const` **shakeAnimation**: `Keyframes`
+
+#### Defined in
+
+[packages/lib-components/src/styled/animations.ts:22](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/styled/animations.ts#L22)
+
+___
+
+### theme
+
+• `Const` **theme**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `colors` | { `background`: `string` = '#e8edf5'; `error`: `string` = '#FF4252'; `gray`: `string` = '#d3d3d3'; `info`: `string` = '#664DE5'; `lightGray`: `string` = '#748BA7'; `placeholder`: `string` = '#f5f5f5'; `placeholderHighlight`: `string` = '#ffffff'; `primary`: `string` = '#664DE5'; `quaternary`: `string` = '#e5cc4d'; `secondary`: `string` = '#030917'; `shade`: `string` = '#EAF8F0'; `success`: `string` = '#3CCD6A'; `tertiary`: `string` = '#be81f6'; `text`: `string` = '#030917'; `warning`: `string` = '#f57c00'; `white`: `string` = '#ffffff' } |
+| `colors.background` | `string` |
+| `colors.error` | `string` |
+| `colors.gray` | `string` |
+| `colors.info` | `string` |
+| `colors.lightGray` | `string` |
+| `colors.placeholder` | `string` |
+| `colors.placeholderHighlight` | `string` |
+| `colors.primary` | `string` |
+| `colors.quaternary` | `string` |
+| `colors.secondary` | `string` |
+| `colors.shade` | `string` |
+| `colors.success` | `string` |
+| `colors.tertiary` | `string` |
+| `colors.text` | `string` |
+| `colors.warning` | `string` |
+| `colors.white` | `string` |
+| `fontSize` | { `huge`: `string` = '6rem'; `large`: `string` = '4.25rem'; `medium`: `string` = '1.825rem'; `mediumLarge`: `string` = '2.825rem'; `small`: `string` = '1.3rem'; `tiny`: `string` = '1rem' } |
+| `fontSize.huge` | `string` |
+| `fontSize.large` | `string` |
+| `fontSize.medium` | `string` |
+| `fontSize.mediumLarge` | `string` |
+| `fontSize.small` | `string` |
+| `fontSize.tiny` | `string` |
+| `shadows` | { `default`: `string` = 'rgb(0 0 0 / 5%) 0px 15px 30px 0px' } |
+| `shadows.default` | `string` |
+| `spacing` | { `large`: `string` = '2rem'; `medium`: `string` = '1.5rem'; `small`: `string` = '1rem' } |
+| `spacing.large` | `string` |
+| `spacing.medium` | `string` |
+| `spacing.small` | `string` |
+
+#### Defined in
+
+[packages/lib-components/src/styled/theme.ts:3](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/styled/theme.ts#L3)
+
+## Functions
+
+### Action
+
+▸ **Action**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `PropsWithChildren`<`ActionProps`\> |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### ActionMenu
+
+▸ **ActionMenu**(`props`): ``null`` \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
+
+**NOTE**: Exotic components are not callable.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`ActionMenuProps`](../interfaces/takaro_lib_components.ActionMenuProps.md) & `RefAttributes`<`HTMLUListElement`\> |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:351
+
+___
+
+### Alert
+
+▸ **Alert**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`AlertProps`](../interfaces/takaro_lib_components.AlertProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Avatar
+
+▸ **Avatar**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `PropsWithChildren`<[`AvatarProps`](../interfaces/takaro_lib_components.AvatarProps.md)\> |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### AvatarGroup
+
+▸ **AvatarGroup**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`AvatarGroupProps`](../interfaces/takaro_lib_components.AvatarGroupProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Button
+
+▸ **Button**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`ButtonProps`](../interfaces/takaro_lib_components.ButtonProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Card
+
+▸ **Card**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `PropsWithChildren`<[`CardProps`](../interfaces/takaro_lib_components.CardProps.md)\> |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Checkbox
+
+▸ **Checkbox**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`CheckboxProps`](../interfaces/takaro_lib_components.CheckboxProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Chip
+
+▸ **Chip**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`ChipProps`](../interfaces/takaro_lib_components.ChipProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### ClipBoard
+
+▸ **ClipBoard**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`ClipBoardProps`](../interfaces/takaro_lib_components.ClipBoardProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### CodeField
+
+▸ **CodeField**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`CodeFieldProps`](../interfaces/takaro_lib_components.CodeFieldProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### CollapseList
+
+▸ **CollapseList**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Object` |
+| `props.children?` | `ReactNode` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Company
+
+▸ **Company**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`CompanyProps`](../interfaces/takaro_lib_components.CompanyProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### ConfirmationModal
+
+▸ **ConfirmationModal**(`props`): ``null`` \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
+
+**NOTE**: Exotic components are not callable.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Pick`<[`ConfirmationModalProps`](../interfaces/takaro_lib_components.ConfirmationModalProps.md), ``"title"`` \| ``"type"`` \| ``"action"`` \| ``"description"`` \| ``"close"`` \| ``"icon"`` \| ``"actionText"``\> & `RefAttributes`<`HTMLDivElement`\> |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:351
+
+___
+
+### Console
+
+▸ **Console**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`ConsoleProps`](../interfaces/takaro_lib_components.ConsoleProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Divider
+
+▸ **Divider**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`DividerProps`](../interfaces/takaro_lib_components.DividerProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Empty
+
+▸ **Empty**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`EmptyProps`](../interfaces/takaro_lib_components.EmptyProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Error
+
+▸ **Error**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`ErrorProps`](../interfaces/takaro_lib_components.ErrorProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Error401
+
+▸ **Error401**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Object` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Error404
+
+▸ **Error404**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`Error404Props`](../interfaces/takaro_lib_components.Error404Props.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Error500
+
+▸ **Error500**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Object` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### ErrorFallback
+
+▸ **ErrorFallback**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Object` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### ErrorMessage
+
+▸ **ErrorMessage**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`ErrorMessageProps`](../interfaces/takaro_lib_components.ErrorMessageProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### ErrorTemplate
+
+▸ **ErrorTemplate**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`ErrorTemplateProps`](../interfaces/takaro_lib_components.ErrorTemplateProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Feed
+
+▸ **Feed**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Object` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### GetStarted
+
+▸ **GetStarted**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`GetStartedProps`](../interfaces/takaro_lib_components.GetStartedProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### HeaderNav
+
+▸ **HeaderNav**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Object` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### IconButton
+
+▸ **IconButton**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`IconButtonProps`](../interfaces/takaro_lib_components.IconButtonProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Loading
+
+▸ **Loading**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`LoadingProps`](../interfaces/takaro_lib_components.LoadingProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### LoadingPage
+
+▸ **LoadingPage**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Object` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### NetworkDetector
+
+▸ **NetworkDetector**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Object` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### NotificationBanner
+
+▸ **NotificationBanner**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`NotificationBannerProps`](../interfaces/takaro_lib_components.NotificationBannerProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### ProgressBar
+
+▸ **ProgressBar**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`ProgressBarProps`](../interfaces/takaro_lib_components.ProgressBarProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### RadioGroup
+
+▸ **RadioGroup**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`RadioGroupProps`](../interfaces/takaro_lib_components.RadioGroupProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### SearchField
+
+▸ **SearchField**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Object` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Select
+
+▸ **Select**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`SelectProps`](../interfaces/takaro_lib_components.SelectProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### SingleActionModal
+
+▸ **SingleActionModal**(`props`): ``null`` \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
+
+**NOTE**: Exotic components are not callable.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Pick`<`SingleActionModalProps`, ``"title"`` \| ``"type"`` \| ``"action"`` \| ``"description"`` \| ``"close"`` \| ``"actionText"``\> & `RefAttributes`<`HTMLDivElement`\> |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:351
+
+___
+
+### Skeleton
+
+▸ **Skeleton**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`SkeletonProps`](../interfaces/takaro_lib_components.SkeletonProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Slider
+
+▸ **Slider**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`SliderProps`](../interfaces/takaro_lib_components.SliderProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### SlimStepper
+
+▸ **SlimStepper**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `PropsWithChildren`<[`SlimStepperProps`](../interfaces/takaro_lib_components.SlimStepperProps.md)\> |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### SnackbarProvider
+
+▸ **SnackbarProvider**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `Object` |
+| `props.children?` | `ReactNode` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Spinner
+
+▸ **Spinner**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`SpinnerProps`](../interfaces/takaro_lib_components.SpinnerProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Stepper
+
+▸ **Stepper**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `PropsWithChildren`<[`StepperProps`](../interfaces/takaro_lib_components.StepperProps.md)\> |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### StepperProvider
+
+▸ **StepperProvider**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `PropsWithChildren`<`StepperProviderProps`\> |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### SupportButton
+
+▸ **SupportButton**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`SupportButtonProps`](../interfaces/takaro_lib_components.SupportButtonProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Switch
+
+▸ **Switch**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`SwitchProps`](../interfaces/takaro_lib_components.SwitchProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### TabSwitch
+
+▸ **TabSwitch**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`TabSwitchProps`](../interfaces/takaro_lib_components.TabSwitchProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Table
+
+▸ **Table**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`TableProps`](../interfaces/takaro_lib_components.TableProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### TextField
+
+▸ **TextField**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`FieldProps`](../interfaces/takaro_lib_components.FieldProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Tile
+
+▸ **Tile**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`TileProps`](../interfaces/takaro_lib_components.TileProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### ToggleButton
+
+▸ **ToggleButton**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | `any` |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### ToggleButtonGroup
+
+▸ **ToggleButtonGroup**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`ToggleButtonGroupProps`](../interfaces/takaro_lib_components.ToggleButtonGroupProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### Tooltip
+
+▸ **Tooltip**(`props`, `context?`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`TooltipProps`](../interfaces/takaro_lib_components.TooltipProps.md) |
+| `context?` | `any` |
+
+#### Returns
+
+``null`` \| `ReactElement`<`any`, `any`\>
+
+#### Defined in
+
+node_modules/@types/react/index.d.ts:521
+
+___
+
+### getInitials
+
+▸ **getInitials**(`name`): `undefined` \| `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+
+#### Returns
+
+`undefined` \| `string`
+
+#### Defined in
+
+[packages/lib-components/src/helpers/getInitials.ts:1](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/helpers/getInitials.ts#L1)
+
+___
+
+### getTransition
+
+▸ **getTransition**(): `Object`
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `damping` | `number` |
+| `stiffness` | `number` |
+| `type` | `string` |
+
+#### Defined in
+
+[packages/lib-components/src/helpers/getTransition.ts:1](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/helpers/getTransition.ts#L1)
+
+___
+
+### pulseAnimation
+
+▸ **pulseAnimation**(`color`): `Keyframes`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `color` | `string` |
+
+#### Returns
+
+`Keyframes`
+
+#### Defined in
+
+[packages/lib-components/src/styled/animations.ts:3](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/styled/animations.ts#L3)
+
+___
+
+### styled
+
+▸ **styled**<`C`\>(`component`): `ThemedStyledFunction`<`StyledComponentInnerComponent`<`C`\>, { `colors`: { `background`: `string` = '#e8edf5'; `error`: `string` = '#FF4252'; `gray`: `string` = '#d3d3d3'; `info`: `string` = '#664DE5'; `lightGray`: `string` = '#748BA7'; `placeholder`: `string` = '#f5f5f5'; `placeholderHighlight`: `string` = '#ffffff'; `primary`: `string` = '#664DE5'; `quaternary`: `string` = '#e5cc4d'; `secondary`: `string` = '#030917'; `shade`: `string` = '#EAF8F0'; `success`: `string` = '#3CCD6A'; `tertiary`: `string` = '#be81f6'; `text`: `string` = '#030917'; `warning`: `string` = '#f57c00'; `white`: `string` = '#ffffff' } ; `fontSize`: { `huge`: `string` = '6rem'; `large`: `string` = '4.25rem'; `medium`: `string` = '1.825rem'; `mediumLarge`: `string` = '2.825rem'; `small`: `string` = '1.3rem'; `tiny`: `string` = '1rem' } ; `shadows`: { `default`: `string` = 'rgb(0 0 0 / 5%) 0px 15px 30px 0px' } ; `spacing`: { `large`: `string` = '2rem'; `medium`: `string` = '1.5rem'; `small`: `string` = '1rem' }  }, `StyledComponentInnerOtherProps`<`C`\>, `StyledComponentInnerAttrs`<`C`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `C` | extends `AnyStyledComponent` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `component` | `C` |
+
+#### Returns
+
+`ThemedStyledFunction`<`StyledComponentInnerComponent`<`C`\>, { `colors`: { `background`: `string` = '#e8edf5'; `error`: `string` = '#FF4252'; `gray`: `string` = '#d3d3d3'; `info`: `string` = '#664DE5'; `lightGray`: `string` = '#748BA7'; `placeholder`: `string` = '#f5f5f5'; `placeholderHighlight`: `string` = '#ffffff'; `primary`: `string` = '#664DE5'; `quaternary`: `string` = '#e5cc4d'; `secondary`: `string` = '#030917'; `shade`: `string` = '#EAF8F0'; `success`: `string` = '#3CCD6A'; `tertiary`: `string` = '#be81f6'; `text`: `string` = '#030917'; `warning`: `string` = '#f57c00'; `white`: `string` = '#ffffff' } ; `fontSize`: { `huge`: `string` = '6rem'; `large`: `string` = '4.25rem'; `medium`: `string` = '1.825rem'; `mediumLarge`: `string` = '2.825rem'; `small`: `string` = '1.3rem'; `tiny`: `string` = '1rem' } ; `shadows`: { `default`: `string` = 'rgb(0 0 0 / 5%) 0px 15px 30px 0px' } ; `spacing`: { `large`: `string` = '2rem'; `medium`: `string` = '1.5rem'; `small`: `string` = '1rem' }  }, `StyledComponentInnerOtherProps`<`C`\>, `StyledComponentInnerAttrs`<`C`\>\>
+
+#### Defined in
+
+node_modules/@types/styled-components/index.d.ts:260
+
+▸ **styled**<`C`\>(`component`): `ThemedStyledFunction`<`C`, { `colors`: { `background`: `string` = '#e8edf5'; `error`: `string` = '#FF4252'; `gray`: `string` = '#d3d3d3'; `info`: `string` = '#664DE5'; `lightGray`: `string` = '#748BA7'; `placeholder`: `string` = '#f5f5f5'; `placeholderHighlight`: `string` = '#ffffff'; `primary`: `string` = '#664DE5'; `quaternary`: `string` = '#e5cc4d'; `secondary`: `string` = '#030917'; `shade`: `string` = '#EAF8F0'; `success`: `string` = '#3CCD6A'; `tertiary`: `string` = '#be81f6'; `text`: `string` = '#030917'; `warning`: `string` = '#f57c00'; `white`: `string` = '#ffffff' } ; `fontSize`: { `huge`: `string` = '6rem'; `large`: `string` = '4.25rem'; `medium`: `string` = '1.825rem'; `mediumLarge`: `string` = '2.825rem'; `small`: `string` = '1.3rem'; `tiny`: `string` = '1rem' } ; `shadows`: { `default`: `string` = 'rgb(0 0 0 / 5%) 0px 15px 30px 0px' } ; `spacing`: { `large`: `string` = '2rem'; `medium`: `string` = '1.5rem'; `small`: `string` = '1rem' }  }, {}, `never`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `C` | extends keyof `IntrinsicElements` \| `ComponentType`<`any`\> |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `component` | `C` |
+
+#### Returns
+
+`ThemedStyledFunction`<`C`, { `colors`: { `background`: `string` = '#e8edf5'; `error`: `string` = '#FF4252'; `gray`: `string` = '#d3d3d3'; `info`: `string` = '#664DE5'; `lightGray`: `string` = '#748BA7'; `placeholder`: `string` = '#f5f5f5'; `placeholderHighlight`: `string` = '#ffffff'; `primary`: `string` = '#664DE5'; `quaternary`: `string` = '#e5cc4d'; `secondary`: `string` = '#030917'; `shade`: `string` = '#EAF8F0'; `success`: `string` = '#3CCD6A'; `tertiary`: `string` = '#be81f6'; `text`: `string` = '#030917'; `warning`: `string` = '#f57c00'; `white`: `string` = '#ffffff' } ; `fontSize`: { `huge`: `string` = '6rem'; `large`: `string` = '4.25rem'; `medium`: `string` = '1.825rem'; `mediumLarge`: `string` = '2.825rem'; `small`: `string` = '1.3rem'; `tiny`: `string` = '1rem' } ; `shadows`: { `default`: `string` = 'rgb(0 0 0 / 5%) 0px 15px 30px 0px' } ; `spacing`: { `large`: `string` = '2rem'; `medium`: `string` = '1.5rem'; `small`: `string` = '1rem' }  }, {}, `never`\>
+
+#### Defined in
+
+node_modules/@types/styled-components/index.d.ts:266
+
+___
+
+### useDebounce
+
+▸ **useDebounce**(`value`, `delay`): `number`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `number` |
+| `delay` | `number` |
+
+#### Returns
+
+`number`
+
+#### Defined in
+
+[packages/lib-components/src/hooks/useDebounce.tsx:3](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/hooks/useDebounce.tsx#L3)
+
+___
+
+### useLocalStorage
+
+▸ **useLocalStorage**<`T`\>(`key`, `initialValue`): [`T`, (`value`: `T`) => `void`]
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | `string` |
+| `initialValue` | `T` |
+
+#### Returns
+
+[`T`, (`value`: `T`) => `void`]
+
+#### Defined in
+
+[packages/lib-components/src/hooks/useLocalStorage.tsx:3](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/hooks/useLocalStorage.tsx#L3)
+
+___
+
+### useLockBodyScroll
+
+▸ **useLockBodyScroll**(`lock?`): `void`
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `lock` | `boolean` | `true` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/hooks/useLockScroll.ts:3](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/hooks/useLockScroll.ts#L3)
+
+___
+
+### useLockRefScroll
+
+▸ **useLockRefScroll**(`ref`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `ref` | `MutableRefObject`<`HTMLElement`\> |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/hooks/useLockScroll.ts:16](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/hooks/useLockScroll.ts#L16)
+
+___
+
+### useModal
+
+▸ **useModal**(): [(`__namedParameters`: `Children`) => `Element`, () => `void`, () => `void`]
+
+#### Returns
+
+[(`__namedParameters`: `Children`) => `Element`, () => `void`, () => `void`]
+
+#### Defined in
+
+[packages/lib-components/src/hooks/useModal.tsx:65](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/hooks/useModal.tsx#L65)
+
+___
+
+### useOnScreen
+
+▸ **useOnScreen**(`ref`, `rootMargin?`): `boolean`
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `ref` | `RefObject`<`any`\> | `undefined` |
+| `rootMargin` | `string` | `'0px'` |
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+[packages/lib-components/src/hooks/useOnScreen.ts:3](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/hooks/useOnScreen.ts#L3)
+
+___
+
+### useOutsideAlerter
+
+▸ **useOutsideAlerter**(`ref`, `f`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `ref` | `RefObject`<`HTMLElement`\> \| `MutableRefObject`<`HTMLElement`\> |
+| `f` | () => `void` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/lib-components/src/hooks/useOutsideAlerter.tsx:3](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/hooks/useOutsideAlerter.tsx#L3)
+
+___
+
+### useQueryParams
+
+▸ **useQueryParams**(): `URLSearchParams`
+
+#### Returns
+
+`URLSearchParams`
+
+#### Defined in
+
+[packages/lib-components/src/hooks/useQueryParams.ts:4](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/hooks/useQueryParams.ts#L4)
+
+___
+
+### useStepper
+
+▸ **useStepper**(): `Object`
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `currentStep` | `any` |
+| `decrementCurrentStep` | () => `any` |
+| `incrementCurrentStep` | () => `any` |
+| `setCurrentStep` | (`amount`: `number`) => `any` |
+| `setSteps` | (`steps`: `ReactNode`[]) => `any` |
+| `steps` | `any` |
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/Steppers/context.tsx:36](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/Steppers/context.tsx#L36)
+
+___
+
+### useTheme
+
+▸ **useTheme**(): `Object`
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `colors` | { `background`: `string` = '#e8edf5'; `error`: `string` = '#FF4252'; `gray`: `string` = '#d3d3d3'; `info`: `string` = '#664DE5'; `lightGray`: `string` = '#748BA7'; `placeholder`: `string` = '#f5f5f5'; `placeholderHighlight`: `string` = '#ffffff'; `primary`: `string` = '#664DE5'; `quaternary`: `string` = '#e5cc4d'; `secondary`: `string` = '#030917'; `shade`: `string` = '#EAF8F0'; `success`: `string` = '#3CCD6A'; `tertiary`: `string` = '#be81f6'; `text`: `string` = '#030917'; `warning`: `string` = '#f57c00'; `white`: `string` = '#ffffff' } |
+| `colors.background` | `string` |
+| `colors.error` | `string` |
+| `colors.gray` | `string` |
+| `colors.info` | `string` |
+| `colors.lightGray` | `string` |
+| `colors.placeholder` | `string` |
+| `colors.placeholderHighlight` | `string` |
+| `colors.primary` | `string` |
+| `colors.quaternary` | `string` |
+| `colors.secondary` | `string` |
+| `colors.shade` | `string` |
+| `colors.success` | `string` |
+| `colors.tertiary` | `string` |
+| `colors.text` | `string` |
+| `colors.warning` | `string` |
+| `colors.white` | `string` |
+| `fontSize` | { `huge`: `string` = '6rem'; `large`: `string` = '4.25rem'; `medium`: `string` = '1.825rem'; `mediumLarge`: `string` = '2.825rem'; `small`: `string` = '1.3rem'; `tiny`: `string` = '1rem' } |
+| `fontSize.huge` | `string` |
+| `fontSize.large` | `string` |
+| `fontSize.medium` | `string` |
+| `fontSize.mediumLarge` | `string` |
+| `fontSize.small` | `string` |
+| `fontSize.tiny` | `string` |
+| `shadows` | { `default`: `string` = 'rgb(0 0 0 / 5%) 0px 15px 30px 0px' } |
+| `shadows.default` | `string` |
+| `spacing` | { `large`: `string` = '2rem'; `medium`: `string` = '1.5rem'; `small`: `string` = '1rem' } |
+| `spacing.large` | `string` |
+| `spacing.medium` | `string` |
+| `spacing.small` | `string` |
+
+#### Defined in
+
+[packages/lib-components/src/hooks/useTheme.tsx:5](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/hooks/useTheme.tsx#L5)
+
+___
+
+### useValidationSchema
+
+▸ **useValidationSchema**(`validationSchema`): (`data`: `any`) => `Promise`<{ `errors`: {} = {}; `values`: `any`  } \| { `errors`: `any` ; `values`: {} = {} }\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `validationSchema` | `AnyObjectSchema` |
+
+#### Returns
+
+`fn`
+
+▸ (`data`): `Promise`<{ `errors`: {} = {}; `values`: `any`  } \| { `errors`: `any` ; `values`: {} = {} }\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `any` |
+
+##### Returns
+
+`Promise`<{ `errors`: {} = {}; `values`: `any`  } \| { `errors`: `any` ; `values`: {} = {} }\>
+
+#### Defined in
+
+[packages/lib-components/src/hooks/useValidationResolver.ts:4](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/hooks/useValidationResolver.ts#L4)

--- a/packages/web-docs/docs/development/packages/modules/takaro_queues.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_queues.md
@@ -1,0 +1,105 @@
+---
+id: "takaro_queues"
+title: "Module: @takaro/queues"
+sidebar_label: "@takaro/queues"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Classes
+
+- [QueuesService](../classes/takaro_queues.QueuesService.md)
+- [TakaroQueue](../classes/takaro_queues.TakaroQueue.md)
+- [TakaroWorker](../classes/takaro_queues.TakaroWorker.md)
+
+## Interfaces
+
+- [IEventQueueData](../interfaces/takaro_queues.IEventQueueData.md)
+- [IJobData](../interfaces/takaro_queues.IJobData.md)
+- [IQueuesConfig](../interfaces/takaro_queues.IQueuesConfig.md)
+
+## Variables
+
+### queuesConfigSchema
+
+• `Const` **queuesConfigSchema**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `queues` | { `commands`: { `concurrency`: { `default`: `number` = 1; `doc`: `string` = 'The number of commands to run at once'; `env`: `string` = 'COMMANDS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } ; `name`: { `default`: `string` = 'commands'; `doc`: `string` = 'The name of the queue to use for commands'; `env`: `string` = 'COMMANDS\_QUEUE\_NAME'; `format`: `StringConstructor` = String }  } ; `cronjobs`: { `concurrency`: { `default`: `number` = 1; `doc`: `string` = 'The number of cronjobs to run at once'; `env`: `string` = 'CRONJOBS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } ; `name`: { `default`: `string` = 'cronjobs'; `doc`: `string` = 'The name of the queue to use for cronjobs'; `env`: `string` = 'CRONJOBS\_QUEUE\_NAME'; `format`: `StringConstructor` = String }  } ; `events`: { `concurrency`: { `default`: `number` = 1; `doc`: `string` = 'The number of events to run at once'; `env`: `string` = 'EVENTS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } ; `name`: { `default`: `string` = 'events'; `doc`: `string` = 'The name of the queue to use for events'; `env`: `string` = 'EVENTS\_QUEUE\_NAME'; `format`: `StringConstructor` = String }  } ; `hooks`: { `concurrency`: { `default`: `number` = 1; `doc`: `string` = 'The number of hooks to run at once'; `env`: `string` = 'HOOKS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } ; `name`: { `default`: `string` = 'hooks'; `doc`: `string` = 'The name of the queue to use for hooks'; `env`: `string` = 'HOOKS\_QUEUE\_NAME'; `format`: `StringConstructor` = String }  }  } |
+| `queues.commands` | { `concurrency`: { `default`: `number` = 1; `doc`: `string` = 'The number of commands to run at once'; `env`: `string` = 'COMMANDS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } ; `name`: { `default`: `string` = 'commands'; `doc`: `string` = 'The name of the queue to use for commands'; `env`: `string` = 'COMMANDS\_QUEUE\_NAME'; `format`: `StringConstructor` = String }  } |
+| `queues.commands.concurrency` | { `default`: `number` = 1; `doc`: `string` = 'The number of commands to run at once'; `env`: `string` = 'COMMANDS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } |
+| `queues.commands.concurrency.default` | `number` |
+| `queues.commands.concurrency.doc` | `string` |
+| `queues.commands.concurrency.env` | `string` |
+| `queues.commands.concurrency.format` | `NumberConstructor` |
+| `queues.commands.name` | { `default`: `string` = 'commands'; `doc`: `string` = 'The name of the queue to use for commands'; `env`: `string` = 'COMMANDS\_QUEUE\_NAME'; `format`: `StringConstructor` = String } |
+| `queues.commands.name.default` | `string` |
+| `queues.commands.name.doc` | `string` |
+| `queues.commands.name.env` | `string` |
+| `queues.commands.name.format` | `StringConstructor` |
+| `queues.cronjobs` | { `concurrency`: { `default`: `number` = 1; `doc`: `string` = 'The number of cronjobs to run at once'; `env`: `string` = 'CRONJOBS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } ; `name`: { `default`: `string` = 'cronjobs'; `doc`: `string` = 'The name of the queue to use for cronjobs'; `env`: `string` = 'CRONJOBS\_QUEUE\_NAME'; `format`: `StringConstructor` = String }  } |
+| `queues.cronjobs.concurrency` | { `default`: `number` = 1; `doc`: `string` = 'The number of cronjobs to run at once'; `env`: `string` = 'CRONJOBS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } |
+| `queues.cronjobs.concurrency.default` | `number` |
+| `queues.cronjobs.concurrency.doc` | `string` |
+| `queues.cronjobs.concurrency.env` | `string` |
+| `queues.cronjobs.concurrency.format` | `NumberConstructor` |
+| `queues.cronjobs.name` | { `default`: `string` = 'cronjobs'; `doc`: `string` = 'The name of the queue to use for cronjobs'; `env`: `string` = 'CRONJOBS\_QUEUE\_NAME'; `format`: `StringConstructor` = String } |
+| `queues.cronjobs.name.default` | `string` |
+| `queues.cronjobs.name.doc` | `string` |
+| `queues.cronjobs.name.env` | `string` |
+| `queues.cronjobs.name.format` | `StringConstructor` |
+| `queues.events` | { `concurrency`: { `default`: `number` = 1; `doc`: `string` = 'The number of events to run at once'; `env`: `string` = 'EVENTS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } ; `name`: { `default`: `string` = 'events'; `doc`: `string` = 'The name of the queue to use for events'; `env`: `string` = 'EVENTS\_QUEUE\_NAME'; `format`: `StringConstructor` = String }  } |
+| `queues.events.concurrency` | { `default`: `number` = 1; `doc`: `string` = 'The number of events to run at once'; `env`: `string` = 'EVENTS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } |
+| `queues.events.concurrency.default` | `number` |
+| `queues.events.concurrency.doc` | `string` |
+| `queues.events.concurrency.env` | `string` |
+| `queues.events.concurrency.format` | `NumberConstructor` |
+| `queues.events.name` | { `default`: `string` = 'events'; `doc`: `string` = 'The name of the queue to use for events'; `env`: `string` = 'EVENTS\_QUEUE\_NAME'; `format`: `StringConstructor` = String } |
+| `queues.events.name.default` | `string` |
+| `queues.events.name.doc` | `string` |
+| `queues.events.name.env` | `string` |
+| `queues.events.name.format` | `StringConstructor` |
+| `queues.hooks` | { `concurrency`: { `default`: `number` = 1; `doc`: `string` = 'The number of hooks to run at once'; `env`: `string` = 'HOOKS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } ; `name`: { `default`: `string` = 'hooks'; `doc`: `string` = 'The name of the queue to use for hooks'; `env`: `string` = 'HOOKS\_QUEUE\_NAME'; `format`: `StringConstructor` = String }  } |
+| `queues.hooks.concurrency` | { `default`: `number` = 1; `doc`: `string` = 'The number of hooks to run at once'; `env`: `string` = 'HOOKS\_QUEUE\_CONCURRENCY'; `format`: `NumberConstructor` = Number } |
+| `queues.hooks.concurrency.default` | `number` |
+| `queues.hooks.concurrency.doc` | `string` |
+| `queues.hooks.concurrency.env` | `string` |
+| `queues.hooks.concurrency.format` | `NumberConstructor` |
+| `queues.hooks.name` | { `default`: `string` = 'hooks'; `doc`: `string` = 'The name of the queue to use for hooks'; `env`: `string` = 'HOOKS\_QUEUE\_NAME'; `format`: `StringConstructor` = String } |
+| `queues.hooks.name.default` | `string` |
+| `queues.hooks.name.doc` | `string` |
+| `queues.hooks.name.env` | `string` |
+| `queues.hooks.name.format` | `StringConstructor` |
+| `redis` | { `host`: { `default`: `string` = 'localhost'; `doc`: `string` = 'The host of the redis server'; `env`: `string` = 'REDIS\_HOST'; `format`: `StringConstructor` = String } ; `password`: { `default`: `string` = ''; `doc`: `string` = 'The password of the redis server'; `env`: `string` = 'REDIS\_PASSWORD'; `format`: `StringConstructor` = String } ; `port`: { `default`: `number` = 6379; `doc`: `string` = 'The port of the redis server'; `env`: `string` = 'REDIS\_PORT'; `format`: `NumberConstructor` = Number } ; `tlsCa`: { `default`: `string` = ''; `doc`: `string` = 'Optional TLS certificate, if the redis server is using TLS'; `env`: `string` = 'REDIS\_TLS\_CA'; `format`: `StringConstructor` = String } ; `username`: { `default`: `string` = ''; `doc`: `string` = 'The username of the redis server'; `env`: `string` = 'REDIS\_USERNAME'; `format`: `StringConstructor` = String }  } |
+| `redis.host` | { `default`: `string` = 'localhost'; `doc`: `string` = 'The host of the redis server'; `env`: `string` = 'REDIS\_HOST'; `format`: `StringConstructor` = String } |
+| `redis.host.default` | `string` |
+| `redis.host.doc` | `string` |
+| `redis.host.env` | `string` |
+| `redis.host.format` | `StringConstructor` |
+| `redis.password` | { `default`: `string` = ''; `doc`: `string` = 'The password of the redis server'; `env`: `string` = 'REDIS\_PASSWORD'; `format`: `StringConstructor` = String } |
+| `redis.password.default` | `string` |
+| `redis.password.doc` | `string` |
+| `redis.password.env` | `string` |
+| `redis.password.format` | `StringConstructor` |
+| `redis.port` | { `default`: `number` = 6379; `doc`: `string` = 'The port of the redis server'; `env`: `string` = 'REDIS\_PORT'; `format`: `NumberConstructor` = Number } |
+| `redis.port.default` | `number` |
+| `redis.port.doc` | `string` |
+| `redis.port.env` | `string` |
+| `redis.port.format` | `NumberConstructor` |
+| `redis.tlsCa` | { `default`: `string` = ''; `doc`: `string` = 'Optional TLS certificate, if the redis server is using TLS'; `env`: `string` = 'REDIS\_TLS\_CA'; `format`: `StringConstructor` = String } |
+| `redis.tlsCa.default` | `string` |
+| `redis.tlsCa.doc` | `string` |
+| `redis.tlsCa.env` | `string` |
+| `redis.tlsCa.format` | `StringConstructor` |
+| `redis.username` | { `default`: `string` = ''; `doc`: `string` = 'The username of the redis server'; `env`: `string` = 'REDIS\_USERNAME'; `format`: `StringConstructor` = String } |
+| `redis.username.default` | `string` |
+| `redis.username.doc` | `string` |
+| `redis.username.env` | `string` |
+| `redis.username.format` | `StringConstructor` |
+
+#### Defined in
+
+[packages/lib-queues/src/config.ts:31](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-queues/src/config.ts#L31)

--- a/packages/web-docs/docs/development/packages/modules/takaro_test.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_test.md
@@ -1,0 +1,77 @@
+---
+id: "takaro_test"
+title: "Module: @takaro/test"
+sidebar_label: "@takaro/test"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Namespaces
+
+- [snapshot](../namespaces/takaro_test.snapshot.md)
+
+## Classes
+
+- [IntegrationTest](../classes/takaro_test.IntegrationTest.md)
+
+## Variables
+
+### integrationConfig
+
+• `Const` **integrationConfig**: `Config`<`IIntegrationTestConfig`\>
+
+#### Defined in
+
+[packages/test/src/test/integrationConfig.ts:41](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/test/integrationConfig.ts#L41)
+
+___
+
+### sandbox
+
+• `Const` **sandbox**: `SinonSandbox`
+
+#### Defined in
+
+[packages/test/src/test/sandbox.ts:3](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/test/sandbox.ts#L3)
+
+## Functions
+
+### expect
+
+▸ **expect**(`val`, `message?`): `Assertion`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `val` | `any` |
+| `message?` | `string` |
+
+#### Returns
+
+`Assertion`
+
+#### Defined in
+
+node_modules/@types/chai/index.d.ts:104
+
+___
+
+### logInWithCapabilities
+
+▸ **logInWithCapabilities**(`client`, `capabilities`): `Promise`<`Client`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `client` | `Client` |
+| `capabilities` | `RoleCreateInputDTOCapabilitiesEnum`[] |
+
+#### Returns
+
+`Promise`<`Client`\>
+
+#### Defined in
+
+[packages/test/src/integrationTest.ts:147](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/integrationTest.ts#L147)

--- a/packages/web-docs/docs/development/packages/modules/takaro_util.md
+++ b/packages/web-docs/docs/development/packages/modules/takaro_util.md
@@ -1,0 +1,62 @@
+---
+id: "takaro_util"
+title: "Module: @takaro/util"
+sidebar_label: "@takaro/util"
+sidebar_position: 0
+custom_edit_url: null
+---
+
+## Namespaces
+
+- [errors](../namespaces/takaro_util.errors.md)
+
+## Classes
+
+- [TakaroDTO](../classes/takaro_util.TakaroDTO.md)
+
+## Functions
+
+### isTakaroDTO
+
+▸ **isTakaroDTO**<`T`\>(`value`): value is TakaroDTO<T\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `unknown` |
+
+#### Returns
+
+value is TakaroDTO<T\>
+
+#### Defined in
+
+[packages/lib-util/src/dto/TakaroDTO.ts:34](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/dto/TakaroDTO.ts#L34)
+
+___
+
+### logger
+
+▸ **logger**(`namespace`, `meta?`): `winston.Logger`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `namespace` | `string` |
+| `meta?` | `JsonObject` |
+
+#### Returns
+
+`winston.Logger`
+
+#### Defined in
+
+[packages/lib-util/src/logger.ts:71](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-util/src/logger.ts#L71)

--- a/packages/web-docs/docs/development/packages/namespaces/_category_.yml
+++ b/packages/web-docs/docs/development/packages/namespaces/_category_.yml
@@ -1,0 +1,2 @@
+label: "Namespaces"
+position: 1

--- a/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.CollapseList.md
+++ b/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.CollapseList.md
@@ -1,0 +1,18 @@
+---
+id: "takaro_lib_components.CollapseList"
+title: "Namespace: CollapseList"
+sidebar_label: "@takaro/lib-components.CollapseList"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).CollapseList
+
+## Variables
+
+### Item
+
+• **Item**: `FC`<`PropsWithChildren`<`ItemProps`\>\>
+
+#### Defined in
+
+[packages/lib-components/src/components/other/CollapseList/index.tsx:81](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/other/CollapseList/index.tsx#L81)

--- a/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.SlimStepper.md
+++ b/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.SlimStepper.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.SlimStepper"
+title: "Namespace: SlimStepper"
+sidebar_label: "@takaro/lib-components.SlimStepper"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).SlimStepper
+
+## Variables
+
+### Step
+
+• **Step**: `FC`<`StepProps`\>
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/Steppers/SlimStepper/index.tsx:125](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/Steppers/SlimStepper/index.tsx#L125)
+
+___
+
+### Steps
+
+• **Steps**: `FC`<`PropsWithChildren`<`void`\>\>
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/Steppers/SlimStepper/index.tsx:126](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/Steppers/SlimStepper/index.tsx#L126)

--- a/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.Stepper.md
+++ b/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.Stepper.md
@@ -1,0 +1,28 @@
+---
+id: "takaro_lib_components.Stepper"
+title: "Namespace: Stepper"
+sidebar_label: "@takaro/lib-components.Stepper"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).Stepper
+
+## Variables
+
+### Step
+
+• **Step**: `FC`<`StepProps`\>
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/Steppers/Stepper/index.tsx:142](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/Steppers/Stepper/index.tsx#L142)
+
+___
+
+### Steps
+
+• **Steps**: `FC`<`PropsWithChildren`<`void`\>\>
+
+#### Defined in
+
+[packages/lib-components/src/components/navigation/Steppers/Stepper/index.tsx:143](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/components/navigation/Steppers/Stepper/index.tsx#L143)

--- a/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.errors.md
+++ b/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.errors.md
@@ -1,0 +1,16 @@
+---
+id: "takaro_lib_components.errors"
+title: "Namespace: errors"
+sidebar_label: "@takaro/lib-components.errors"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).errors
+
+## Classes
+
+- [FailedLogOutError](../classes/takaro_lib_components.errors.FailedLogOutError.md)
+- [InternalServerError](../classes/takaro_lib_components.errors.InternalServerError.md)
+- [NotAuthorizedError](../classes/takaro_lib_components.errors.NotAuthorizedError.md)
+- [ResponseClientError](../classes/takaro_lib_components.errors.ResponseClientError.md)
+- [ResponseValidationError](../classes/takaro_lib_components.errors.ResponseValidationError.md)

--- a/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.testing.md
+++ b/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.testing.md
@@ -1,0 +1,2896 @@
+---
+id: "takaro_lib_components.testing"
+title: "Namespace: testing"
+sidebar_label: "@takaro/lib-components.testing"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).testing
+
+## Namespaces
+
+- [prettyFormat](takaro_lib_components.testing.prettyFormat.md)
+- [queries](takaro_lib_components.testing.queries.md)
+- [queryHelpers](takaro_lib_components.testing.queryHelpers.md)
+
+## Interfaces
+
+- [ByRoleOptions](../interfaces/takaro_lib_components.testing.ByRoleOptions.md)
+- [Config](../interfaces/takaro_lib_components.testing.Config.md)
+- [ConfigFn](../interfaces/takaro_lib_components.testing.ConfigFn.md)
+- [DefaultNormalizerOptions](../interfaces/takaro_lib_components.testing.DefaultNormalizerOptions.md)
+- [MatcherOptions](../interfaces/takaro_lib_components.testing.MatcherOptions.md)
+- [NormalizerOptions](../interfaces/takaro_lib_components.testing.NormalizerOptions.md)
+- [PrettyDOMOptions](../interfaces/takaro_lib_components.testing.PrettyDOMOptions.md)
+- [Queries](../interfaces/takaro_lib_components.testing.Queries-1.md)
+- [QueryOptions](../interfaces/takaro_lib_components.testing.QueryOptions.md)
+- [RenderHookOptions](../interfaces/takaro_lib_components.testing.RenderHookOptions.md)
+- [RenderHookResult](../interfaces/takaro_lib_components.testing.RenderHookResult.md)
+- [RenderOptions](../interfaces/takaro_lib_components.testing.RenderOptions.md)
+- [SelectorMatcherOptions](../interfaces/takaro_lib_components.testing.SelectorMatcherOptions.md)
+- [Suggestion](../interfaces/takaro_lib_components.testing.Suggestion.md)
+- [waitForOptions](../interfaces/takaro_lib_components.testing.waitForOptions.md)
+
+## Type Aliases
+
+### AllByAttribute
+
+Ƭ **AllByAttribute**: (`attribute`: `string`, `container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `HTMLElement`[]
+
+#### Type declaration
+
+▸ (`attribute`, `container`, `id`, `options?`): `HTMLElement`[]
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `attribute` | `string` |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`HTMLElement`[]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:23
+
+___
+
+### AllByBoundAttribute
+
+Ƭ **AllByBoundAttribute**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `T`[]
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T`[]
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`T`[]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:11
+
+___
+
+### AllByRole
+
+Ƭ **AllByRole**<`T`\>: (`container`: `HTMLElement`, `role`: [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher), `options?`: [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md)) => `T`[]
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `role`, `options?`): `T`[]
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `role` | [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher) |
+| `options?` | [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md) |
+
+##### Returns
+
+`T`[]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:127
+
+___
+
+### AllByText
+
+Ƭ **AllByText**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md)) => `T`[]
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T`[]
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md) |
+
+##### Returns
+
+`T`[]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:43
+
+___
+
+### BoundFunction
+
+Ƭ **BoundFunction**<`T`\>: `T` extends (`container`: `HTMLElement`, ...`args`: infer P) => infer R ? (...`args`: `P`) => `R` : `never`
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/get-queries-for-element.d.ts:3
+
+___
+
+### BoundFunctions
+
+Ƭ **BoundFunctions**<`Q`\>: `Q` extends typeof [`queries`](takaro_lib_components.testing.queries.md) ? { `findAllByAltText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`[]\> ; `findAllByDisplayValue`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`[]\> ; `findAllByLabelText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`[]\> ; `findAllByPlaceholderText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`[]\> ; `findAllByRole`: <T\>(...`args`: [role: ByRoleMatcher, options?: ByRoleOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`[]\> ; `findAllByTestId`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`[]\> ; `findAllByText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`[]\> ; `findAllByTitle`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`[]\> ; `findByAltText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`\> ; `findByDisplayValue`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`\> ; `findByLabelText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`\> ; `findByPlaceholderText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`\> ; `findByRole`: <T\>(...`args`: [role: ByRoleMatcher, options?: ByRoleOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`\> ; `findByTestId`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`\> ; `findByText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`\> ; `findByTitle`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions]) => `Promise`<`T`\> ; `getAllByAltText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T`[] ; `getAllByDisplayValue`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T`[] ; `getAllByLabelText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions]) => `T`[] ; `getAllByPlaceholderText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T`[] ; `getAllByRole`: <T\>(...`args`: [role: ByRoleMatcher, options?: ByRoleOptions]) => `T`[] ; `getAllByTestId`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T`[] ; `getAllByText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions]) => `T`[] ; `getAllByTitle`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T`[] ; `getByAltText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T` ; `getByDisplayValue`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T` ; `getByLabelText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions]) => `T` ; `getByPlaceholderText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T` ; `getByRole`: <T\>(...`args`: [role: ByRoleMatcher, options?: ByRoleOptions]) => `T` ; `getByTestId`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T` ; `getByText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions]) => `T` ; `getByTitle`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T` ; `queryAllByAltText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T`[] ; `queryAllByDisplayValue`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T`[] ; `queryAllByLabelText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions]) => `T`[] ; `queryAllByPlaceholderText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T`[] ; `queryAllByRole`: <T\>(...`args`: [role: ByRoleMatcher, options?: ByRoleOptions]) => `T`[] ; `queryAllByTestId`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T`[] ; `queryAllByText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions]) => `T`[] ; `queryAllByTitle`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => `T`[] ; `queryByAltText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => ``null`` \| `T` ; `queryByDisplayValue`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => ``null`` \| `T` ; `queryByLabelText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions]) => ``null`` \| `T` ; `queryByPlaceholderText`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => ``null`` \| `T` ; `queryByRole`: <T\>(...`args`: [role: ByRoleMatcher, options?: ByRoleOptions]) => ``null`` \| `T` ; `queryByTestId`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => ``null`` \| `T` ; `queryByText`: <T\>(...`args`: [id: Matcher, options?: SelectorMatcherOptions]) => ``null`` \| `T` ; `queryByTitle`: <T\>(...`args`: [id: Matcher, options?: MatcherOptions]) => ``null`` \| `T`  } & { [P in keyof Q]: BoundFunction<Q[P]\> } : { [P in keyof Q]: BoundFunction<Q[P]\> }
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `Q` |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/get-queries-for-element.d.ts:10
+
+___
+
+### BuiltQueryMethods
+
+Ƭ **BuiltQueryMethods**<`Arguments`\>: [[`QueryBy`](takaro_lib_components.testing.queryHelpers.md#queryby)<`Arguments`\>, [`GetAllBy`](takaro_lib_components.testing.queryHelpers.md#getallby)<`Arguments`\>, [`GetBy`](takaro_lib_components.testing.queryHelpers.md#getby)<`Arguments`\>, [`FindAllBy`](takaro_lib_components.testing.queryHelpers.md#findallby)<`Arguments`\>, [`FindBy`](takaro_lib_components.testing.queryHelpers.md#findby)<`Arguments`\>]
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:62
+
+___
+
+### ByRoleMatcher
+
+Ƭ **ByRoleMatcher**: `ARIARole` \| [`MatcherFunction`](takaro_lib_components.testing.md#matcherfunction) \| {}
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:11
+
+___
+
+### CreateFunction
+
+Ƭ **CreateFunction**: (`eventName`: `string`, `node`: `Document` \| `Element` \| `Window` \| `Node`, `init?`: {}, `options?`: { `EventType?`: `string` ; `defaultInit?`: {}  }) => `Event`
+
+#### Type declaration
+
+▸ (`eventName`, `node`, `init?`, `options?`): `Event`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` |
+| `node` | `Document` \| `Element` \| `Window` \| `Node` |
+| `init?` | `Object` |
+| `options?` | `Object` |
+| `options.EventType?` | `string` |
+| `options.defaultInit?` | `Object` |
+
+##### Returns
+
+`Event`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/events.d.ts:100
+
+___
+
+### CreateObject
+
+Ƭ **CreateObject**: { [K in EventType]: Function }
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/events.d.ts:106
+
+___
+
+### EventType
+
+Ƭ **EventType**: ``"copy"`` \| ``"cut"`` \| ``"paste"`` \| ``"compositionEnd"`` \| ``"compositionStart"`` \| ``"compositionUpdate"`` \| ``"keyDown"`` \| ``"keyPress"`` \| ``"keyUp"`` \| ``"focus"`` \| ``"blur"`` \| ``"focusIn"`` \| ``"focusOut"`` \| ``"change"`` \| ``"input"`` \| ``"invalid"`` \| ``"submit"`` \| ``"reset"`` \| ``"click"`` \| ``"contextMenu"`` \| ``"dblClick"`` \| ``"drag"`` \| ``"dragEnd"`` \| ``"dragEnter"`` \| ``"dragExit"`` \| ``"dragLeave"`` \| ``"dragOver"`` \| ``"dragStart"`` \| ``"drop"`` \| ``"mouseDown"`` \| ``"mouseEnter"`` \| ``"mouseLeave"`` \| ``"mouseMove"`` \| ``"mouseOut"`` \| ``"mouseOver"`` \| ``"mouseUp"`` \| ``"popState"`` \| ``"select"`` \| ``"touchCancel"`` \| ``"touchEnd"`` \| ``"touchMove"`` \| ``"touchStart"`` \| ``"resize"`` \| ``"scroll"`` \| ``"wheel"`` \| ``"abort"`` \| ``"canPlay"`` \| ``"canPlayThrough"`` \| ``"durationChange"`` \| ``"emptied"`` \| ``"encrypted"`` \| ``"ended"`` \| ``"loadedData"`` \| ``"loadedMetadata"`` \| ``"loadStart"`` \| ``"pause"`` \| ``"play"`` \| ``"playing"`` \| ``"progress"`` \| ``"rateChange"`` \| ``"seeked"`` \| ``"seeking"`` \| ``"stalled"`` \| ``"suspend"`` \| ``"timeUpdate"`` \| ``"volumeChange"`` \| ``"waiting"`` \| ``"load"`` \| ``"error"`` \| ``"animationStart"`` \| ``"animationEnd"`` \| ``"animationIteration"`` \| ``"transitionCancel"`` \| ``"transitionEnd"`` \| ``"transitionRun"`` \| ``"transitionStart"`` \| ``"doubleClick"`` \| ``"pointerOver"`` \| ``"pointerEnter"`` \| ``"pointerDown"`` \| ``"pointerMove"`` \| ``"pointerUp"`` \| ``"pointerCancel"`` \| ``"pointerOut"`` \| ``"pointerLeave"`` \| ``"gotPointerCapture"`` \| ``"lostPointerCapture"``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/events.d.ts:1
+
+___
+
+### FindAllBy
+
+Ƭ **FindAllBy**<`Arguments`\>: [`QueryMethod`](takaro_lib_components.testing.queryHelpers.md#querymethod)<[`Arguments`[``0``], Arguments[1]?, waitForOptions?], `Promise`<`HTMLElement`[]\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:52
+
+___
+
+### FindAllByBoundAttribute
+
+Ƭ **FindAllByBoundAttribute**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`[]\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`, `waitForElementOptions?`): `Promise`<`T`[]\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`[]\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:17
+
+___
+
+### FindAllByRole
+
+Ƭ **FindAllByRole**<`T`\>: (`container`: `HTMLElement`, `role`: [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher), `options?`: [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`[]\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `role`, `options?`, `waitForElementOptions?`): `Promise`<`T`[]\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `role` | [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher) |
+| `options?` | [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`[]\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:152
+
+___
+
+### FindAllByText
+
+Ƭ **FindAllByText**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`[]\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`, `waitForElementOptions?`): `Promise`<`T`[]\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`[]\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:49
+
+___
+
+### FindBy
+
+Ƭ **FindBy**<`Arguments`\>: [`QueryMethod`](takaro_lib_components.testing.queryHelpers.md#querymethod)<[`Arguments`[``0``], Arguments[1]?, waitForOptions?], `Promise`<`HTMLElement`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:57
+
+___
+
+### FindByBoundAttribute
+
+Ƭ **FindByBoundAttribute**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`, `waitForElementOptions?`): `Promise`<`T`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:30
+
+___
+
+### FindByRole
+
+Ƭ **FindByRole**<`T`\>: (`container`: `HTMLElement`, `role`: [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher), `options?`: [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `role`, `options?`, `waitForElementOptions?`): `Promise`<`T`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `role` | [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher) |
+| `options?` | [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:145
+
+___
+
+### FindByText
+
+Ƭ **FindByText**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`, `waitForElementOptions?`): `Promise`<`T`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:62
+
+___
+
+### FireFunction
+
+Ƭ **FireFunction**: (`element`: `Document` \| `Element` \| `Window` \| `Node`, `event`: `Event`) => `boolean`
+
+#### Type declaration
+
+▸ (`element`, `event`): `boolean`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `element` | `Document` \| `Element` \| `Window` \| `Node` |
+| `event` | `Event` |
+
+##### Returns
+
+`boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/events.d.ts:90
+
+___
+
+### FireObject
+
+Ƭ **FireObject**: { [K in EventType]: Function }
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/events.d.ts:94
+
+___
+
+### GetAllBy
+
+Ƭ **GetAllBy**<`Arguments`\>: [`QueryMethod`](takaro_lib_components.testing.queryHelpers.md#querymethod)<`Arguments`, `HTMLElement`[]\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:48
+
+___
+
+### GetBy
+
+Ƭ **GetBy**<`Arguments`\>: [`QueryMethod`](takaro_lib_components.testing.queryHelpers.md#querymethod)<`Arguments`, `HTMLElement`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:56
+
+___
+
+### GetByBoundAttribute
+
+Ƭ **GetByBoundAttribute**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `T`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`T`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:24
+
+___
+
+### GetByRole
+
+Ƭ **GetByRole**<`T`\>: (`container`: `HTMLElement`, `role`: [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher), `options?`: [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md)) => `T`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `role`, `options?`): `T`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `role` | [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher) |
+| `options?` | [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md) |
+
+##### Returns
+
+`T`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:133
+
+___
+
+### GetByText
+
+Ƭ **GetByText**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md)) => `T`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md) |
+
+##### Returns
+
+`T`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:56
+
+___
+
+### GetErrorFunction
+
+Ƭ **GetErrorFunction**<`Arguments`\>: (`c`: `Element` \| ``null``, ...`args`: `Arguments`) => `string`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] = [`string`] |
+
+#### Type declaration
+
+▸ (`c`, ...`args`): `string`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `c` | `Element` \| ``null`` |
+| `...args` | `Arguments` |
+
+##### Returns
+
+`string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:6
+
+___
+
+### Match
+
+Ƭ **Match**: (`textToMatch`: `string`, `node`: `HTMLElement` \| ``null``, `matcher`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `boolean`
+
+#### Type declaration
+
+▸ (`textToMatch`, `node`, `matcher`, `options?`): `boolean`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `textToMatch` | `string` |
+| `node` | `HTMLElement` \| ``null`` |
+| `matcher` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:30
+
+___
+
+### Matcher
+
+Ƭ **Matcher**: [`MatcherFunction`](takaro_lib_components.testing.md#matcherfunction) \| `RegExp` \| `number` \| `string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:7
+
+___
+
+### MatcherFunction
+
+Ƭ **MatcherFunction**: (`content`: `string`, `element`: `Element` \| ``null``) => `boolean`
+
+#### Type declaration
+
+▸ (`content`, `element`): `boolean`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `content` | `string` |
+| `element` | `Element` \| ``null`` |
+
+##### Returns
+
+`boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:3
+
+___
+
+### Method
+
+Ƭ **Method**: ``"AltText"`` \| ``"alttext"`` \| ``"DisplayValue"`` \| ``"displayvalue"`` \| ``"LabelText"`` \| ``"labeltext"`` \| ``"PlaceholderText"`` \| ``"placeholdertext"`` \| ``"Role"`` \| ``"role"`` \| ``"TestId"`` \| ``"testid"`` \| ``"Text"`` \| ``"text"`` \| ``"Title"`` \| ``"title"``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/suggestions.d.ts:24
+
+___
+
+### NormalizerFn
+
+Ƭ **NormalizerFn**: (`text`: `string`) => `string`
+
+#### Type declaration
+
+▸ (`text`): `string`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `text` | `string` |
+
+##### Returns
+
+`string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:13
+
+___
+
+### Query
+
+Ƭ **Query**: (`container`: `HTMLElement`, ...`args`: `any`[]) => `Error` \| `HTMLElement` \| `HTMLElement`[] \| `Promise`<`HTMLElement`[]\> \| `Promise`<`HTMLElement`\> \| ``null``
+
+#### Type declaration
+
+▸ (`container`, ...`args`): `Error` \| `HTMLElement` \| `HTMLElement`[] \| `Promise`<`HTMLElement`[]\> \| `Promise`<`HTMLElement`\> \| ``null``
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `...args` | `any`[] |
+
+##### Returns
+
+`Error` \| `HTMLElement` \| `HTMLElement`[] \| `Promise`<`HTMLElement`[]\> \| `Promise`<`HTMLElement`\> \| ``null``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/get-queries-for-element.d.ts:163
+
+___
+
+### QueryArgs
+
+Ƭ **QueryArgs**: [`string`, QueryOptions?]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/suggestions.d.ts:5
+
+___
+
+### QueryBy
+
+Ƭ **QueryBy**<`Arguments`\>: [`QueryMethod`](takaro_lib_components.testing.queryHelpers.md#querymethod)<`Arguments`, `HTMLElement` \| ``null``\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:44
+
+___
+
+### QueryByAttribute
+
+Ƭ **QueryByAttribute**: (`attribute`: `string`, `container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `HTMLElement` \| ``null``
+
+#### Type declaration
+
+▸ (`attribute`, `container`, `id`, `options?`): `HTMLElement` \| ``null``
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `attribute` | `string` |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`HTMLElement` \| ``null``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:16
+
+___
+
+### QueryByBoundAttribute
+
+Ƭ **QueryByBoundAttribute**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `T` \| ``null``
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T` \| ``null``
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`T` \| ``null``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:5
+
+___
+
+### QueryByRole
+
+Ƭ **QueryByRole**<`T`\>: (`container`: `HTMLElement`, `role`: [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher), `options?`: [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md)) => `T` \| ``null``
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `role`, `options?`): `T` \| ``null``
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `role` | [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher) |
+| `options?` | [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md) |
+
+##### Returns
+
+`T` \| ``null``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:139
+
+___
+
+### QueryByText
+
+Ƭ **QueryByText**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md)) => `T` \| ``null``
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T` \| ``null``
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md) |
+
+##### Returns
+
+`T` \| ``null``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:37
+
+___
+
+### QueryMethod
+
+Ƭ **QueryMethod**<`Arguments`, `Return`\>: (`container`: `HTMLElement`, ...`args`: `Arguments`) => `Return`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+| `Return` | `Return` |
+
+#### Type declaration
+
+▸ (`container`, ...`args`): `Return`
+
+query methods have a common call signature. Only the return type differs.
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `...args` | `Arguments` |
+
+##### Returns
+
+`Return`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:40
+
+___
+
+### RenderResult
+
+Ƭ **RenderResult**<`Q`, `Container`, `BaseElement`\>: { `asFragment`: () => `DocumentFragment` ; `baseElement`: `BaseElement` ; `container`: `Container` ; `debug`: (`baseElement?`: `Element` \| `DocumentFragment` \| (`Element` \| `DocumentFragment`)[], `maxLength?`: `number`, `options?`: [`OptionsReceived`](takaro_lib_components.testing.prettyFormat.md#optionsreceived)) => `void` ; `rerender`: (`ui`: `React.ReactElement`) => `void` ; `unmount`: () => `void`  } & { [P in keyof Q]: BoundFunction<Q[P]\> }
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Q` | extends [`Queries`](../interfaces/takaro_lib_components.testing.Queries-1.md) = typeof [`queries`](takaro_lib_components.testing.queries.md) |
+| `Container` | extends `Element` \| `DocumentFragment` = `HTMLElement` |
+| `BaseElement` | extends `Element` \| `DocumentFragment` = `Container` |
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:14
+
+___
+
+### Screen
+
+Ƭ **Screen**<`Q`\>: [`BoundFunctions`](takaro_lib_components.testing.md#boundfunctions)<`Q`\> & { `debug`: (`element?`: (`Element` \| `HTMLDocument`)[] \| `Element` \| `HTMLDocument`, `maxLength?`: `number`, `options?`: [`OptionsReceived`](takaro_lib_components.testing.prettyFormat.md#optionsreceived)) => `void` ; `logTestingPlaygroundURL`: (`element?`: `Element` \| `HTMLDocument`) => `string`  }
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Q` | extends [`Queries`](../interfaces/takaro_lib_components.testing.Queries-1.md) = typeof [`queries`](takaro_lib_components.testing.queries.md) |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/screen.d.ts:5
+
+___
+
+### Variant
+
+Ƭ **Variant**: ``"find"`` \| ``"findAll"`` \| ``"get"`` \| ``"getAll"`` \| ``"query"`` \| ``"queryAll"``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/suggestions.d.ts:16
+
+___
+
+### WithSuggest
+
+Ƭ **WithSuggest**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `suggest?` | `boolean` |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:4
+
+## Variables
+
+### screen
+
+• `Const` **screen**: [`Screen`](takaro_lib_components.testing.md#screen)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/screen.d.ts:22
+
+## Functions
+
+### act
+
+▸ **act**(`callback`): `Promise`<`undefined`\>
+
+Simply calls ReactDOMTestUtils.act(cb)
+If that's not available (older version of react) then it
+simply calls the given callback immediately
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | () => `Promise`<`void`\> |
+
+#### Returns
+
+`Promise`<`undefined`\>
+
+#### Defined in
+
+node_modules/@types/react-dom/test-utils/index.d.ts:301
+
+▸ **act**(`callback`): `void`
+
+Simply calls ReactDOMTestUtils.act(cb)
+If that's not available (older version of react) then it
+simply calls the given callback immediately
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | () => `VoidOrUndefinedOnly` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node_modules/@types/react-dom/test-utils/index.d.ts:302
+
+___
+
+### buildQueries
+
+▸ **buildQueries**<`Arguments`\>(`queryAllBy`, `getMultipleError`, `getMissingError`): [`BuiltQueryMethods`](takaro_lib_components.testing.queryHelpers.md#builtquerymethods)<`Arguments`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `queryAllBy` | [`GetAllBy`](takaro_lib_components.testing.queryHelpers.md#getallby)<`Arguments`\> |
+| `getMultipleError` | [`GetErrorFunction`](takaro_lib_components.testing.queryHelpers.md#geterrorfunction)<`Arguments`\> |
+| `getMissingError` | [`GetErrorFunction`](takaro_lib_components.testing.queryHelpers.md#geterrorfunction)<`Arguments`\> |
+
+#### Returns
+
+[`BuiltQueryMethods`](takaro_lib_components.testing.queryHelpers.md#builtquerymethods)<`Arguments`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:70
+
+___
+
+### cleanup
+
+▸ **cleanup**(): `void`
+
+Unmounts React trees that were mounted with render.
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:154
+
+___
+
+### computeHeadingLevel
+
+▸ **computeHeadingLevel**(`element`): `number` \| `undefined`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `element` | `Element` |
+
+#### Returns
+
+`number` \| `undefined`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/role-helpers.d.ts:9
+
+___
+
+### configure
+
+▸ **configure**(`configDelta`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `configDelta` | [`ConfigFn`](../interfaces/takaro_lib_components.testing.ConfigFn.md) \| `Partial`<[`Config`](../interfaces/takaro_lib_components.testing.Config.md)\> |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:26
+
+___
+
+### createEvent
+
+▸ **createEvent**(`eventName`, `node`, `init?`, `options?`): `Event`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `eventName` | `string` |
+| `node` | `Element` \| `Node` \| `Window` \| `Document` |
+| `init?` | `Object` |
+| `options?` | `Object` |
+| `options.EventType?` | `string` |
+| `options.defaultInit?` | `Object` |
+
+#### Returns
+
+`Event`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/events.d.ts:100
+
+___
+
+### findAllByAltText
+
+▸ **findAllByAltText**<`T`\>(...`args`): `ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:228
+
+___
+
+### findAllByDisplayValue
+
+▸ **findAllByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:264
+
+___
+
+### findAllByLabelText
+
+▸ **findAllByLabelText**<`T`\>(...`args`): `ReturnType`<[`FindAllByText`](takaro_lib_components.testing.queries.md#findallbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByText`](takaro_lib_components.testing.queries.md#findallbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:174
+
+___
+
+### findAllByPlaceholderText
+
+▸ **findAllByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:192
+
+___
+
+### findAllByRole
+
+▸ **findAllByRole**<`T`\>(...`args`): `ReturnType`<[`FindAllByRole`](takaro_lib_components.testing.queries.md#findallbyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByRole`](takaro_lib_components.testing.queries.md#findallbyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:282
+
+___
+
+### findAllByTestId
+
+▸ **findAllByTestId**<`T`\>(...`args`): `ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:300
+
+___
+
+### findAllByText
+
+▸ **findAllByText**<`T`\>(...`args`): `ReturnType`<[`FindAllByText`](takaro_lib_components.testing.queries.md#findallbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByText`](takaro_lib_components.testing.queries.md#findallbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:210
+
+___
+
+### findAllByTitle
+
+▸ **findAllByTitle**<`T`\>(...`args`): `ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:246
+
+___
+
+### findByAltText
+
+▸ **findByAltText**<`T`\>(...`args`): `ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:225
+
+___
+
+### findByDisplayValue
+
+▸ **findByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:261
+
+___
+
+### findByLabelText
+
+▸ **findByLabelText**<`T`\>(...`args`): `ReturnType`<[`FindByText`](takaro_lib_components.testing.queries.md#findbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByText`](takaro_lib_components.testing.queries.md#findbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:171
+
+___
+
+### findByPlaceholderText
+
+▸ **findByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:189
+
+___
+
+### findByRole
+
+▸ **findByRole**<`T`\>(...`args`): `ReturnType`<[`FindByRole`](takaro_lib_components.testing.queries.md#findbyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByRole`](takaro_lib_components.testing.queries.md#findbyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:279
+
+___
+
+### findByTestId
+
+▸ **findByTestId**<`T`\>(...`args`): `ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:297
+
+___
+
+### findByText
+
+▸ **findByText**<`T`\>(...`args`): `ReturnType`<[`FindByText`](takaro_lib_components.testing.queries.md#findbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByText`](takaro_lib_components.testing.queries.md#findbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:207
+
+___
+
+### findByTitle
+
+▸ **findByTitle**<`T`\>(...`args`): `ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:243
+
+___
+
+### fireEvent
+
+▸ **fireEvent**(`element`, `event`): `boolean`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `element` | `Element` \| `Node` \| `Window` \| `Document` |
+| `event` | `Event` |
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/events.d.ts:90
+
+___
+
+### getAllByAltText
+
+▸ **getAllByAltText**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:216
+
+___
+
+### getAllByDisplayValue
+
+▸ **getAllByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:252
+
+___
+
+### getAllByLabelText
+
+▸ **getAllByLabelText**<`T`\>(...`args`): `ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:162
+
+___
+
+### getAllByPlaceholderText
+
+▸ **getAllByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:180
+
+___
+
+### getAllByRole
+
+▸ **getAllByRole**<`T`\>(...`args`): `ReturnType`<[`AllByRole`](takaro_lib_components.testing.queries.md#allbyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByRole`](takaro_lib_components.testing.queries.md#allbyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:270
+
+___
+
+### getAllByTestId
+
+▸ **getAllByTestId**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:288
+
+___
+
+### getAllByText
+
+▸ **getAllByText**<`T`\>(...`args`): `ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:198
+
+___
+
+### getAllByTitle
+
+▸ **getAllByTitle**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:234
+
+___
+
+### getByAltText
+
+▸ **getByAltText**<`T`\>(...`args`): `ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:213
+
+___
+
+### getByDisplayValue
+
+▸ **getByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:249
+
+___
+
+### getByLabelText
+
+▸ **getByLabelText**<`T`\>(...`args`): `ReturnType`<[`GetByText`](takaro_lib_components.testing.queries.md#getbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByText`](takaro_lib_components.testing.queries.md#getbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:159
+
+___
+
+### getByPlaceholderText
+
+▸ **getByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:177
+
+___
+
+### getByRole
+
+▸ **getByRole**<`T`\>(...`args`): `ReturnType`<[`GetByRole`](takaro_lib_components.testing.queries.md#getbyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByRole`](takaro_lib_components.testing.queries.md#getbyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:267
+
+___
+
+### getByTestId
+
+▸ **getByTestId**<`T`\>(...`args`): `ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:285
+
+___
+
+### getByText
+
+▸ **getByText**<`T`\>(...`args`): `ReturnType`<[`GetByText`](takaro_lib_components.testing.queries.md#getbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByText`](takaro_lib_components.testing.queries.md#getbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:195
+
+___
+
+### getByTitle
+
+▸ **getByTitle**<`T`\>(...`args`): `ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:231
+
+___
+
+### getConfig
+
+▸ **getConfig**(): [`Config`](../interfaces/takaro_lib_components.testing.Config.md)
+
+#### Returns
+
+[`Config`](../interfaces/takaro_lib_components.testing.Config.md)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/config.d.ts:27
+
+___
+
+### getDefaultNormalizer
+
+▸ **getDefaultNormalizer**(`options?`): [`NormalizerFn`](takaro_lib_components.testing.md#normalizerfn)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options?` | [`DefaultNormalizerOptions`](../interfaces/takaro_lib_components.testing.DefaultNormalizerOptions.md) |
+
+#### Returns
+
+[`NormalizerFn`](takaro_lib_components.testing.md#normalizerfn)
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/matches.d.ts:42
+
+___
+
+### getElementError
+
+▸ **getElementError**(`message`, `container`): `Error`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | ``null`` \| `string` |
+| `container` | `HTMLElement` |
+
+#### Returns
+
+`Error`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:32
+
+___
+
+### getNodeText
+
+▸ **getNodeText**(`node`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `node` | `HTMLElement` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/get-node-text.d.ts:1
+
+___
+
+### getQueriesForElement
+
+▸ **getQueriesForElement**<`QueriesToBind`, `T`\>(`element`, `queriesToBind?`): [`BoundFunctions`](takaro_lib_components.testing.md#boundfunctions)<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `QueriesToBind` | extends [`Queries`](../interfaces/takaro_lib_components.testing.Queries-1.md) = [`queries`](takaro_lib_components.testing.queries.md) |
+| `T` | extends [`Queries`](../interfaces/takaro_lib_components.testing.Queries-1.md) = `QueriesToBind` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `element` | `HTMLElement` |
+| `queriesToBind?` | `T` |
+
+#### Returns
+
+[`BoundFunctions`](takaro_lib_components.testing.md#boundfunctions)<`T`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/get-queries-for-element.d.ts:178
+
+___
+
+### getRoles
+
+▸ **getRoles**(`container`): `Object`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+
+#### Returns
+
+`Object`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/role-helpers.d.ts:2
+
+___
+
+### getSuggestedQuery
+
+▸ **getSuggestedQuery**(`element`, `variant?`, `method?`): [`Suggestion`](../interfaces/takaro_lib_components.testing.Suggestion.md) \| `undefined`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `element` | `HTMLElement` |
+| `variant?` | [`Variant`](takaro_lib_components.testing.md#variant) |
+| `method?` | [`Method`](takaro_lib_components.testing.md#method) |
+
+#### Returns
+
+[`Suggestion`](../interfaces/takaro_lib_components.testing.Suggestion.md) \| `undefined`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/suggestions.d.ts:42
+
+___
+
+### isInaccessible
+
+▸ **isInaccessible**(`element`): `boolean`
+
+https://testing-library.com/docs/dom-testing-library/api-helpers#isinaccessible
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `element` | `Element` |
+
+#### Returns
+
+`boolean`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/role-helpers.d.ts:8
+
+___
+
+### logDOM
+
+▸ **logDOM**(`dom?`, `maxLength?`, `options?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `dom?` | `Element` \| `HTMLDocument` |
+| `maxLength?` | `number` |
+| `options?` | [`PrettyDOMOptions`](../interfaces/takaro_lib_components.testing.PrettyDOMOptions.md) |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/pretty-dom.d.ts:16
+
+___
+
+### logRoles
+
+▸ **logRoles**(`container`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/role-helpers.d.ts:1
+
+___
+
+### prettyDOM
+
+▸ **prettyDOM**(`dom?`, `maxLength?`, `options?`): `string` \| ``false``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `dom?` | `Element` \| `HTMLDocument` |
+| `maxLength?` | `number` |
+| `options?` | [`PrettyDOMOptions`](../interfaces/takaro_lib_components.testing.PrettyDOMOptions.md) |
+
+#### Returns
+
+`string` \| ``false``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/pretty-dom.d.ts:11
+
+___
+
+### queryAllByAltText
+
+▸ **queryAllByAltText**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:222
+
+___
+
+### queryAllByAttribute
+
+▸ **queryAllByAttribute**(`attribute`, `container`, `id`, `options?`): `HTMLElement`[]
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `attribute` | `string` |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+#### Returns
+
+`HTMLElement`[]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:23
+
+___
+
+### queryAllByDisplayValue
+
+▸ **queryAllByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:258
+
+___
+
+### queryAllByLabelText
+
+▸ **queryAllByLabelText**<`T`\>(...`args`): `ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:168
+
+___
+
+### queryAllByPlaceholderText
+
+▸ **queryAllByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:186
+
+___
+
+### queryAllByRole
+
+▸ **queryAllByRole**<`T`\>(...`args`): `ReturnType`<[`AllByRole`](takaro_lib_components.testing.queries.md#allbyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByRole`](takaro_lib_components.testing.queries.md#allbyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:276
+
+___
+
+### queryAllByTestId
+
+▸ **queryAllByTestId**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:294
+
+___
+
+### queryAllByText
+
+▸ **queryAllByText**<`T`\>(...`args`): `ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:204
+
+___
+
+### queryAllByTitle
+
+▸ **queryAllByTitle**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:240
+
+___
+
+### queryByAltText
+
+▸ **queryByAltText**<`T`\>(...`args`): `ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:219
+
+___
+
+### queryByAttribute
+
+▸ **queryByAttribute**(`attribute`, `container`, `id`, `options?`): ``null`` \| `HTMLElement`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `attribute` | `string` |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+#### Returns
+
+``null`` \| `HTMLElement`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:16
+
+___
+
+### queryByDisplayValue
+
+▸ **queryByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:255
+
+___
+
+### queryByLabelText
+
+▸ **queryByLabelText**<`T`\>(...`args`): `ReturnType`<[`QueryByText`](takaro_lib_components.testing.queries.md#querybytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByText`](takaro_lib_components.testing.queries.md#querybytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:165
+
+___
+
+### queryByPlaceholderText
+
+▸ **queryByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:183
+
+___
+
+### queryByRole
+
+▸ **queryByRole**<`T`\>(...`args`): `ReturnType`<[`QueryByRole`](takaro_lib_components.testing.queries.md#querybyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByRole`](takaro_lib_components.testing.queries.md#querybyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:273
+
+___
+
+### queryByTestId
+
+▸ **queryByTestId**<`T`\>(...`args`): `ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:291
+
+___
+
+### queryByText
+
+▸ **queryByText**<`T`\>(...`args`): `ReturnType`<[`QueryByText`](takaro_lib_components.testing.queries.md#querybytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByText`](takaro_lib_components.testing.queries.md#querybytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:201
+
+___
+
+### queryByTitle
+
+▸ **queryByTitle**<`T`\>(...`args`): `ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:237
+
+___
+
+### render
+
+▸ **render**(`ui`, `options?`): [`RenderResult`](takaro_lib_components.testing.md#renderresult)<[`queries`](takaro_lib_components.testing.queries.md), `HTMLElement`, `HTMLElement`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `ui` | `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\> |
+| `options?` | `Omit`<[`RenderOptions`](../interfaces/takaro_lib_components.testing.RenderOptions.md)<[`queries`](takaro_lib_components.testing.queries.md), `HTMLElement`, `HTMLElement`\>, ``"wrapper"``\> |
+
+#### Returns
+
+[`RenderResult`](takaro_lib_components.testing.md#renderresult)<[`queries`](takaro_lib_components.testing.queries.md), `HTMLElement`, `HTMLElement`\>
+
+#### Defined in
+
+[packages/lib-components/src/test/testUtils.tsx:21](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/lib-components/src/test/testUtils.tsx#L21)
+
+___
+
+### renderHook
+
+▸ **renderHook**<`Result`, `Props`, `Q`, `Container`, `BaseElement`\>(`render`, `options?`): [`RenderHookResult`](../interfaces/takaro_lib_components.testing.RenderHookResult.md)<`Result`, `Props`\>
+
+Allows you to render a hook within a test React component without having to
+create that component yourself.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Result` | `Result` |
+| `Props` | `Props` |
+| `Q` | extends [`Queries`](../interfaces/takaro_lib_components.testing.Queries-1.md) = [`queries`](takaro_lib_components.testing.queries.md) |
+| `Container` | extends `Element` \| `DocumentFragment` = `HTMLElement` |
+| `BaseElement` | extends `Element` \| `DocumentFragment` = `Container` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `render` | (`initialProps`: `Props`) => `Result` |
+| `options?` | [`RenderHookOptions`](../interfaces/takaro_lib_components.testing.RenderHookOptions.md)<`Props`, `Q`, `Container`, `BaseElement`\> |
+
+#### Returns
+
+[`RenderHookResult`](../interfaces/takaro_lib_components.testing.RenderHookResult.md)<`Result`, `Props`\>
+
+#### Defined in
+
+node_modules/@testing-library/react/types/index.d.ts:140
+
+___
+
+### waitFor
+
+▸ **waitFor**<`T`\>(`callback`, `options?`): `Promise`<`T`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | () => `T` \| `Promise`<`T`\> |
+| `options?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+#### Returns
+
+`Promise`<`T`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/wait-for.d.ts:9
+
+___
+
+### waitForElementToBeRemoved
+
+▸ **waitForElementToBeRemoved**<`T`\>(`callback`, `options?`): `Promise`<`void`\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `callback` | `T` \| () => `T` |
+| `options?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/wait-for-element-to-be-removed.d.ts:3
+
+___
+
+### within
+
+▸ **within**<`QueriesToBind`, `T`\>(`element`, `queriesToBind?`): [`BoundFunctions`](takaro_lib_components.testing.md#boundfunctions)<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `QueriesToBind` | extends [`Queries`](../interfaces/takaro_lib_components.testing.Queries-1.md) = [`queries`](takaro_lib_components.testing.queries.md) |
+| `T` | extends [`Queries`](../interfaces/takaro_lib_components.testing.Queries-1.md) = `QueriesToBind` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `element` | `HTMLElement` |
+| `queriesToBind?` | `T` |
+
+#### Returns
+
+[`BoundFunctions`](takaro_lib_components.testing.md#boundfunctions)<`T`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/get-queries-for-element.d.ts:178

--- a/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.testing.prettyFormat.md
+++ b/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.testing.prettyFormat.md
@@ -1,0 +1,296 @@
+---
+id: "takaro_lib_components.testing.prettyFormat"
+title: "Namespace: prettyFormat"
+sidebar_label: "@takaro/lib-components.testing.prettyFormat"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](takaro_lib_components.testing.md).prettyFormat
+
+## Interfaces
+
+- [PrettyFormatOptions](../interfaces/takaro_lib_components.testing.prettyFormat.PrettyFormatOptions.md)
+
+## References
+
+### default
+
+Renames and re-exports [format](takaro_lib_components.testing.prettyFormat.md#format)
+
+## Type Aliases
+
+### Colors
+
+Ƭ **Colors**: `Object`
+
+Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `comment` | { `close`: `string` ; `open`: `string`  } |
+| `comment.close` | `string` |
+| `comment.open` | `string` |
+| `content` | { `close`: `string` ; `open`: `string`  } |
+| `content.close` | `string` |
+| `content.open` | `string` |
+| `prop` | { `close`: `string` ; `open`: `string`  } |
+| `prop.close` | `string` |
+| `prop.open` | `string` |
+| `tag` | { `close`: `string` ; `open`: `string`  } |
+| `tag.close` | `string` |
+| `tag.open` | `string` |
+| `value` | { `close`: `string` ; `open`: `string`  } |
+| `value.close` | `string` |
+| `value.open` | `string` |
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:7
+
+___
+
+### CompareKeys
+
+Ƭ **CompareKeys**: (`a`: `string`, `b`: `string`) => `number` \| `undefined`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:46
+
+___
+
+### Config
+
+Ƭ **Config**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `callToJSON` | `boolean` |
+| `colors` | [`Colors`](takaro_lib_components.testing.prettyFormat.md#colors) |
+| `compareKeys` | [`CompareKeys`](takaro_lib_components.testing.prettyFormat.md#comparekeys) |
+| `escapeRegex` | `boolean` |
+| `escapeString` | `boolean` |
+| `indent` | `string` |
+| `maxDepth` | `number` |
+| `min` | `boolean` |
+| `plugins` | [`Plugins`](takaro_lib_components.testing.prettyFormat.md#plugins) |
+| `printBasicPrototype` | `boolean` |
+| `printFunctionName` | `boolean` |
+| `spacingInner` | `string` |
+| `spacingOuter` | `string` |
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:76
+
+___
+
+### NewPlugin
+
+Ƭ **NewPlugin**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `serialize` | (`val`: `any`, `config`: [`Config`](takaro_lib_components.testing.prettyFormat.md#config), `indentation`: `string`, `depth`: `number`, `refs`: [`Refs`](takaro_lib_components.testing.prettyFormat.md#refs), `printer`: [`Printer`](takaro_lib_components.testing.prettyFormat.md#printer)) => `string` |
+| `test` | `Test` |
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:93
+
+___
+
+### OldPlugin
+
+Ƭ **OldPlugin**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `print` | (`val`: `unknown`, `print`: `Print`, `indent`: `Indent`, `options`: `PluginOptions`, `colors`: [`Colors`](takaro_lib_components.testing.prettyFormat.md#colors)) => `string` |
+| `test` | `Test` |
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:102
+
+___
+
+### Options
+
+Ƭ **Options**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `callToJSON` | `boolean` |
+| `compareKeys` | [`CompareKeys`](takaro_lib_components.testing.prettyFormat.md#comparekeys) |
+| `escapeRegex` | `boolean` |
+| `escapeString` | `boolean` |
+| `highlight` | `boolean` |
+| `indent` | `number` |
+| `maxDepth` | `number` |
+| `min` | `boolean` |
+| `plugins` | [`Plugins`](takaro_lib_components.testing.prettyFormat.md#plugins) |
+| `printBasicPrototype` | `boolean` |
+| `printFunctionName` | `boolean` |
+| `theme` | [`Theme`](takaro_lib_components.testing.prettyFormat.md#theme) |
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:47
+
+___
+
+### OptionsReceived
+
+Ƭ **OptionsReceived**: [`PrettyFormatOptions`](../interfaces/takaro_lib_components.testing.prettyFormat.PrettyFormatOptions.md)
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:75
+
+___
+
+### Plugin
+
+Ƭ **Plugin**: [`NewPlugin`](takaro_lib_components.testing.prettyFormat.md#newplugin) \| [`OldPlugin`](takaro_lib_components.testing.prettyFormat.md#oldplugin)
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:106
+
+___
+
+### Plugins
+
+Ƭ **Plugins**: [`Plugin`](takaro_lib_components.testing.prettyFormat.md#plugin)[]
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:107
+
+___
+
+### Printer
+
+Ƭ **Printer**: (`val`: `unknown`, `config`: [`Config`](takaro_lib_components.testing.prettyFormat.md#config), `indentation`: `string`, `depth`: `number`, `refs`: [`Refs`](takaro_lib_components.testing.prettyFormat.md#refs), `hasCalledToJSON?`: `boolean`) => `string`
+
+#### Type declaration
+
+▸ (`val`, `config`, `indentation`, `depth`, `refs`, `hasCalledToJSON?`): `string`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `val` | `unknown` |
+| `config` | [`Config`](takaro_lib_components.testing.prettyFormat.md#config) |
+| `indentation` | `string` |
+| `depth` | `number` |
+| `refs` | [`Refs`](takaro_lib_components.testing.prettyFormat.md#refs) |
+| `hasCalledToJSON?` | `boolean` |
+
+##### Returns
+
+`string`
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:91
+
+___
+
+### Refs
+
+Ƭ **Refs**: `unknown`[]
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:30
+
+___
+
+### Theme
+
+Ƭ **Theme**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `comment` | `string` |
+| `content` | `string` |
+| `prop` | `string` |
+| `tag` | `string` |
+| `value` | `string` |
+
+#### Defined in
+
+node_modules/pretty-format/build/types.d.ts:32
+
+## Variables
+
+### DEFAULT\_OPTIONS
+
+• `Const` **DEFAULT\_OPTIONS**: [`Options`](takaro_lib_components.testing.prettyFormat.md#options)
+
+#### Defined in
+
+node_modules/pretty-format/build/index.d.ts:9
+
+___
+
+### plugins
+
+• `Const` **plugins**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `AsymmetricMatcher` | [`NewPlugin`](takaro_lib_components.testing.prettyFormat.md#newplugin) |
+| `ConvertAnsi` | [`NewPlugin`](takaro_lib_components.testing.prettyFormat.md#newplugin) |
+| `DOMCollection` | [`NewPlugin`](takaro_lib_components.testing.prettyFormat.md#newplugin) |
+| `DOMElement` | [`NewPlugin`](takaro_lib_components.testing.prettyFormat.md#newplugin) |
+| `Immutable` | [`NewPlugin`](takaro_lib_components.testing.prettyFormat.md#newplugin) |
+| `ReactElement` | [`NewPlugin`](takaro_lib_components.testing.prettyFormat.md#newplugin) |
+| `ReactTestComponent` | [`NewPlugin`](takaro_lib_components.testing.prettyFormat.md#newplugin) |
+
+#### Defined in
+
+node_modules/pretty-format/build/index.d.ts:16
+
+## Functions
+
+### format
+
+▸ **format**(`val`, `options?`): `string`
+
+Returns a presentation string of your `val` object
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `val` | `unknown` | any potential JavaScript object |
+| `options?` | [`PrettyFormatOptions`](../interfaces/takaro_lib_components.testing.prettyFormat.PrettyFormatOptions.md) | Custom settings |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+node_modules/pretty-format/build/index.d.ts:15

--- a/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.testing.queries.md
+++ b/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.testing.queries.md
@@ -1,0 +1,1746 @@
+---
+id: "takaro_lib_components.testing.queries"
+title: "Namespace: queries"
+sidebar_label: "@takaro/lib-components.testing.queries"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](takaro_lib_components.testing.md).queries
+
+## Interfaces
+
+- [ByRoleOptions](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md)
+
+## Type Aliases
+
+### AllByBoundAttribute
+
+Ƭ **AllByBoundAttribute**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `T`[]
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T`[]
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`T`[]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:11
+
+___
+
+### AllByRole
+
+Ƭ **AllByRole**<`T`\>: (`container`: `HTMLElement`, `role`: [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher), `options?`: [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md)) => `T`[]
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `role`, `options?`): `T`[]
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `role` | [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher) |
+| `options?` | [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md) |
+
+##### Returns
+
+`T`[]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:127
+
+___
+
+### AllByText
+
+Ƭ **AllByText**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md)) => `T`[]
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T`[]
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md) |
+
+##### Returns
+
+`T`[]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:43
+
+___
+
+### FindAllByBoundAttribute
+
+Ƭ **FindAllByBoundAttribute**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`[]\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`, `waitForElementOptions?`): `Promise`<`T`[]\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`[]\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:17
+
+___
+
+### FindAllByRole
+
+Ƭ **FindAllByRole**<`T`\>: (`container`: `HTMLElement`, `role`: [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher), `options?`: [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`[]\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `role`, `options?`, `waitForElementOptions?`): `Promise`<`T`[]\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `role` | [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher) |
+| `options?` | [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`[]\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:152
+
+___
+
+### FindAllByText
+
+Ƭ **FindAllByText**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`[]\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`, `waitForElementOptions?`): `Promise`<`T`[]\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`[]\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:49
+
+___
+
+### FindByBoundAttribute
+
+Ƭ **FindByBoundAttribute**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`, `waitForElementOptions?`): `Promise`<`T`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:30
+
+___
+
+### FindByRole
+
+Ƭ **FindByRole**<`T`\>: (`container`: `HTMLElement`, `role`: [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher), `options?`: [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `role`, `options?`, `waitForElementOptions?`): `Promise`<`T`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `role` | [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher) |
+| `options?` | [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:145
+
+___
+
+### FindByText
+
+Ƭ **FindByText**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md), `waitForElementOptions?`: [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md)) => `Promise`<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`, `waitForElementOptions?`): `Promise`<`T`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md) |
+| `waitForElementOptions?` | [`waitForOptions`](../interfaces/takaro_lib_components.testing.waitForOptions.md) |
+
+##### Returns
+
+`Promise`<`T`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:62
+
+___
+
+### GetByBoundAttribute
+
+Ƭ **GetByBoundAttribute**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `T`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`T`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:24
+
+___
+
+### GetByRole
+
+Ƭ **GetByRole**<`T`\>: (`container`: `HTMLElement`, `role`: [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher), `options?`: [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md)) => `T`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `role`, `options?`): `T`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `role` | [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher) |
+| `options?` | [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md) |
+
+##### Returns
+
+`T`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:133
+
+___
+
+### GetByText
+
+Ƭ **GetByText**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md)) => `T`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md) |
+
+##### Returns
+
+`T`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:56
+
+___
+
+### QueryByBoundAttribute
+
+Ƭ **QueryByBoundAttribute**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `T` \| ``null``
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T` \| ``null``
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`T` \| ``null``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:5
+
+___
+
+### QueryByRole
+
+Ƭ **QueryByRole**<`T`\>: (`container`: `HTMLElement`, `role`: [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher), `options?`: [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md)) => `T` \| ``null``
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `role`, `options?`): `T` \| ``null``
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `role` | [`ByRoleMatcher`](takaro_lib_components.testing.md#byrolematcher) |
+| `options?` | [`ByRoleOptions`](../interfaces/takaro_lib_components.testing.queries.ByRoleOptions.md) |
+
+##### Returns
+
+`T` \| ``null``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:139
+
+___
+
+### QueryByText
+
+Ƭ **QueryByText**<`T`\>: (`container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md)) => `T` \| ``null``
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Type declaration
+
+▸ (`container`, `id`, `options?`): `T` \| ``null``
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`SelectorMatcherOptions`](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md) |
+
+##### Returns
+
+`T` \| ``null``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:37
+
+## Functions
+
+### findAllByAltText
+
+▸ **findAllByAltText**<`T`\>(...`args`): `ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:228
+
+___
+
+### findAllByDisplayValue
+
+▸ **findAllByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:264
+
+___
+
+### findAllByLabelText
+
+▸ **findAllByLabelText**<`T`\>(...`args`): `ReturnType`<[`FindAllByText`](takaro_lib_components.testing.queries.md#findallbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByText`](takaro_lib_components.testing.queries.md#findallbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:174
+
+___
+
+### findAllByPlaceholderText
+
+▸ **findAllByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:192
+
+___
+
+### findAllByRole
+
+▸ **findAllByRole**<`T`\>(...`args`): `ReturnType`<[`FindAllByRole`](takaro_lib_components.testing.queries.md#findallbyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByRole`](takaro_lib_components.testing.queries.md#findallbyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:282
+
+___
+
+### findAllByTestId
+
+▸ **findAllByTestId**<`T`\>(...`args`): `ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:300
+
+___
+
+### findAllByText
+
+▸ **findAllByText**<`T`\>(...`args`): `ReturnType`<[`FindAllByText`](takaro_lib_components.testing.queries.md#findallbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByText`](takaro_lib_components.testing.queries.md#findallbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:210
+
+___
+
+### findAllByTitle
+
+▸ **findAllByTitle**<`T`\>(...`args`): `ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindAllByBoundAttribute`](takaro_lib_components.testing.queries.md#findallbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:246
+
+___
+
+### findByAltText
+
+▸ **findByAltText**<`T`\>(...`args`): `ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:225
+
+___
+
+### findByDisplayValue
+
+▸ **findByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:261
+
+___
+
+### findByLabelText
+
+▸ **findByLabelText**<`T`\>(...`args`): `ReturnType`<[`FindByText`](takaro_lib_components.testing.queries.md#findbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByText`](takaro_lib_components.testing.queries.md#findbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:171
+
+___
+
+### findByPlaceholderText
+
+▸ **findByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:189
+
+___
+
+### findByRole
+
+▸ **findByRole**<`T`\>(...`args`): `ReturnType`<[`FindByRole`](takaro_lib_components.testing.queries.md#findbyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByRole`](takaro_lib_components.testing.queries.md#findbyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:279
+
+___
+
+### findByTestId
+
+▸ **findByTestId**<`T`\>(...`args`): `ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:297
+
+___
+
+### findByText
+
+▸ **findByText**<`T`\>(...`args`): `ReturnType`<[`FindByText`](takaro_lib_components.testing.queries.md#findbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByText`](takaro_lib_components.testing.queries.md#findbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:207
+
+___
+
+### findByTitle
+
+▸ **findByTitle**<`T`\>(...`args`): `ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions, waitForElementOptions?: waitForOptions] |
+
+#### Returns
+
+`ReturnType`<[`FindByBoundAttribute`](takaro_lib_components.testing.queries.md#findbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:243
+
+___
+
+### getAllByAltText
+
+▸ **getAllByAltText**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:216
+
+___
+
+### getAllByDisplayValue
+
+▸ **getAllByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:252
+
+___
+
+### getAllByLabelText
+
+▸ **getAllByLabelText**<`T`\>(...`args`): `ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:162
+
+___
+
+### getAllByPlaceholderText
+
+▸ **getAllByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:180
+
+___
+
+### getAllByRole
+
+▸ **getAllByRole**<`T`\>(...`args`): `ReturnType`<[`AllByRole`](takaro_lib_components.testing.queries.md#allbyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByRole`](takaro_lib_components.testing.queries.md#allbyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:270
+
+___
+
+### getAllByTestId
+
+▸ **getAllByTestId**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:288
+
+___
+
+### getAllByText
+
+▸ **getAllByText**<`T`\>(...`args`): `ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:198
+
+___
+
+### getAllByTitle
+
+▸ **getAllByTitle**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:234
+
+___
+
+### getByAltText
+
+▸ **getByAltText**<`T`\>(...`args`): `ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:213
+
+___
+
+### getByDisplayValue
+
+▸ **getByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:249
+
+___
+
+### getByLabelText
+
+▸ **getByLabelText**<`T`\>(...`args`): `ReturnType`<[`GetByText`](takaro_lib_components.testing.queries.md#getbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByText`](takaro_lib_components.testing.queries.md#getbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:159
+
+___
+
+### getByPlaceholderText
+
+▸ **getByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:177
+
+___
+
+### getByRole
+
+▸ **getByRole**<`T`\>(...`args`): `ReturnType`<[`GetByRole`](takaro_lib_components.testing.queries.md#getbyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByRole`](takaro_lib_components.testing.queries.md#getbyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:267
+
+___
+
+### getByTestId
+
+▸ **getByTestId**<`T`\>(...`args`): `ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:285
+
+___
+
+### getByText
+
+▸ **getByText**<`T`\>(...`args`): `ReturnType`<[`GetByText`](takaro_lib_components.testing.queries.md#getbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByText`](takaro_lib_components.testing.queries.md#getbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:195
+
+___
+
+### getByTitle
+
+▸ **getByTitle**<`T`\>(...`args`): `ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`GetByBoundAttribute`](takaro_lib_components.testing.queries.md#getbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:231
+
+___
+
+### queryAllByAltText
+
+▸ **queryAllByAltText**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:222
+
+___
+
+### queryAllByDisplayValue
+
+▸ **queryAllByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:258
+
+___
+
+### queryAllByLabelText
+
+▸ **queryAllByLabelText**<`T`\>(...`args`): `ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:168
+
+___
+
+### queryAllByPlaceholderText
+
+▸ **queryAllByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:186
+
+___
+
+### queryAllByRole
+
+▸ **queryAllByRole**<`T`\>(...`args`): `ReturnType`<[`AllByRole`](takaro_lib_components.testing.queries.md#allbyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByRole`](takaro_lib_components.testing.queries.md#allbyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:276
+
+___
+
+### queryAllByTestId
+
+▸ **queryAllByTestId**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:294
+
+___
+
+### queryAllByText
+
+▸ **queryAllByText**<`T`\>(...`args`): `ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByText`](takaro_lib_components.testing.queries.md#allbytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:204
+
+___
+
+### queryAllByTitle
+
+▸ **queryAllByTitle**<`T`\>(...`args`): `ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`AllByBoundAttribute`](takaro_lib_components.testing.queries.md#allbyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:240
+
+___
+
+### queryByAltText
+
+▸ **queryByAltText**<`T`\>(...`args`): `ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:219
+
+___
+
+### queryByDisplayValue
+
+▸ **queryByDisplayValue**<`T`\>(...`args`): `ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:255
+
+___
+
+### queryByLabelText
+
+▸ **queryByLabelText**<`T`\>(...`args`): `ReturnType`<[`QueryByText`](takaro_lib_components.testing.queries.md#querybytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByText`](takaro_lib_components.testing.queries.md#querybytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:165
+
+___
+
+### queryByPlaceholderText
+
+▸ **queryByPlaceholderText**<`T`\>(...`args`): `ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:183
+
+___
+
+### queryByRole
+
+▸ **queryByRole**<`T`\>(...`args`): `ReturnType`<[`QueryByRole`](takaro_lib_components.testing.queries.md#querybyrole)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, role: ByRoleMatcher, options?: ByRoleOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByRole`](takaro_lib_components.testing.queries.md#querybyrole)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:273
+
+___
+
+### queryByTestId
+
+▸ **queryByTestId**<`T`\>(...`args`): `ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:291
+
+___
+
+### queryByText
+
+▸ **queryByText**<`T`\>(...`args`): `ReturnType`<[`QueryByText`](takaro_lib_components.testing.queries.md#querybytext)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: SelectorMatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByText`](takaro_lib_components.testing.queries.md#querybytext)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:201
+
+___
+
+### queryByTitle
+
+▸ **queryByTitle**<`T`\>(...`args`): `ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` = `HTMLElement` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `...args` | [container: HTMLElement, id: Matcher, options?: MatcherOptions] |
+
+#### Returns
+
+`ReturnType`<[`QueryByBoundAttribute`](takaro_lib_components.testing.queries.md#querybyboundattribute)<`T`\>\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/queries.d.ts:237

--- a/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.testing.queryHelpers.md
+++ b/packages/web-docs/docs/development/packages/namespaces/takaro_lib_components.testing.queryHelpers.md
@@ -1,0 +1,338 @@
+---
+id: "takaro_lib_components.testing.queryHelpers"
+title: "Namespace: queryHelpers"
+sidebar_label: "@takaro/lib-components.testing.queryHelpers"
+custom_edit_url: null
+---
+
+[@takaro/lib-components](../modules/takaro_lib_components.md).[testing](takaro_lib_components.testing.md).queryHelpers
+
+## Interfaces
+
+- [SelectorMatcherOptions](../interfaces/takaro_lib_components.testing.queryHelpers.SelectorMatcherOptions.md)
+
+## Type Aliases
+
+### AllByAttribute
+
+Ƭ **AllByAttribute**: (`attribute`: `string`, `container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `HTMLElement`[]
+
+#### Type declaration
+
+▸ (`attribute`, `container`, `id`, `options?`): `HTMLElement`[]
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `attribute` | `string` |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`HTMLElement`[]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:23
+
+___
+
+### BuiltQueryMethods
+
+Ƭ **BuiltQueryMethods**<`Arguments`\>: [[`QueryBy`](takaro_lib_components.testing.queryHelpers.md#queryby)<`Arguments`\>, [`GetAllBy`](takaro_lib_components.testing.queryHelpers.md#getallby)<`Arguments`\>, [`GetBy`](takaro_lib_components.testing.queryHelpers.md#getby)<`Arguments`\>, [`FindAllBy`](takaro_lib_components.testing.queryHelpers.md#findallby)<`Arguments`\>, [`FindBy`](takaro_lib_components.testing.queryHelpers.md#findby)<`Arguments`\>]
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:62
+
+___
+
+### FindAllBy
+
+Ƭ **FindAllBy**<`Arguments`\>: [`QueryMethod`](takaro_lib_components.testing.queryHelpers.md#querymethod)<[`Arguments`[``0``], Arguments[1]?, waitForOptions?], `Promise`<`HTMLElement`[]\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:52
+
+___
+
+### FindBy
+
+Ƭ **FindBy**<`Arguments`\>: [`QueryMethod`](takaro_lib_components.testing.queryHelpers.md#querymethod)<[`Arguments`[``0``], Arguments[1]?, waitForOptions?], `Promise`<`HTMLElement`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:57
+
+___
+
+### GetAllBy
+
+Ƭ **GetAllBy**<`Arguments`\>: [`QueryMethod`](takaro_lib_components.testing.queryHelpers.md#querymethod)<`Arguments`, `HTMLElement`[]\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:48
+
+___
+
+### GetBy
+
+Ƭ **GetBy**<`Arguments`\>: [`QueryMethod`](takaro_lib_components.testing.queryHelpers.md#querymethod)<`Arguments`, `HTMLElement`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:56
+
+___
+
+### GetErrorFunction
+
+Ƭ **GetErrorFunction**<`Arguments`\>: (`c`: `Element` \| ``null``, ...`args`: `Arguments`) => `string`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] = [`string`] |
+
+#### Type declaration
+
+▸ (`c`, ...`args`): `string`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `c` | `Element` \| ``null`` |
+| `...args` | `Arguments` |
+
+##### Returns
+
+`string`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:6
+
+___
+
+### QueryBy
+
+Ƭ **QueryBy**<`Arguments`\>: [`QueryMethod`](takaro_lib_components.testing.queryHelpers.md#querymethod)<`Arguments`, `HTMLElement` \| ``null``\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:44
+
+___
+
+### QueryByAttribute
+
+Ƭ **QueryByAttribute**: (`attribute`: `string`, `container`: `HTMLElement`, `id`: [`Matcher`](takaro_lib_components.testing.md#matcher), `options?`: [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md)) => `HTMLElement` \| ``null``
+
+#### Type declaration
+
+▸ (`attribute`, `container`, `id`, `options?`): `HTMLElement` \| ``null``
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `attribute` | `string` |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+##### Returns
+
+`HTMLElement` \| ``null``
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:16
+
+___
+
+### QueryMethod
+
+Ƭ **QueryMethod**<`Arguments`, `Return`\>: (`container`: `HTMLElement`, ...`args`: `Arguments`) => `Return`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+| `Return` | `Return` |
+
+#### Type declaration
+
+▸ (`container`, ...`args`): `Return`
+
+query methods have a common call signature. Only the return type differs.
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `container` | `HTMLElement` |
+| `...args` | `Arguments` |
+
+##### Returns
+
+`Return`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:40
+
+___
+
+### WithSuggest
+
+Ƭ **WithSuggest**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `suggest?` | `boolean` |
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:4
+
+## Functions
+
+### buildQueries
+
+▸ **buildQueries**<`Arguments`\>(`queryAllBy`, `getMultipleError`, `getMissingError`): [`BuiltQueryMethods`](takaro_lib_components.testing.queryHelpers.md#builtquerymethods)<`Arguments`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Arguments` | extends `any`[] |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `queryAllBy` | [`GetAllBy`](takaro_lib_components.testing.queryHelpers.md#getallby)<`Arguments`\> |
+| `getMultipleError` | [`GetErrorFunction`](takaro_lib_components.testing.queryHelpers.md#geterrorfunction)<`Arguments`\> |
+| `getMissingError` | [`GetErrorFunction`](takaro_lib_components.testing.queryHelpers.md#geterrorfunction)<`Arguments`\> |
+
+#### Returns
+
+[`BuiltQueryMethods`](takaro_lib_components.testing.queryHelpers.md#builtquerymethods)<`Arguments`\>
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:70
+
+___
+
+### getElementError
+
+▸ **getElementError**(`message`, `container`): `Error`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `message` | ``null`` \| `string` |
+| `container` | `HTMLElement` |
+
+#### Returns
+
+`Error`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:32
+
+___
+
+### queryAllByAttribute
+
+▸ **queryAllByAttribute**(`attribute`, `container`, `id`, `options?`): `HTMLElement`[]
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `attribute` | `string` |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+#### Returns
+
+`HTMLElement`[]
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:23
+
+___
+
+### queryByAttribute
+
+▸ **queryByAttribute**(`attribute`, `container`, `id`, `options?`): ``null`` \| `HTMLElement`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `attribute` | `string` |
+| `container` | `HTMLElement` |
+| `id` | [`Matcher`](takaro_lib_components.testing.md#matcher) |
+| `options?` | [`MatcherOptions`](../interfaces/takaro_lib_components.testing.MatcherOptions.md) |
+
+#### Returns
+
+``null`` \| `HTMLElement`
+
+#### Defined in
+
+node_modules/@testing-library/dom/types/query-helpers.d.ts:16

--- a/packages/web-docs/docs/development/packages/namespaces/takaro_test.snapshot.md
+++ b/packages/web-docs/docs/development/packages/namespaces/takaro_test.snapshot.md
@@ -1,0 +1,33 @@
+---
+id: "takaro_test.snapshot"
+title: "Namespace: snapshot"
+sidebar_label: "@takaro/test.snapshot"
+custom_edit_url: null
+---
+
+[@takaro/test](../modules/takaro_test.md).snapshot
+
+## Classes
+
+- [ITestWithSnapshot](../classes/takaro_test.snapshot.ITestWithSnapshot.md)
+
+## Functions
+
+### matchSnapshot
+
+▸ **matchSnapshot**(`test`, `response`): `Promise`<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `test` | [`ITestWithSnapshot`](../classes/takaro_test.snapshot.ITestWithSnapshot.md)<`unknown`\> |
+| `response` | `ITakaroAPIAxiosResponse`<`unknown`\> |
+
+#### Returns
+
+`Promise`<`void`\>
+
+#### Defined in
+
+[packages/test/src/snapshots.ts:56](https://github.com/niekcandaele/Takaro/blob/91fb19b/packages/test/src/snapshots.ts#L56)

--- a/packages/web-docs/docs/development/packages/namespaces/takaro_util.errors.md
+++ b/packages/web-docs/docs/development/packages/namespaces/takaro_util.errors.md
@@ -1,0 +1,23 @@
+---
+id: "takaro_util.errors"
+title: "Namespace: errors"
+sidebar_label: "@takaro/util.errors"
+custom_edit_url: null
+---
+
+[@takaro/util](../modules/takaro_util.md).errors
+
+## Classes
+
+- [BadRequestError](../classes/takaro_util.errors.BadRequestError.md)
+- [ConfigError](../classes/takaro_util.errors.ConfigError.md)
+- [ConflictError](../classes/takaro_util.errors.ConflictError.md)
+- [ForbiddenError](../classes/takaro_util.errors.ForbiddenError.md)
+- [GameServerError](../classes/takaro_util.errors.GameServerError.md)
+- [InternalServerError](../classes/takaro_util.errors.InternalServerError.md)
+- [NotFoundError](../classes/takaro_util.errors.NotFoundError.md)
+- [NotImplementedError](../classes/takaro_util.errors.NotImplementedError.md)
+- [TakaroError](../classes/takaro_util.errors.TakaroError.md)
+- [UnauthorizedError](../classes/takaro_util.errors.UnauthorizedError.md)
+- [ValidationError](../classes/takaro_util.errors.ValidationError.md)
+- [WsTimeOutError](../classes/takaro_util.errors.WsTimeOutError.md)

--- a/packages/web-docs/docusaurus.config.js
+++ b/packages/web-docs/docusaurus.config.js
@@ -32,6 +32,24 @@ async function createConfig() {
       locales: ['en'],
     },
 
+    plugins: [
+      [
+        'docusaurus-plugin-typedoc',
+
+        // Plugin / TypeDoc options
+        {
+          entryPoints: ['../..'],
+          entryPointStrategy: 'packages',
+          sidebar: {
+            categoryLabel: 'Packages API',
+            fullNames: true,
+          },
+          tsconfig: '../lib-config/tsconfig.json',
+          out: 'development/packages',
+        },
+      ],
+    ],
+
     presets: [
       [
         'classic',

--- a/packages/web-docs/package.json
+++ b/packages/web-docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start:dev": "docusaurus start --port 13005 --host 0.0.0.0",
+    "start:dev": "TYPEDOC_WATCH=true docusaurus start --port 13005 --host 0.0.0.0",
     "build": "docusaurus build",
     "docusaurus": "docusaurus",
     "swizzle": "docusaurus swizzle",
@@ -19,16 +19,18 @@
     "@docusaurus/preset-classic": "^2.2.0",
     "@docusaurus/theme-mermaid": "^2.2.0",
     "@mdx-js/react": "^1.6.22",
+    "@types/react": "17.0.2",
+    "@types/react-dom": "17.0.2",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "@types/react": "17.0.2",
-    "@types/react-dom": "17.0.2"
+    "react-dom": "17.0.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.2.0",
     "@tsconfig/docusaurus": "^1.0.5",
+    "docusaurus-plugin-typedoc": "^0.17.5",
+    "typedoc-plugin-markdown": "^3.13.6",
     "typescript": "^4.7.4"
   },
   "browserslist": {


### PR DESCRIPTION
Using https://github.com/tgreyuk/typedoc-plugin-markdown/tree/master/packages/docusaurus-plugin-typedoc

TODO: 

- Should show READMEs of the packages (Should be [supported by TypeDoc](https://github.com/TypeStrong/typedoc/pull/1977) but maybe the Docusaurus plugin doesn't support it?)

- Better dev-mode setup. If you change source code in one of the packages, the docs should automatically update (and get committed ?)


![image](https://user-images.githubusercontent.com/22315101/200424925-4393e864-284b-414c-bd1c-531d624a5e98.png)
