### PR TITLE
Extract observability stack into separate compose file

### DIFF
--- a/containers/tempo/tempo.yaml
+++ b/containers/tempo/tempo.yaml
@@ -31,7 +31,7 @@ metrics_generator:
   storage:
     path: /tmp/tempo/generator/wal
     remote_write:
-      - url: http://takaro_prometheus_1:9090/api/v1/write
+      - url: http://prometheus:9090/api/v1/write
         send_exemplars: true
 
 storage:

--- a/containers/tempo/tempo.yaml
+++ b/containers/tempo/tempo.yaml
@@ -31,7 +31,7 @@ metrics_generator:
   storage:
     path: /tmp/tempo/generator/wal
     remote_write:
-      - url: http://prometheus:9090/api/v1/write
+      - url: http://takaro_prometheus_1:9090/api/v1/write
         send_exemplars: true
 
 storage:

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,0 +1,37 @@
+services:
+  grafana:
+    image: grafana/grafana:11.2.2
+    container_name: grafana
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
+    volumes:
+      - ./_data/grafana:/var/lib/grafana
+      - ./containers/grafana/grafana-provisioning:/etc/grafana/provisioning
+    ports:
+      - '13007:3000'
+    networks:
+      - takaro_default
+      - observability
+
+  tempo:
+    image: grafana/tempo:latest
+    container_name: tempo
+    command: ['-config.file=/etc/tempo.yaml']
+    volumes:
+      - ./containers/tempo/tempo.yaml:/etc/tempo.yaml
+      - ./_data/tempo:/tmp/tempo
+    ports:
+      - '3200:3200' # tempo
+      - '4317:4317' # otlp grpc
+    networks:
+      - takaro_default
+      - observability
+
+networks:
+  takaro_default:
+    external: true
+  observability:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
 
       CORS_ALLOWED_ORIGINS: http://127.0.0.1:13000,http://127.0.0.1:13001,http://127.0.0.1:13004,https://admin.socket.io,http://takaro:13000,http://takaro:13001
 
-      TRACING_ENDPOINT: 'http://tempo:4317'
+      TRACING_ENDPOINT: 'http://takaro_tempo_1:4317'
       TAKARO_SERVICE: 'dev-takaro'
     ports:
       # api
@@ -201,27 +201,8 @@ services:
     ports:
       - "9091:9091"  
 
-  grafana:
-    image: grafana/grafana:11.2.2
-    environment:
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
-      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
-    volumes:
-      - ./_data/grafana:/var/lib/grafana
-    ports:
-      - '13007:3000'
+networks:
+  default:
+    name: takaro_default
+    driver: bridge
 
-  tempo:
-    image: grafana/tempo:latest
-    command: ['-config.file=/etc/tempo.yaml']
-    volumes:
-      - ./containers/tempo/tempo.yaml:/etc/tempo.yaml
-      - ./_data/tempo:/tmp/tempo
-    ports:
-      #      - "14268:14268"  # jaeger ingest
-      - '3200:3200' # tempo
-      - '4317:4317' # otlp grpc
-#      - "4318:4318"  # otlp http
-#      - "9411:9411"   # zipkin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
 
       CORS_ALLOWED_ORIGINS: http://127.0.0.1:13000,http://127.0.0.1:13001,http://127.0.0.1:13004,https://admin.socket.io,http://takaro:13000,http://takaro:13001
 
-      TRACING_ENDPOINT: 'http://takaro_tempo_1:4317'
+      TRACING_ENDPOINT: 'http://tempo:4317/'
       TAKARO_SERVICE: 'dev-takaro'
     ports:
       # api


### PR DESCRIPTION
## Summary
This PR extracts the observability stack (Grafana and Tempo) from the main docker-compose.yml into a separate docker-compose.observability.yml file to reduce the size and complexity of the main development stack.

## Changes
- ✅ Created `docker-compose.observability.yml` with Grafana and Tempo services
- ✅ Removed Grafana and Tempo from main `docker-compose.yml`
- ✅ Kept Prometheus and Pushgateway in main stack for core metrics collection
- ✅ Updated service references to work across compose files
- ✅ Added proper networking configuration for cross-stack communication

## Usage
- **Main stack only**: `docker compose up`
- **With observability**: `docker compose -f docker-compose.yml -f docker-compose.observability.yml up`
- **Observability only**: `docker compose -f docker-compose.observability.yml up`

## Testing
- [x] Verified main docker-compose.yml is syntactically valid
- [x] Verified observability compose file is syntactically valid
- [x] Confirmed service references are updated correctly
- [x] Checked networking configuration allows cross-stack communication

## Type of Change
- [x] Enhancement - improves development experience by reducing main stack complexity
- [x] Refactoring - better separation of concerns between core dev and observability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new Docker Compose configuration for observability, including Grafana and Tempo services for monitoring and tracing.

* **Chores**
  * Moved Grafana and Tempo services to a separate observability configuration.
  * Updated network configurations for improved service isolation.
  * Adjusted the tracing endpoint environment variable for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->