### PR TITLE
Add missing READ_ITEMS and MANAGE_ITEMS permissions

### DIFF
--- a/packages/lib-db/src/migrations/sql/20250707205720-items-permissions-missing.ts
+++ b/packages/lib-db/src/migrations/sql/20250707205720-items-permissions-missing.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex('permission').insert([
+    {
+      permission: 'READ_ITEMS',
+      description: 'Can view item details',
+      friendlyName: 'Read Items',
+    },
+    {
+      permission: 'MANAGE_ITEMS',
+      description: 'Can create, update, and delete items',
+      friendlyName: 'Manage Items',
+    },
+  ]);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex('permission').whereIn('permission', ['READ_ITEMS', 'MANAGE_ITEMS']).del();
+}


### PR DESCRIPTION
## Summary
- Added database migration to insert missing system permissions
- Fixed issue where READ_ITEMS and MANAGE_ITEMS were defined in code but missing from database
- Resolves frontend display issues and API endpoint authorization failures

## Changes
- Created migration file: `20250707205720-items-permissions-missing.ts`
- Inserts READ_ITEMS permission with description and friendly name
- Inserts MANAGE_ITEMS permission with description and friendly name

## Testing
- [x] Migration runs successfully
- [x] Permissions are correctly inserted into database
- [x] All 22 system permissions now present in database

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new permissions to support viewing and managing item details within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->