### PR TITLE
fix: do not log full error.message on errors

### DIFF
--- a/packages/lib-apiclient/src/lib/baseClient.ts
+++ b/packages/lib-apiclient/src/lib/baseClient.ts
@@ -78,7 +78,7 @@ export class BaseApiClient<T extends IBaseApiClientConfig> {
           details = JSON.stringify(data.meta);
         }
 
-        this.log.error(`☠️ Request errored: ${error.message}`, {
+        this.log.error('☠️ Request errored', {
           details,
           status: error.response?.status,
           statusText: error.response?.statusText,


### PR DESCRIPTION
This object contains waaaayyy too many details about the request, including auth headers