### PR TITLE
Fix 7d2d platform id shenanigans

### DIFF
--- a/packages/lib-gameserver/src/gameservers/7d2d/index.ts
+++ b/packages/lib-gameserver/src/gameservers/7d2d/index.ts
@@ -58,7 +58,6 @@ export class SevenDaysToDie implements IGameServer {
           ip: p.ip,
           name: p.name,
           epicOnlineServicesId: p.crossplatformid.replace('EOS_', ''),
-          platformId: p.steamid.replace('Steam_', ''),
           ping: p.ping,
         };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the display of the "platformId" property from player data in the player list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->