### PR TITLE
Fix: select query in drawer, not rendered in portal

### DIFF
--- a/packages/web-main/src/routes/_auth/_global/user.$userId.role.assign.tsx
+++ b/packages/web-main/src/routes/_auth/_global/user.$userId.role.assign.tsx
@@ -78,7 +78,7 @@ function Component() {
             <form onSubmit={handleSubmit(onSubmit)} id="assign-user-role-form">
               <CollapseList.Item title="General">
                 <TextField readOnly control={control} name="id" label="User" />
-                <RoleSelectQueryField control={control} name="roleId" label="Role" />
+                <RoleSelectQueryField inPortal control={control} name="roleId" label="Role" />
                 <DatePicker
                   mode="absolute"
                   control={control}


### PR DESCRIPTION
Catalysm: This is in global users -> user select -> edit roles