### PR TITLE
fix: prevent shop claim race condition with database-level locking

### DIFF
--- a/packages/app-api/src/controllers/__tests__/ShopOrder.integration.test.ts
+++ b/packages/app-api/src/controllers/__tests__/ShopOrder.integration.test.ts
@@ -275,6 +275,59 @@ const tests = [
   }),
   new IntegrationTest<IShopSetup>({
     group,
+    snapshot: false,
+    name: 'Race condition protection: Multiple concurrent claim attempts only succeed once',
+    setup: shopSetup,
+    test: async function () {
+      // Create a single order
+      const order = await this.setupData.client1.shopOrder.shopOrderControllerCreate({
+        listingId: this.setupData.listing100.id,
+        amount: 1,
+      });
+
+      // Attempt to claim the same order concurrently multiple times
+      const claimPromises = [];
+      const numConcurrentAttempts = 5;
+
+      for (let i = 0; i < numConcurrentAttempts; i++) {
+        claimPromises.push(
+          this.setupData.client1.shopOrder
+            .shopOrderControllerClaim(order.data.data.id)
+            .then((res) => ({ success: true, status: res.data.data.status }))
+            .catch((error) => ({
+              success: false,
+              error: isAxiosError(error) && error.response ? error.response.data.meta.error : error,
+            })),
+        );
+      }
+
+      // Wait for all claim attempts to complete
+      const results = await Promise.all(claimPromises);
+
+      // Verify that exactly one claim succeeded
+      const successfulClaims = results.filter((r) => r.success);
+      const failedClaims = results.filter((r) => !r.success);
+
+      expect(successfulClaims).to.have.length(1);
+      expect(successfulClaims[0].status).to.eq(ShopOrderOutputDTOStatusEnum.Completed);
+
+      expect(failedClaims).to.have.length(numConcurrentAttempts - 1);
+
+      // All failed claims should have the correct error
+      failedClaims.forEach((failed) => {
+        expect(failed.error.code).to.eq('BadRequestError');
+        expect(failed.error.message).to.eq('Can only claim paid, unclaimed orders. Current status: COMPLETED');
+      });
+
+      // Verify the order is indeed completed
+      const finalOrder = await this.setupData.client1.shopOrder.shopOrderControllerGetOne(order.data.data.id);
+      expect(finalOrder.data.data.status).to.eq(ShopOrderOutputDTOStatusEnum.Completed);
+
+      return finalOrder;
+    },
+  }),
+  new IntegrationTest<IShopSetup>({
+    group,
     snapshot: true,
     name: 'Cancel order',
     setup: shopSetup,

--- a/packages/app-api/src/db/shopOrder.ts
+++ b/packages/app-api/src/db/shopOrder.ts
@@ -116,4 +116,23 @@ export class ShopOrderRepo extends ITakaroRepo<
   async delete(_id: string): Promise<boolean> {
     throw new errors.NotImplementedError();
   }
+
+  async findOneForUpdate(id: string, trx: any): Promise<ShopOrderOutputDTO> {
+    const { model } = await this.getModel();
+    const res = await model.query(trx).modify('domainScoped', this.domainId).forUpdate().findById(id);
+    if (!res) {
+      throw new errors.NotFoundError();
+    }
+    return new ShopOrderOutputDTO(res);
+  }
+
+  async updateWithTransaction(id: string, data: ShopOrderUpdateDTO, trx: any): Promise<ShopOrderOutputDTO> {
+    const { model } = await this.getModel();
+    const order = await model
+      .query(trx)
+      .modify('domainScoped', this.domainId)
+      .updateAndFetchById(id, { status: data.status })
+      .returning('*');
+    return new ShopOrderOutputDTO(order);
+  }
 }

--- a/packages/app-api/src/service/Shop/index.ts
+++ b/packages/app-api/src/service/Shop/index.ts
@@ -268,70 +268,108 @@ export class ShopListingService extends TakaroService<
   }
 
   async claimOrder(orderId: string): Promise<ShopOrderOutputDTO> {
-    const order = await this.orderRepo.findOne(orderId);
-    if (!order) throw new errors.NotFoundError(`Shop order with id ${orderId} not found`);
-    await this.checkIfOrderBelongsToUser(order);
-    if (order.status !== ShopOrderStatus.PAID)
-      throw new errors.BadRequestError(`Can only claim paid, unclaimed orders. Current status: ${order.status}`);
+    const { model } = await this.orderRepo.getModel();
 
-    const listing = await this.findOne(order.listingId);
-    const gameServerId = listing.gameServerId;
+    // Retry logic for handling transaction conflicts
+    const maxRetries = 3;
+    let lastError: Error | null = null;
 
-    const playerService = new PlayerService(this.domainId);
-    const { pogs } = await playerService.resolveFromId(order.playerId, gameServerId);
-    const pog = pogs.find((pog) => pog.gameServerId === gameServerId);
-    if (!pog) throw new errors.BadRequestError('You have not logged in to the game server yet.');
-    if (!pog.online)
-      throw new errors.BadRequestError(
-        'You must be online in the game server to claim the order. If you have just logged in, please wait a few seconds and try again.',
-      );
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        return await model.transaction(async (trx) => {
+          // Lock the order row for update to prevent concurrent claims
+          const order = await this.orderRepo.findOneForUpdate(orderId, trx);
+          if (!order) throw new errors.NotFoundError(`Shop order with id ${orderId} not found`);
+          await this.checkIfOrderBelongsToUser(order);
 
-    const gameServerService = new GameServerService(this.domainId);
-    if (listing.items.length) {
-      for (let i = 0; i < order.amount; i++) {
-        await Promise.all(
-          listing.items.map((item) =>
-            gameServerService.giveItem(gameServerId, pog.playerId, item.item.id, item.amount, item.quality),
-          ),
-        );
-      }
+          // Check status again within the transaction with the lock held
+          if (order.status !== ShopOrderStatus.PAID)
+            throw new errors.BadRequestError(`Can only claim paid, unclaimed orders. Current status: ${order.status}`);
 
-      await gameServerService.sendMessage(
-        gameServerId,
-        'You have received items from a shop order.',
-        new IMessageOptsDTO({
-          recipient: new IPlayerReferenceDTO({ gameId: pog.gameId }),
-        }),
-      );
-      for (const item of listing.items) {
-        await gameServerService.sendMessage(
-          gameServerId,
-          `${item.amount}x ${item.item.name}`,
-          new IMessageOptsDTO({
-            recipient: new IPlayerReferenceDTO({ gameId: pog.gameId }),
-          }),
-        );
+          // Update status immediately after checking to minimize race condition window
+          const updatedOrder = await this.orderRepo.updateWithTransaction(
+            orderId,
+            new ShopOrderUpdateDTO({ status: ShopOrderStatus.COMPLETED }),
+            trx,
+          );
+
+          const listing = await this.findOne(order.listingId);
+          const gameServerId = listing.gameServerId;
+
+          const playerService = new PlayerService(this.domainId);
+          const { pogs } = await playerService.resolveFromId(order.playerId, gameServerId);
+          const pog = pogs.find((pog) => pog.gameServerId === gameServerId);
+          if (!pog) throw new errors.BadRequestError('You have not logged in to the game server yet.');
+          if (!pog.online)
+            throw new errors.BadRequestError(
+              'You must be online in the game server to claim the order. If you have just logged in, please wait a few seconds and try again.',
+            );
+
+          const gameServerService = new GameServerService(this.domainId);
+          if (listing.items.length) {
+            for (let i = 0; i < order.amount; i++) {
+              await Promise.all(
+                listing.items.map((item) =>
+                  gameServerService.giveItem(gameServerId, pog.playerId, item.item.id, item.amount, item.quality),
+                ),
+              );
+            }
+
+            await gameServerService.sendMessage(
+              gameServerId,
+              'You have received items from a shop order.',
+              new IMessageOptsDTO({
+                recipient: new IPlayerReferenceDTO({ gameId: pog.gameId }),
+              }),
+            );
+            for (const item of listing.items) {
+              await gameServerService.sendMessage(
+                gameServerId,
+                `${item.amount}x ${item.item.name}`,
+                new IMessageOptsDTO({
+                  recipient: new IPlayerReferenceDTO({ gameId: pog.gameId }),
+                }),
+              );
+            }
+          }
+
+          await this.eventService.create(
+            new EventCreateDTO({
+              eventName: EVENT_TYPES.SHOP_ORDER_STATUS_CHANGED,
+              gameserverId: gameServerId,
+              playerId: pog.playerId,
+              meta: new TakaroEventShopOrderStatusChanged({
+                id: updatedOrder.id,
+                status: ShopOrderStatus.COMPLETED,
+              }),
+            }),
+          );
+
+          return updatedOrder;
+        });
+      } catch (error: any) {
+        lastError = error;
+
+        // Check if this is a deadlock/lock timeout error that we should retry
+        // PostgreSQL error codes: 40P01 (deadlock detected), 55P03 (lock not available)
+        if (error.code === '40P01' || error.code === '55P03' || error.message?.includes('lock')) {
+          this.log.warn(
+            `Transaction conflict on attempt ${attempt + 1}/${maxRetries} for order ${orderId}: ${error.message}`,
+          );
+          if (attempt < maxRetries - 1) {
+            // Add exponential backoff delay before retry
+            await new Promise((resolve) => setTimeout(resolve, Math.pow(2, attempt) * 100));
+            continue;
+          }
+        }
+
+        // For other errors or if it's a business logic error, throw immediately
+        throw error;
       }
     }
 
-    const updatedOrder = await this.orderRepo.update(
-      orderId,
-      new ShopOrderUpdateDTO({ status: ShopOrderStatus.COMPLETED }),
-    );
-
-    await this.eventService.create(
-      new EventCreateDTO({
-        eventName: EVENT_TYPES.SHOP_ORDER_STATUS_CHANGED,
-        gameserverId: gameServerId,
-        playerId: pog.playerId,
-        meta: new TakaroEventShopOrderStatusChanged({
-          id: updatedOrder.id,
-          status: ShopOrderStatus.COMPLETED,
-        }),
-      }),
-    );
-
-    return updatedOrder;
+    // If we've exhausted all retries, throw the last error
+    throw lastError || new errors.InternalServerError('Failed to claim order after multiple attempts');
   }
 
   async cancelOrder(orderId: string): Promise<ShopOrderOutputDTO> {


### PR DESCRIPTION
## Summary
Implements a foolproof fix for the race condition that allowed players to claim shop items multiple times by executing rapid concurrent requests.

## Changes
- **Added transaction support to ShopOrderRepo** with row-level locking methods
  - `findOneForUpdate()` - Uses SELECT...FOR UPDATE to acquire exclusive lock
  - `updateWithTransaction()` - Performs atomic updates within transaction
- **Refactored claimOrder() method** to use database transactions
  - Entire claim operation wrapped in transaction for atomicity
  - Order row locked before status check to prevent concurrent access
  - Status updated immediately after lock acquisition
- **Implemented retry logic** with exponential backoff
  - Handles PostgreSQL deadlock (40P01) and lock timeout (55P03) errors
  - Retries up to 3 times with increasing delays
- **Added comprehensive integration test**
  - Simulates 5 concurrent claim attempts on same order
  - Verifies exactly one succeeds, others fail with correct error

## Technical Details
The fix uses PostgreSQL's row-level locking (SELECT...FOR UPDATE) within a transaction to ensure that only one request can claim an order at a time. When multiple requests try to claim the same order:
1. First request acquires the lock and proceeds
2. Other requests wait for the lock or timeout
3. When they finally get the lock, the status check fails (order already COMPLETED)
4. Transaction retry logic handles any deadlock scenarios gracefully

## Testing
- [x] Added integration test for concurrent claim attempts
- [x] Verified existing tests still pass
- [x] Tested retry logic for transaction conflicts
- [x] No console errors

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update