### PR TITLE
fix: click bubble up on delete gameserver dialog

### DIFF
--- a/packages/lib-components/src/components/dialogs/Dialog/DialogContent.tsx
+++ b/packages/lib-components/src/components/dialogs/Dialog/DialogContent.tsx
@@ -23,7 +23,14 @@ export const DialogContent = forwardRef<HTMLDivElement, React.HTMLProps<HTMLDivE
     return (
       <FloatingPortal root={root}>
         {context.open && (
-          <StyledFloatingOverlay lockScroll>
+          <StyledFloatingOverlay
+            lockScroll
+            onClick={(e) => {
+              // Prevent clicks within dialog to bubble up to parent element with click event.
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+          >
             <FloatingFocusManager context={floatingContext}>
               <Card
                 ref={ref}


### PR DESCRIPTION
the onclick within the delete gameserver dialog bubbled up to its parent, which contains a navigation. I added a stoppropagation, preventdefault in the dialog itself. Ideally that shouldnt be an onclick but rather a wrapping link, then this problem wouldn't exist..