### PR TITLE
chore: dump some dev data for mail templates

### DIFF
--- a/containers/ory/kratos/crazy.template.jsonnet
+++ b/containers/ory/kratos/crazy.template.jsonnet
@@ -1,0 +1,72 @@
+// Postmark API integration template for Ory Kratos
+function(ctx) {
+  // Extract basic fields from the context
+  local recipient = ctx.recipient,
+  local template_type = ctx.template_type,
+  
+  // Extract data from template_data if it exists
+  local hasTemplateData = "template_data" in ctx,
+  local templateData = if hasTemplateData then ctx.template_data else {},
+  
+  // Extract recovery-specific fields
+  local recoveryCode = if hasTemplateData && "recovery_code" in templateData then templateData.recovery_code 
+                       else if "recovery_code" in ctx then ctx.recovery_code 
+                       else null,
+  
+  // Handle other template-specific fields
+  local recoveryUrl = if hasTemplateData && "recovery_url" in templateData then templateData.recovery_url 
+                      else if "recovery_url" in ctx then ctx.recovery_url 
+                      else null,
+  local verificationCode = if hasTemplateData && "verification_code" in templateData then templateData.verification_code 
+                           else if "verification_code" in ctx then ctx.verification_code 
+                           else null,
+  local verificationUrl = if hasTemplateData && "verification_url" in templateData then templateData.verification_url 
+                          else if "verification_url" in ctx then ctx.verification_url 
+                          else null,
+  local loginCode = if hasTemplateData && "login_code" in templateData then templateData.login_code 
+                    else if "login_code" in ctx then ctx.login_code 
+                    else null,
+  local registrationCode = if hasTemplateData && "registration_code" in templateData then templateData.registration_code 
+                           else if "registration_code" in ctx then ctx.registration_code 
+                           else null,
+  
+  // Generate subject based on template type
+  local generatedSubject = 
+    if template_type == "recovery_code_valid" then "Recover access to your account"
+    else if template_type == "verification_valid" then "Verify your email address"
+    else if template_type == "login_code_valid" then "Your login code"
+    else if template_type == "registration_code_valid" then "Your registration code"
+    else "Notification from Takaro",
+  
+  // Generate body based on template type and available codes
+  local generatedBody = 
+    if template_type == "recovery_code_valid" && recoveryCode != null then 
+      "Hi,\n\nplease recover access to your account by entering the following code:\n\n" + recoveryCode + "\n"
+    else if template_type == "verification_valid" && verificationCode != null then 
+      "Hi,\n\nplease verify your email address by entering the following code:\n\n" + verificationCode + "\n"
+    else if template_type == "login_code_valid" && loginCode != null then 
+      "Hi,\n\nplease log in to your account by entering the following code:\n\n" + loginCode + "\n"
+    else if template_type == "registration_code_valid" && registrationCode != null then 
+      "Hi,\n\nplease complete your registration by entering the following code:\n\n" + registrationCode + "\n"
+    else "Hi,\n\nThis is a notification from Takaro.\n",
+  
+  // Try to use provided subject/body first, then fall back to generated ones
+  local subject = if hasTemplateData && "subject" in templateData && templateData.subject != null 
+                  then templateData.subject 
+                  else if "subject" in ctx && ctx.subject != null 
+                  then ctx.subject 
+                  else generatedSubject,
+  
+  local body = if hasTemplateData && "body" in templateData && templateData.body != null 
+               then templateData.body 
+               else if "body" in ctx && ctx.body != null 
+               then ctx.body 
+               else generatedBody,
+  
+  // Construct the Postmark API request
+  From: "noreply@takaro.io",
+  To: recipient,
+  Subject: subject,
+  TextBody: body,
+  MessageStream: "outbound"
+}

--- a/containers/ory/kratos/default.template.jsonnet
+++ b/containers/ory/kratos/default.template.jsonnet
@@ -1,0 +1,13 @@
+function(ctx) {
+  recipient: ctx.recipient,
+  template_type: ctx.template_type,
+  to: if "template_data" in ctx && "to" in ctx.template_data then ctx.template_data.to else null,
+  recovery_code: if "template_data" in ctx && "recovery_code" in ctx.template_data then ctx.template_data.recovery_code else null,
+  recovery_url: if "template_data" in ctx && "recovery_url" in ctx.template_data then ctx.template_data.recovery_url else null,
+  verification_url: if "template_data" in ctx && "verification_url" in ctx.template_data then ctx.template_data.verification_url else null,
+  verification_code: if "template_data" in ctx && "verification_code" in ctx.template_data then ctx.template_data.verification_code else null,
+  login_code: if "template_data" in ctx && "login_code" in ctx.template_data then ctx.template_data.login_code else null,
+  registration_code: if "template_data" in ctx && "registration_code" in ctx.template_data then ctx.template_data.registration_code else null,
+  subject: if "template_data" in ctx && "subject" in ctx.template_data then ctx.template_data.subject else null,
+  body: if "template_data" in ctx && "body" in ctx.template_data then ctx.template_data.body else null
+}

--- a/containers/ory/kratos/kratos.yml
+++ b/containers/ory/kratos/kratos.yml
@@ -117,6 +117,23 @@ courier:
     connection_uri: 'smtp://mailhog:1025/?disable_starttls=true'
     from_address: noreply@takaro.io
     from_name: Takaro
+# courier:
+#   delivery_strategy: http
+#   http:
+#     request_config:
+#       #url: https://api.postmarkapp.com/email
+#       url: http://192.168.50.35:9999
+#       method: POST
+#       body: file:///etc/config/kratos/default.template.jsonnet
+#       headers:
+#         Content-Type: application/json
+#         Accept: application/json
+#       auth:
+#         type: api_key
+#         config:
+#           name: X-Postmark-Server-Token
+#           value: xxx
+#           in: header
 
 # https://github.com/ory/kratos/pull/3624
 # SPA flows no longer return a 422 error.

--- a/containers/ory/kratos/postmark.template.jsonnet
+++ b/containers/ory/kratos/postmark.template.jsonnet
@@ -1,0 +1,9 @@
+// This is a version of the template for ory v1.3.0
+function(ctx) {
+  From: "noreply@takaro.io",
+  To: ctx.recipient,
+  Subject: if "template_data" in ctx && "subject" in ctx.template_data then ctx.template_data.subject else null,
+  TextBody: if "template_data" in ctx && "body" in ctx.template_data then ctx.template_data.body else "",
+  HtmlBody: if "template_data" in ctx && "body" in ctx.template_data then ctx.template_data.body else "",
+  MessageStream: "outbound"
+}


### PR DESCRIPTION
At the time of writing, a workaround is in place to fix the DO SMTP block. In dev we can still use the same mailhog method, but leaving these files/comments here as 'documentation' :)