### PR TITLE
ci: remove retries for certain steps

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -24,13 +24,7 @@ jobs:
           node-version: 18.x
           cache: "npm"
 
-      - uses: nick-fields/retry@v2
-        name: Init development environment
-        with:
-          timeout_minutes: 30
-          max_attempts: 5
-          shell: pwsh
-          command: ./scripts/dev-init.sh
+      - run: ./scripts/dev-init.sh
 
       - name: Build packages
         run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,13 +34,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: nick-fields/retry@v2
-        name: Init development environment
-        with:
-          timeout_minutes: 30
-          max_attempts: 5
-          shell: pwsh
-          command: ./scripts/dev-init.sh
+      - run: ./scripts/dev-init.sh
 
       - run: npm -w packages/web-docs run export
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -113,23 +113,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - uses: nick-fields/retry@v2
-        name: Init development environment
-        with:
-          timeout_minutes: 30
-          max_attempts: 5
-          shell: pwsh
-          command: ./scripts/dev-init.sh
+      - run: ./scripts/dev-init.sh
 
       - run: npm run test:style
 
-      - uses: nick-fields/retry@v2
-        name: Integration tests
-        with:
-          timeout_minutes: 60
-          max_attempts: 5
-          shell: pwsh
-          command: npx zx scripts/integration-tests.mjs
+      - run: ./scripts/dev-init.sh
+      - run: npx zx scripts/integration-tests.mjs
         env:
           DOCKER_TAG: ${{ needs.docker.outputs.docker_tag }}
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
We've recently been able to get CI a lot more stable with a kernel config change. This means, we _probably_ don't need these retries anymore. It's better to fail fast IMO