### PR TITLE
feat: improve queue memory usage

### DIFF
--- a/packages/app-api/src/service/CommandService.ts
+++ b/packages/app-api/src/service/CommandService.ts
@@ -326,7 +326,7 @@ export class CommandService extends TakaroService<
       const promises = parsedCommands.map(async ({ data, db }) => {
         return queueService.queues.commands.queue.add({
           domainId: this.domainId,
-          function: db.function.code,
+          functionId: db.function.id,
           itemId: db.id,
           data,
           gameServerId,

--- a/packages/app-api/src/service/CronJobService.ts
+++ b/packages/app-api/src/service/CronJobService.ts
@@ -198,7 +198,7 @@ export class CronJobService extends TakaroService<
     const jobId = this.getJobId(modInstallation, cronJob);
     await queueService.queues.cronjobs.queue.add(
       {
-        function: cronJob.function.code,
+        functionId: cronJob.function.id,
         domainId: this.domainId,
         itemId: cronJob.id,
         gameServerId: modInstallation.gameserverId,

--- a/packages/app-api/src/service/HookService.ts
+++ b/packages/app-api/src/service/HookService.ts
@@ -197,7 +197,7 @@ export class HookService extends TakaroService<
               ),
             },
             domainId: this.domainId,
-            function: hook.function.code,
+            functionId: hook.function.id,
             gameServerId,
           });
         })

--- a/packages/app-vmm/src/service/workers/commandWorker.ts
+++ b/packages/app-vmm/src/service/workers/commandWorker.ts
@@ -18,7 +18,7 @@ async function processCommand(job: Job<IJobData>) {
   });
 
   await executeFunction(
-    job.data.function,
+    job.data.functionId,
     {
       ...job.data.data,
       gameServerId: job.data.gameServerId,

--- a/packages/app-vmm/src/service/workers/cronjobWorker.ts
+++ b/packages/app-vmm/src/service/workers/cronjobWorker.ts
@@ -17,7 +17,7 @@ async function processCronJob(job: Job<IJobData>) {
   });
 
   await executeFunction(
-    job.data.function,
+    job.data.functionId,
     {
       ...job.data.data,
       gameServerId: job.data.gameServerId,

--- a/packages/app-vmm/src/service/workers/hookWorker.ts
+++ b/packages/app-vmm/src/service/workers/hookWorker.ts
@@ -17,7 +17,7 @@ async function processHook(job: Job<IJobData>) {
   });
 
   await executeFunction(
-    job.data.function,
+    job.data.functionId,
     {
       ...job.data.data,
       gameServerId: job.data.gameServerId,

--- a/packages/lib-queues/src/dataDefinitions.ts
+++ b/packages/lib-queues/src/dataDefinitions.ts
@@ -6,7 +6,7 @@ export interface IBaseJobData {
 }
 
 export interface IJobData extends IBaseJobData {
-  function: string;
+  functionId: string;
 
   /**
    * The id of the item that triggered this job (cronjobId, commandId or hookId)


### PR DESCRIPTION
Storing only the id and fetching on-demand means our queue needs a lot less memory