### PR TITLE
refactor: event awaiter to be more stable

### DIFF
--- a/packages/app-api/src/controllers/__tests__/VariableController.integration.test.ts
+++ b/packages/app-api/src/controllers/__tests__/VariableController.integration.test.ts
@@ -2,7 +2,7 @@ import {
   IntegrationTest,
   expect,
   integrationConfig,
-  waitForEvents,
+  EventsAwaiter,
 } from '@takaro/test';
 import {
   GameServerOutputDTO,
@@ -50,8 +50,9 @@ const setupWithGameServersAndPlayers = async function (
     }),
   });
 
-  const connectedEvents = waitForEvents(
-    this.client,
+  const eventsAwaiter = new EventsAwaiter();
+  await eventsAwaiter.connect(this.client);
+  const connectedEvents = eventsAwaiter.waitForEvents(
     GameEvents.PLAYER_CONNECTED,
     10
   );

--- a/packages/app-api/src/service/__tests__/CommandService.integration.test.ts
+++ b/packages/app-api/src/service/__tests__/CommandService.integration.test.ts
@@ -3,7 +3,7 @@ import {
   sandbox,
   expect,
   integrationConfig,
-  waitForEvents,
+  EventsAwaiter,
 } from '@takaro/test';
 import {
   CommandOutputDTO,
@@ -68,8 +68,9 @@ async function setup(
     })
   ).data.data;
 
-  const connectedEvents = waitForEvents(
-    this.client,
+  const eventsAwaiter = new EventsAwaiter();
+  await eventsAwaiter.connect(this.client);
+  const connectedEvents = eventsAwaiter.waitForEvents(
     GameEvents.PLAYER_CONNECTED,
     5
   );

--- a/packages/lib-modules/src/__tests__/help.integration.test.ts
+++ b/packages/lib-modules/src/__tests__/help.integration.test.ts
@@ -1,4 +1,4 @@
-import { IntegrationTest, expect, waitForEvents } from '@takaro/test';
+import { IntegrationTest, expect, EventsAwaiter } from '@takaro/test';
 import { GameEvents } from '@takaro/gameserver';
 import {
   IModuleTestsSetupData,
@@ -19,7 +19,9 @@ const tests = [
         this.setupData.gameserver.id,
         this.setupData.utilsModule.id
       );
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 3);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 3);
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
         {
@@ -56,7 +58,9 @@ const tests = [
         this.setupData.gameserver.id,
         this.setupData.teleportsModule.id
       );
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 7);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 7);
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
         {
@@ -100,7 +104,9 @@ const tests = [
         this.setupData.utilsModule.id
       );
 
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 1);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 1);
 
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
@@ -131,7 +137,9 @@ const tests = [
         this.setupData.utilsModule.id
       );
 
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 1);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 1);
 
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,

--- a/packages/lib-modules/src/__tests__/onboarding.integration.test.ts
+++ b/packages/lib-modules/src/__tests__/onboarding.integration.test.ts
@@ -1,4 +1,4 @@
-import { IntegrationTest, expect, waitForEvents } from '@takaro/test';
+import { IntegrationTest, expect, EventsAwaiter } from '@takaro/test';
 import { GameEvents } from '@takaro/gameserver';
 import {
   IModuleTestsSetupData,
@@ -18,7 +18,9 @@ const tests = [
         this.setupData.gameserver.id,
         this.setupData.onboardingModule.id
       );
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE);
       await this.client.hook.hookControllerTrigger({
         gameServerId: this.setupData.gameserver.id,
         eventType: GameEvents.PLAYER_CONNECTED,

--- a/packages/lib-modules/src/__tests__/ping.integration.test.ts
+++ b/packages/lib-modules/src/__tests__/ping.integration.test.ts
@@ -1,4 +1,4 @@
-import { IntegrationTest, expect, waitForEvents } from '@takaro/test';
+import { IntegrationTest, expect, EventsAwaiter } from '@takaro/test';
 import { GameEvents } from '@takaro/gameserver';
 import {
   IModuleTestsSetupData,
@@ -19,7 +19,9 @@ const tests = [
         this.setupData.utilsModule.id
       );
 
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE);
 
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,

--- a/packages/lib-modules/src/__tests__/serverMessages.integration.test.ts
+++ b/packages/lib-modules/src/__tests__/serverMessages.integration.test.ts
@@ -1,4 +1,4 @@
-import { IntegrationTest, expect, waitForEvents } from '@takaro/test';
+import { IntegrationTest, expect, EventsAwaiter } from '@takaro/test';
 import { GameEvents } from '@takaro/gameserver';
 import {
   IModuleTestsSetupData,
@@ -19,7 +19,9 @@ const tests = [
         this.setupData.serverMessagesModule.id
       );
 
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE);
 
       await this.client.cronjob.cronJobControllerTrigger({
         cronjobId: this.setupData.serverMessagesModule.cronJobs[0].id,
@@ -50,7 +52,9 @@ const tests = [
         }
       );
 
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE);
 
       await this.client.cronjob.cronJobControllerTrigger({
         cronjobId: this.setupData.serverMessagesModule.cronJobs[0].id,
@@ -79,7 +83,9 @@ const tests = [
       );
 
       // We should see each of our test messages at least once
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 10);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 10);
 
       // Trigger it 10 times
       await Promise.all(

--- a/packages/lib-modules/src/__tests__/setupData.integration.test.ts
+++ b/packages/lib-modules/src/__tests__/setupData.integration.test.ts
@@ -2,7 +2,7 @@ import { ModuleOutputDTO, GameServerOutputDTO } from '@takaro/apiclient';
 import {
   integrationConfig,
   IntegrationTest,
-  waitForEvents,
+  EventsAwaiter,
 } from '@takaro/test';
 import { GameEvents } from '@takaro/gameserver';
 
@@ -55,8 +55,10 @@ export const modulesTestSetup = async function (
   const onboardingModule = modules.find((m) => m.name === 'playerOnboarding');
   if (!onboardingModule) throw new Error('playerOnboarding module not found');
 
-  const connectedEvents = waitForEvents(
-    this.client,
+  const eventAwaiter = new EventsAwaiter();
+  await eventAwaiter.connect(this.client);
+
+  const connectedEvents = eventAwaiter.waitForEvents(
     GameEvents.PLAYER_CONNECTED,
     5
   );

--- a/packages/lib-modules/src/__tests__/teleports.integration.test.ts
+++ b/packages/lib-modules/src/__tests__/teleports.integration.test.ts
@@ -1,4 +1,4 @@
-import { IntegrationTest, expect, waitForEvents } from '@takaro/test';
+import { IntegrationTest, expect, EventsAwaiter } from '@takaro/test';
 import { GameEvents } from '@takaro/gameserver';
 import {
   IModuleTestsSetupData,
@@ -18,7 +18,9 @@ const tests = [
         this.setupData.gameserver.id,
         this.setupData.teleportsModule.id
       );
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE);
 
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
@@ -45,8 +47,9 @@ const tests = [
         this.setupData.teleportsModule.id
       );
 
-      const firstEvents = waitForEvents(
-        this.client,
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const firstEvents = eventAwaiter.waitForEvents(
         GameEvents.CHAT_MESSAGE,
         1
       );
@@ -64,8 +67,7 @@ const tests = [
       expect((await firstEvents).length).to.be.eq(1);
       expect((await firstEvents)[0].data.msg).to.be.eq('Teleport test set.');
 
-      const secondEvents = waitForEvents(
-        this.client,
+      const secondEvents = eventAwaiter.waitForEvents(
         GameEvents.CHAT_MESSAGE,
         1
       );
@@ -99,7 +101,9 @@ const tests = [
           userConfig: JSON.stringify({ maxTeleports: 3 }),
         }
       );
-      const setEvents = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 3);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const setEvents = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 3);
 
       await Promise.all(
         Array.from({ length: 3 }).map(async (_, i) => {
@@ -120,7 +124,7 @@ const tests = [
       for (const event of await setEvents) {
         expect(event.data.msg).to.match(/Teleport test\d set\./);
       }
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE);
 
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
@@ -149,7 +153,9 @@ const tests = [
         this.setupData.teleportsModule.id
       );
 
-      const setEvents = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 1);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const setEvents = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 1);
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
         {
@@ -163,7 +169,7 @@ const tests = [
       expect((await setEvents).length).to.be.eq(1);
       expect((await setEvents)[0].data.msg).to.be.eq('Teleport test set.');
 
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 1);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 1);
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
         {
@@ -188,7 +194,9 @@ const tests = [
         this.setupData.gameserver.id,
         this.setupData.teleportsModule.id
       );
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE);
 
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
@@ -217,7 +225,9 @@ const tests = [
         this.setupData.teleportsModule.id
       );
 
-      const setEvents = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 3);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const setEvents = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 3);
 
       await Promise.all(
         Array.from({ length: 3 }).map(async (_, i) => {
@@ -239,7 +249,7 @@ const tests = [
         expect(event.data.msg).to.match(/Teleport test\d set\./);
       }
 
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 4);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 4);
 
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
@@ -275,7 +285,9 @@ const tests = [
         this.setupData.gameserver.id,
         this.setupData.teleportsModule.id
       );
-      const setEvents = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 3);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const setEvents = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 3);
 
       await Promise.all(
         Array.from({ length: 3 }).map(async (_, i) => {
@@ -296,7 +308,7 @@ const tests = [
       for (const event of await setEvents) {
         expect(event.data.msg).to.match(/Teleport test\d set\./);
       }
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE, 1);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE, 1);
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
         {
@@ -321,7 +333,9 @@ const tests = [
         this.setupData.gameserver.id,
         this.setupData.teleportsModule.id
       );
-      const events = waitForEvents(this.client, GameEvents.CHAT_MESSAGE);
+      const eventAwaiter = new EventsAwaiter();
+      await eventAwaiter.connect(this.client);
+      const events = eventAwaiter.waitForEvents(GameEvents.CHAT_MESSAGE);
       await this.client.command.commandControllerTrigger(
         this.setupData.gameserver.id,
         {

--- a/packages/test/src/main.ts
+++ b/packages/test/src/main.ts
@@ -1,6 +1,6 @@
 export { expect } from './test/expect.js';
 export { sandbox } from './test/sandbox.js';
-export { IDetectedEvent, waitForEvents } from './test/waitForEvents.js';
+export { IDetectedEvent, EventsAwaiter } from './test/waitForEvents.js';
 export { integrationConfig } from './test/integrationConfig.js';
 
 export * as snapshot from './snapshots.js';

--- a/packages/test/src/test/waitForEvents.ts
+++ b/packages/test/src/test/waitForEvents.ts
@@ -1,6 +1,6 @@
 import { GameEvents } from '@takaro/gameserver';
 import { Client } from '@takaro/apiclient';
-import { io } from 'socket.io-client';
+import { io, Socket } from 'socket.io-client';
 import { integrationConfig } from './integrationConfig.js';
 
 export interface IDetectedEvent {
@@ -8,45 +8,58 @@ export interface IDetectedEvent {
   data: any;
 }
 
-export async function waitForEvents(
-  client: Client,
-  expectedEvent: GameEvents,
-  amount = 1
-) {
-  const events: IDetectedEvent[] = [];
-  let hasFinished = false;
-  return Promise.race([
-    new Promise<IDetectedEvent[]>(async (resolve) => {
-      const socket = io(integrationConfig.get('host'), {
+export class EventsAwaiter {
+  socket: Socket;
+
+  async connect(client: Client) {
+    return new Promise<void>((resolve, reject) => {
+      this.socket = io(integrationConfig.get('host'), {
         extraHeaders: {
           Authorization: `Bearer ${client.token}`,
         },
       });
 
-      socket.on('gameEvent', (_gameserverId, event, data) => {
-        if (event !== expectedEvent) {
-          // log.warn(`Received event ${event} but expected ${expectedEvent}`);
-          // log.warn(JSON.stringify({ event, data }, null, 2));
-          return;
-        }
-
-        if (event === expectedEvent) {
-          events.push({ event, data });
-        }
-
-        if (events.length === amount) {
-          hasFinished = true;
-          resolve(events);
-        }
+      this.socket.on('connect', () => {
+        return resolve();
       });
-    }),
-    new Promise<IDetectedEvent[]>((_, reject) => {
-      setTimeout(() => {
-        if (hasFinished) return;
-        console.warn(`Event ${expectedEvent} timed out`);
-        console.warn(JSON.stringify(events, null, 2));
-        reject(new Error(`Event ${expectedEvent} timed out`));
-      }, 15000);
-    }),
-  ]);
+
+      this.socket.on('connect_error', (err) => {
+        return reject(err);
+      });
+    });
+  }
+
+  async waitForEvents(expectedEvent: GameEvents, amount = 1) {
+    const events: IDetectedEvent[] = [];
+    let hasFinished = false;
+
+    return Promise.race([
+      new Promise<IDetectedEvent[]>(async (resolve) => {
+        this.socket.on('gameEvent', (_gameserverId, event, data) => {
+          if (event !== expectedEvent) {
+            // log.warn(`Received event ${event} but expected ${expectedEvent}`);
+            // log.warn(JSON.stringify({ event, data }, null, 2));
+            return;
+          }
+
+          if (event === expectedEvent) {
+            events.push({ event, data });
+          }
+
+          if (events.length === amount) {
+            hasFinished = true;
+            resolve(events);
+          }
+        });
+      }),
+      new Promise<IDetectedEvent[]>((_, reject) => {
+        setTimeout(() => {
+          if (hasFinished) return;
+          console.warn(`Event ${expectedEvent} timed out`);
+          console.warn(JSON.stringify(events, null, 2));
+          reject(new Error(`Event ${expectedEvent} timed out`));
+        }, 15000);
+      }),
+    ]);
+  }
 }


### PR DESCRIPTION
By splitting the connect action and listening for events, we can be more precise