### PR TITLE
Ensure TypeScript checks use project context for test files

### DIFF
--- a/scripts/typecheck-tests.sh
+++ b/scripts/typecheck-tests.sh
@@ -44,9 +44,51 @@ typecheck_tests() {
         echo "  - $file"
     done
     
-    # Run TypeScript check on all files
+    # Run TypeScript check on all files using project context
     echo "Checking TypeScript compilation..."
-    if ! npx tsc --noEmit --skipLibCheck "${test_files[@]}"; then
+    
+    # Create a temporary file list for TypeScript to check
+    local temp_file_list=$(mktemp)
+    
+    # Write files to the temp list (one per line)
+    for file in "${test_files[@]}"; do
+        echo "$file" >> "$temp_file_list"
+    done
+    
+    # Run TypeScript with project context and check only our specific files
+    # We use --listFilesOnly first to validate files are in the project
+    local check_output
+    local check_exit_code
+    
+    # Check if files are part of the TypeScript project
+    if ! npx tsc --project . --listFilesOnly | grep -qf "$temp_file_list"; then
+        echo "Warning: Some test files may not be included in the TypeScript project"
+    fi
+    
+    # Now run the actual type check
+    # We use a trick: compile the whole project but only show errors for our files
+    check_output=$(npx tsc --noEmit --project . 2>&1 || true)
+    check_exit_code=$?
+    
+    # Filter output to only show errors for our test files
+    local filtered_output=""
+    local has_errors=false
+    
+    while IFS= read -r line; do
+        for file in "${test_files[@]}"; do
+            if [[ "$line" == *"$file"* ]]; then
+                filtered_output+="$line"$'\n'
+                has_errors=true
+                break
+            fi
+        done
+    done <<< "$check_output"
+    
+    # Clean up temp file
+    rm -f "$temp_file_list"
+    
+    if [[ "$has_errors" == "true" ]]; then
+        echo "$filtered_output"
         echo ""
         echo "❌ TypeScript check failed!"
         echo "Please fix the TypeScript errors above before running tests."


### PR DESCRIPTION
## Summary
This PR fixes an issue where TypeScript errors in test files were not being caught by the test scripts. The TypeScript check was running files in isolation without the project context, preventing strict type checking rules from being applied.

## Problem
- Test scripts would report "TypeScript check passed!" even when files contained TypeScript errors
- Errors like `catch (e) { console.log(e.message) }` would pass the check but fail at runtime
- This led to cryptic error messages when tests actually ran

## Solution
- Modified `scripts/typecheck-tests.sh` to use the full project context with `npx tsc --noEmit --project .`
- Added filtering to only show errors for the specific test files being checked
- This ensures all TypeScript strict mode rules are properly applied

## Testing
- Created a test file with a TypeScript error (untyped catch block)
- Verified the old script incorrectly passed the check
- Confirmed the new script properly catches the error
- Tested that valid TypeScript still passes the check

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the process for TypeScript checking of test files, enhancing accuracy and error reporting during type checks. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->