### PR TITLE
Add helpful error messages when wrong ID type is used in tracking endpoints

### DIFF
--- a/packages/app-api/src/controllers/__tests__/TrackingController.integration.test.ts
+++ b/packages/app-api/src/controllers/__tests__/TrackingController.integration.test.ts
@@ -898,6 +898,68 @@ const tests = [
       });
     },
   }),
+  new IntegrationTest<SetupGameServerPlayers.ISetupData>({
+    group,
+    snapshot: false,
+    name: 'Returns helpful error when Player ID is used instead of PoG ID for movement history',
+    setup: SetupGameServerPlayers.setup,
+    expectedStatus: 400,
+    test: async function () {
+      if (!this.standardDomainId) throw new Error('standardDomainId is not set');
+
+      // Get the actual player ID (not PoG ID)
+      const playerId = this.setupData.players[0].id;
+
+      try {
+        await this.client.tracking.trackingControllerGetPlayerMovementHistory({
+          playerId: [playerId], // Using player ID instead of PoG ID
+          startDate: '2024-01-01T00:00:00Z',
+          endDate: '2024-01-10T00:00:00Z',
+        });
+        throw new Error('Expected request to fail');
+      } catch (error) {
+        if (isAxiosError(error)) {
+          expect(error.response?.status).to.equal(400);
+          expect(error.response?.data.meta.error.message).to.include('This appears to be a Player ID');
+          expect(error.response?.data.meta.error.message).to.include('PlayerOnGameserver ID');
+          expect(error.response?.data.meta.error.message).to.include('/gameservers/{gameServerId}/players/{playerId}');
+        } else {
+          throw error;
+        }
+      }
+    },
+  }),
+  new IntegrationTest<SetupGameServerPlayers.ISetupData>({
+    group,
+    snapshot: false,
+    name: 'Returns helpful error when Player ID is used instead of PoG ID for inventory history',
+    setup: SetupGameServerPlayers.setup,
+    expectedStatus: 400,
+    test: async function () {
+      if (!this.standardDomainId) throw new Error('standardDomainId is not set');
+
+      // Get the actual player ID (not PoG ID)
+      const playerId = this.setupData.players[0].id;
+
+      try {
+        await this.client.tracking.trackingControllerGetPlayerInventoryHistory({
+          playerId: playerId, // Using player ID instead of PoG ID
+          startDate: '2024-01-01T00:00:00Z',
+          endDate: '2024-01-10T00:00:00Z',
+        });
+        throw new Error('Expected request to fail');
+      } catch (error) {
+        if (isAxiosError(error)) {
+          expect(error.response?.status).to.equal(400);
+          expect(error.response?.data.meta.error.message).to.include('This appears to be a Player ID');
+          expect(error.response?.data.meta.error.message).to.include('PlayerOnGameserver ID');
+          expect(error.response?.data.meta.error.message).to.include('/gameservers/{gameServerId}/players/{playerId}');
+        } else {
+          throw error;
+        }
+      }
+    },
+  }),
 ];
 
 describe(group, function () {


### PR DESCRIPTION
## Summary
This PR fixes issue #2185 by adding helpful error messages to tracking endpoints when users pass the wrong type of ID (Player ID instead of PlayerOnGameserver ID).

## Problem
The tracking endpoints expect PlayerOnGameserver (PoG) IDs, but users often mistakenly pass Player IDs. Since both are UUIDs, validation passes but queries return empty results without explanation, causing confusion.

## Solution
- Added a `checkIdType` helper method that detects whether an ID is a Player ID or PoG ID
- Updated `getPlayerMovementHistory` and `getPlayerInventoryHistory` to check for wrong ID types when no results are found
- Return clear error messages that:
  - Explain the ID appears to be a Player ID
  - Clarify that the endpoint requires a PlayerOnGameserver ID
  - Provide guidance on finding the correct ID via `/gameservers/{gameServerId}/players/{playerId}`

## Changes
- ✅ Added ID type detection logic in TrackingService
- ✅ Enhanced error handling in tracking methods
- ✅ Added integration tests to verify error messages

## Testing
- [x] Integration tests added and passing
- [x] Error messages provide clear guidance to users
- [x] No breaking changes - only adds helpful error messages

## Type of Change
- [x] Bug fix (improves error messaging)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Fixes #2185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for player tracking endpoints. If a Player ID is used instead of the required PlayerOnGameserver (PoG) ID, the API now returns a clear error message with guidance on using the correct ID format.

* **Tests**
  * Added integration tests to verify that the API returns helpful error messages when a Player ID is mistakenly used in place of a PoG ID for movement and inventory history requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->