### PR TITLE
Several fixes for system worker jobs

### DIFF
--- a/packages/app-api/src/service/Module/index.ts
+++ b/packages/app-api/src/service/Module/index.ts
@@ -253,7 +253,18 @@ export class ModuleService extends TakaroService<ModuleModel, ModuleOutputDTO, M
 
   async seedBuiltinModules() {
     const modules = getModules();
-    await Promise.all(modules.map((m: ModuleTransferDTO<unknown>) => this.seedModule(m, { isBuiltin: true })));
+    await Promise.all(
+      modules.map(async (m: ModuleTransferDTO<unknown>) => {
+        try {
+          await this.seedModule(m, { isBuiltin: true });
+        } catch (error) {
+          this.log.warn('Failed to seed builtin module', {
+            error: (error as Error).message,
+            module: m.name,
+          });
+        }
+      }),
+    );
   }
 
   async seedModule(data: ModuleTransferDTO<unknown>, { isBuiltin } = { isBuiltin: false }): Promise<ModuleOutputDTO> {

--- a/packages/app-api/src/workers/systemWorker.ts
+++ b/packages/app-api/src/workers/systemWorker.ts
@@ -171,6 +171,7 @@ async function ensureCronjobsScheduled(domainId: string, gameServerId?: string) 
   const processGameServer = async (gsId: string) => {
     const gameserver = await gameServerService.findOne(gsId, false);
     if (!gameserver) return;
+    if (!gameserver.enabled) return;
 
     ctx.addData({ gameServer: gsId });
     log.info(`🕰 Processing cronjobs for game server ${gsId}`);
@@ -202,6 +203,9 @@ async function syncItems(domainId: string, gameServerId?: string) {
   const processGameServer = async (gsId: string) => {
     ctx.addData({ gameServer: gsId });
     log.info(`🔄 Testing reachability for game server ${gsId}`);
+    const gameserver = await gameServerService.findOne(gsId, false);
+    if (!gameserver) return;
+    if (!gameserver.enabled) return;
 
     const reachable = await gameServerService.testReachability(gsId);
     if (reachable.connectable) {
@@ -229,6 +233,9 @@ async function syncBans(domainId: string, gameServerId?: string) {
   const processGameServer = async (gsId: string) => {
     ctx.addData({ gameServer: gsId });
     log.info(`🔄 Testing reachability for game server ${gsId}`);
+    const gameserver = await gameServerService.findOne(gsId, false);
+    if (!gameserver) return;
+    if (!gameserver.enabled) return;
 
     const reachable = await gameServerService.testReachability(gsId);
     if (reachable.connectable) {

--- a/packages/lib-util/src/context.ts
+++ b/packages/lib-util/src/context.ts
@@ -11,7 +11,11 @@ interface TransactionStore {
 }
 
 function isValidTransactionStore(store: unknown): store is TransactionStore {
-  return typeof store === 'object' && store !== null && Object.values(store).every((val) => typeof val === 'string');
+  return (
+    typeof store === 'object' &&
+    store !== null &&
+    Object.values(store).every((val) => typeof val === 'string' || val === undefined || val === null)
+  );
 }
 
 class Context {


### PR DESCRIPTION
- Ignore jobs for disabled gameservers
- Do not crash if one module fails to seed, always handle all of them
- Context tracing was not reporting accurate data if one of the values was undefined/null