### PR TITLE
Fix user signups with duplicated domain names

### DIFF
--- a/packages/lib-db/src/migrations/sql/20240908185212-domain-name-not-unique.ts
+++ b/packages/lib-db/src/migrations/sql/20240908185212-domain-name-not-unique.ts
@@ -1,0 +1,12 @@
+import ms from 'ms';
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('domains', (table) => {
+    table.dropUnique(['name'], 'domains_name_unique');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // None, this is a one-way migration
+}


### PR DESCRIPTION
When users sign up for their domain, they can choose the name. It does not have to be unique (anymore?), we never treated name as unique anyways