### PR TITLE
Fix cross-browser flag rendering in GeoMercator component

### DIFF
--- a/packages/lib-components/src/components/charts/GeoMercator/index.tsx
+++ b/packages/lib-components/src/components/charts/GeoMercator/index.tsx
@@ -13,19 +13,7 @@ import { useCallback } from 'react';
 import { localPoint } from '@visx/event';
 import { ZoomControls } from '../ZoomControls';
 import { alpha2ToAlpha3 } from './iso3166-alpha2-to-alpha3';
-
-const getCountryFlag = (countryCode: string): string => {
-  if (!countryCode || countryCode.length !== 2) {
-    return '';
-  }
-
-  const codePoints = countryCode
-    .toUpperCase()
-    .split('')
-    .map((char) => 127397 + char.charCodeAt(0));
-
-  return String.fromCodePoint(...codePoints);
-};
+import { Flag } from '../../visual/Flag';
 
 const alpha3ToAlpha2: Record<string, string> = Object.entries(alpha2ToAlpha3).reduce(
   (acc, [alpha2, alpha3]) => {
@@ -92,9 +80,8 @@ const CountryCell = styled.div`
 `;
 
 const FlagCell = styled(CountryCell)`
-  width: 16px;
+  width: 20px;
   text-align: center;
-  font-size: 10px;
   padding-right: 4px;
 `;
 
@@ -151,13 +138,12 @@ const CountrySidebar = <T,>({ data, xAccessor, yAccessor }: CountrySidebarProps<
         const countryCode = xAccessor(item);
         const playerCount = yAccessor(item);
         const alpha2Code = countryCode.length === 3 ? alpha3ToAlpha2[countryCode] : countryCode;
-        const flag = getCountryFlag(alpha2Code);
         // Prefer 2-letter country codes for display if available
         const displayCode = alpha2Code || countryCode;
 
         return (
           <CountryRow key={`${countryCode}-${index}`}>
-            <FlagCell>{flag}</FlagCell>
+            <FlagCell>{alpha2Code && <Flag countryCode={alpha2Code} size={1} />}</FlagCell>
             <CountryCell2>{displayCode}</CountryCell2>
             <CountCell>{playerCount}</CountCell>
           </CountryRow>

--- a/packages/lib-components/src/components/visual/Flag/index.tsx
+++ b/packages/lib-components/src/components/visual/Flag/index.tsx
@@ -1,0 +1,41 @@
+import { styled } from '../../../styled';
+import { FC, ImgHTMLAttributes } from 'react';
+
+const FlagImg = styled.img`
+  width: 1rem;
+  height: 1rem;
+  object-fit: cover;
+  border-radius: 2px;
+`;
+
+export interface FlagProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src' | 'alt'> {
+  /** 2-letter ISO country code (e.g., 'US', 'FR', 'JP') */
+  countryCode: string;
+  /** Optional country name for better accessibility */
+  countryName?: string;
+  /** Size of the flag in rem units */
+  size?: number;
+}
+
+export const Flag: FC<FlagProps> = ({ countryCode, countryName, size = 1, style, ...props }) => {
+  if (!countryCode || countryCode.length !== 2) {
+    return null;
+  }
+
+  const uppercaseCode = countryCode.toUpperCase();
+  const flagUrl = `http://purecatamphetamine.github.io/country-flag-icons/3x2/${uppercaseCode}.svg`;
+  const altText = countryName ? `Flag of ${countryName}` : `Flag of ${uppercaseCode}`;
+
+  return (
+    <FlagImg
+      src={flagUrl}
+      alt={altText}
+      style={{
+        width: `${size}rem`,
+        height: `${size}rem`,
+        ...style,
+      }}
+      {...props}
+    />
+  );
+};

--- a/packages/lib-components/src/components/visual/index.ts
+++ b/packages/lib-components/src/components/visual/index.ts
@@ -3,3 +3,6 @@ export type { CardProps } from './Card';
 
 export { Divider } from './Divider';
 export type { DividerProps } from './Divider';
+
+export { Flag } from './Flag';
+export type { FlagProps } from './Flag';


### PR DESCRIPTION
## Summary
Replaces problematic Unicode flag emojis with reliable SVG flags to fix cross-browser compatibility issues in the GeoMercator component.

## Problem
- Unicode flag emojis don't render properly on Windows browsers (Chrome, Edge)
- Flags display as two-letter country codes instead of actual flag images
- Inconsistent user experience across different platforms

## Solution
- Created reusable `Flag` component using SVG flags from purecatamphetamine CDN
- Replaced `getCountryFlag` function with new SVG-based approach
- Increased flag size from 0.625rem to 1rem for better visibility
- Expanded FlagCell width from 16px to 20px to accommodate larger flags

## Changes
- ✅ New `Flag` component in `lib-components/src/components/visual/Flag/`
- ✅ Updated GeoMercator to use SVG flags instead of Unicode emojis
- ✅ Improved flag visibility with larger size
- ✅ Consistent flag rendering across all browsers and platforms

## Testing
- [x] Code has been tested locally
- [x] Flags render consistently across browsers
- [x] No breaking changes to existing functionality
- [x] Linting and formatting checks pass

## Type of Change
- [x] Bug fix (cross-browser compatibility)
- [x] Enhancement (better flag visibility)