### PR TITLE
Remove Produktly analytics integration

### DIFF
--- a/packages/web-main/index.html
+++ b/packages/web-main/index.html
@@ -43,17 +43,6 @@
   </style>
 
   <script id="global-config" src="/env.js"></script>
-  <script>
-  (function (w, d, f) {
-    var a = d.getElementsByTagName('head')[0];
-    var s = d.createElement('script');
-    s.async = 1;
-    s.src = f;
-    s.setAttribute('id', 'produktlyScript');
-    s.dataset.clientToken = "35fa6a12f75360fb014339bd6e71975367bef5f92f8d1e2fd2e67db7e2daccd5535068f8d95b1befcbb6659a347c8377ea91edd288732ba1338d1ea0d9fa427e8205a59e9c8caa14ec8d8822833d99272d8c986e53de8d4dd139b04425c7e03142ec3ed2";
-    a.appendChild(s);
-  })(window, document, "https://public.produktly.com/js/main.js");
-</script>
 </head>
 
 <body>

--- a/packages/web-main/src/hooks/useAuth.tsx
+++ b/packages/web-main/src/hooks/useAuth.tsx
@@ -34,14 +34,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       email: session.user.email,
       domain: session.domain,
     });
-
-    // @ts-expect-error - We load Produktly via a script tag in the index...
-    window.Produktly.identifyUser(session.user.idpId, {
-      domain: session.domain,
-      createdAt: session.user.createdAt,
-      email: session.user.email,
-      permissions: session.user.roles.map((role) => role.role.permissions.map((p) => p.permission.permission)).flat(),
-    });
   }, []);
 
   const getSession = async function (): Promise<MeOutputDTO> {


### PR DESCRIPTION
## Summary
- Removed Produktly analytics service from the Takaro web application
- Cleaned up all references to Produktly in the codebase

## Changes
- Removed Produktly script loading from `index.html` (CDN script tag)
- Removed Produktly user identification from `useAuth.tsx` hook
- Removed associated TypeScript error comment
- No npm dependencies to remove (Produktly was loaded via CDN)

## Testing
- [x] Code has been tested locally
- [x] All pre-commit hooks pass
- [x] No TypeScript errors
- [x] Authentication flow continues to work with PostHog and Sentry

## Impact
- No breaking changes - Produktly was only used for analytics
- PostHog and Sentry integrations remain intact for user tracking
- No functionality is affected by this removal