### PR TITLE
feat: add collapsible navbar with toggle button

### DIFF
--- a/packages/web-main/src/components/Navbar/GameServerNav.tsx
+++ b/packages/web-main/src/components/Navbar/GameServerNav.tsx
@@ -19,7 +19,11 @@ import { useQuery } from '@tanstack/react-query';
 
 const route = getRouteApi('/_auth/gameserver/$gameServerId');
 
-export const GameServerNav: FC = () => {
+interface GameServerNavProps {
+  isCollapsed?: boolean;
+}
+
+export const GameServerNav: FC<GameServerNavProps> = ({ isCollapsed = false }) => {
   const navigate = useNavigate();
   const { data: gameservers, isPending } = useQuery(gameServersQueryOptions());
   const { gameServerId } = route.useParams();
@@ -76,35 +80,39 @@ export const GameServerNav: FC = () => {
 
   if (isPending) {
     return (
-      <Nav data-testid="server-nav">
-        <h3>Game Server</h3>
-        <Skeleton variant="text" width="100%" height="35px" />
-        {gameServerLinks.map((link) => renderLink(link))}
+      <Nav data-testid="server-nav" $isCollapsed={isCollapsed}>
+        {!isCollapsed && <h3>Game Server</h3>}
+        {!isCollapsed && <Skeleton variant="text" width="100%" height="35px" />}
+        {gameServerLinks.map((link) => renderLink(link, isCollapsed))}
       </Nav>
     );
   }
 
   return (
-    <Nav data-testid="server-nav">
+    <Nav data-testid="server-nav" $isCollapsed={isCollapsed}>
       {gameServerId && gameServerId !== '' && gameservers && gameservers.data.length > 0 ? (
         <>
-          <h3>Game Server</h3>
-          {gameservers.data.length > 1 && <GlobalGameServerSelect currentSelectedGameServerId={gameServerId} />}
-          {gameServerLinks.map((link) => renderLink(link))}
+          {!isCollapsed && <h3>Game Server</h3>}
+          {!isCollapsed && gameservers.data.length > 1 && (
+            <GlobalGameServerSelect currentSelectedGameServerId={gameServerId} />
+          )}
+          {gameServerLinks.map((link) => renderLink(link, isCollapsed))}
         </>
       ) : (
         <>
-          <h3>Game Server</h3>
-          <NoServersCallToAction
-            initial={{ opacity: 0, y: -10 }}
-            transition={{ delay: 0.5 }}
-            animate={{ opacity: 1, y: 0 }}
-          >
-            <p>Step into the world of Takaro by adding your first server!</p>
-            <Button icon={<AddServerIcon />} fullWidth onClick={() => navigate({ to: '/gameservers/create' })}>
-              Add a server
-            </Button>
-          </NoServersCallToAction>
+          {!isCollapsed && <h3>Game Server</h3>}
+          {!isCollapsed && (
+            <NoServersCallToAction
+              initial={{ opacity: 0, y: -10 }}
+              transition={{ delay: 0.5 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
+              <p>Step into the world of Takaro by adding your first server!</p>
+              <Button icon={<AddServerIcon />} fullWidth onClick={() => navigate({ to: '/gameservers/create' })}>
+                Add a server
+              </Button>
+            </NoServersCallToAction>
+          )}
         </>
       )}
     </Nav>

--- a/packages/web-main/src/components/Navbar/index.tsx
+++ b/packages/web-main/src/components/Navbar/index.tsx
@@ -1,6 +1,6 @@
-import { FC, ReactElement } from 'react';
+import { FC, ReactElement, useState, useEffect } from 'react';
 import { LinkProps } from '@tanstack/react-router';
-import { Chip, RequiredPermissions, Tooltip, useTheme } from '@takaro/lib-components';
+import { Chip, RequiredPermissions, Tooltip, useTheme, IconButton } from '@takaro/lib-components';
 import { UserDropdown } from './UserDropdown';
 import { Nav, IconNav, Container, IconNavContainer } from './style';
 import { PERMISSIONS } from '@takaro/apiclient';
@@ -14,6 +14,8 @@ import {
   AiOutlineUser as RolesIcon,
   AiOutlineEdit as VariablesIcon,
   AiOutlineClockCircle as EventsIcon,
+  AiOutlineLeft as CollapseIcon,
+  AiOutlineRight as ExpandIcon,
 
   // icon nav
   AiOutlineBook as DocumentationIcon,
@@ -126,59 +128,103 @@ interface NavbarProps {
 export const Navbar: FC<NavbarProps> = ({ showGameServerNav }) => {
   const theme = useTheme();
   const { version } = getTakaroVersionComponents(getConfigVar('takaroVersion'));
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  // Load collapsed state from localStorage on mount
+  useEffect(() => {
+    const savedState = localStorage.getItem('navbar-collapsed');
+    if (savedState !== null) {
+      setIsCollapsed(JSON.parse(savedState));
+    }
+  }, []);
+
+  // Save collapsed state to localStorage when it changes
+  useEffect(() => {
+    localStorage.setItem('navbar-collapsed', JSON.stringify(isCollapsed));
+  }, [isCollapsed]);
+
+  const toggleCollapse = () => {
+    setIsCollapsed(!isCollapsed);
+  };
 
   return (
-    <Container animate={{ width: 325 }} transition={{ duration: 1, type: 'spring', bounce: 0.5 }}>
+    <Container
+      animate={{ width: isCollapsed ? 60 : 325 }}
+      transition={{ duration: 0.3, type: 'spring', bounce: 0.3 }}
+      $isCollapsed={isCollapsed}
+    >
+      <div style={{ position: 'absolute', top: theme.spacing['1'], right: theme.spacing['0_5'], zIndex: 10 }}>
+        <Tooltip>
+          <Tooltip.Trigger asChild>
+            <IconButton
+              icon={isCollapsed ? <ExpandIcon /> : <CollapseIcon />}
+              onClick={toggleCollapse}
+              size="small"
+              ariaLabel={isCollapsed ? 'Expand navbar' : 'Collapse navbar'}
+            />
+          </Tooltip.Trigger>
+          <Tooltip.Content>{isCollapsed ? 'Expand' : 'Collapse'}</Tooltip.Content>
+        </Tooltip>
+      </div>
       <IconNavContainer data-testid="takaro-icon-nav">
-        {showGameServerNav && <GameServerNav />}
-        <Nav data-testid="global-nav">
-          {domainLinks.length > 0 && <h3>Global</h3>}
-          {domainLinks.map((link) => renderLink(link))}
+        {showGameServerNav && <GameServerNav isCollapsed={isCollapsed} />}
+        <Nav data-testid="global-nav" $isCollapsed={isCollapsed}>
+          {domainLinks.length > 0 && !isCollapsed && <h3>Global</h3>}
+          {domainLinks.map((link) => renderLink(link, isCollapsed))}
         </Nav>
       </IconNavContainer>
-      <div style={{ width: '100%' }}>
-        <UserDropdown />
-        <div style={{ display: 'flex', justifyContent: 'center', marginTop: theme.spacing['1'], alignItems: 'center' }}>
-          <span style={{ marginRight: theme.spacing['0_5'] }}>Domain: </span>
-          <Chip
-            showIcon="hover"
-            color="secondary"
-            variant="outline"
-            label={`${document.cookie.replace(TAKARO_DOMAIN_COOKIE_REGEX, '$1')}`}
-          />
+      {!isCollapsed && (
+        <div style={{ width: '100%' }}>
+          <UserDropdown />
+          <div
+            style={{ display: 'flex', justifyContent: 'center', marginTop: theme.spacing['1'], alignItems: 'center' }}
+          >
+            <span style={{ marginRight: theme.spacing['0_5'] }}>Domain: </span>
+            <Chip
+              showIcon="hover"
+              color="secondary"
+              variant="outline"
+              label={`${document.cookie.replace(TAKARO_DOMAIN_COOKIE_REGEX, '$1')}`}
+            />
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              marginTop: theme.spacing['0_75'],
+            }}
+          >
+            Version: <Chip showIcon="hover" color="secondary" variant="outline" label={version} />
+          </div>
+          <IconNav>
+            <Tooltip>
+              <Tooltip.Trigger asChild>
+                <a href="https://aka.takaro.io/github" target="_blank" rel="noreferrer">
+                  <GithubIcon size={18} />
+                </a>
+              </Tooltip.Trigger>
+              <Tooltip.Content>Github</Tooltip.Content>
+            </Tooltip>
+            <Tooltip>
+              <Tooltip.Trigger asChild>
+                <a href="https://docs.takaro.io" target="_blank" rel="noreferrer">
+                  <DocumentationIcon size={18} />
+                </a>
+              </Tooltip.Trigger>
+              <Tooltip.Content>Documentation</Tooltip.Content>
+            </Tooltip>
+            <Tooltip>
+              <Tooltip.Trigger asChild>
+                <a href="https://aka.takaro.io/discord" target="_blank" rel="noreferrer">
+                  <DiscordIcon size={18} />
+                </a>
+              </Tooltip.Trigger>
+              <Tooltip.Content>Discord</Tooltip.Content>
+            </Tooltip>
+          </IconNav>
         </div>
-        <div
-          style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', marginTop: theme.spacing['0_75'] }}
-        >
-          Version: <Chip showIcon="hover" color="secondary" variant="outline" label={version} />
-        </div>
-        <IconNav>
-          <Tooltip>
-            <Tooltip.Trigger asChild>
-              <a href="https://aka.takaro.io/github" target="_blank" rel="noreferrer">
-                <GithubIcon size={18} />
-              </a>
-            </Tooltip.Trigger>
-            <Tooltip.Content>Github</Tooltip.Content>
-          </Tooltip>
-          <Tooltip>
-            <Tooltip.Trigger asChild>
-              <a href="https://docs.takaro.io" target="_blank" rel="noreferrer">
-                <DocumentationIcon size={18} />
-              </a>
-            </Tooltip.Trigger>
-            <Tooltip.Content>Documentation</Tooltip.Content>
-          </Tooltip>
-          <Tooltip>
-            <Tooltip.Trigger asChild>
-              <a href="https://aka.takaro.io/discord" target="_blank" rel="noreferrer">
-                <DiscordIcon size={18} />
-              </a>
-            </Tooltip.Trigger>
-            <Tooltip.Content>Discord</Tooltip.Content>
-          </Tooltip>
-        </IconNav>
-      </div>
+      )}
     </Container>
   );
 };

--- a/packages/web-main/src/components/Navbar/renderLink.tsx
+++ b/packages/web-main/src/components/Navbar/renderLink.tsx
@@ -3,24 +3,35 @@ import { DeveloperModeGuard } from '../DeveloperModeGuard';
 import { PermissionsGuard } from '../PermissionsGuard';
 import { cloneElement } from 'react';
 import { NavbarLink } from '.';
+import { Tooltip } from '@takaro/lib-components';
 
-export const renderLink = ({
-  linkProps,
-  icon,
-  label,
-  requiredPermissions,
-  requiresDevelopmentModeEnabled = false,
-}: NavbarLink) => (
-  <DeveloperModeGuard key={`developer-mode-guard-${linkProps.to}`} enabled={requiresDevelopmentModeEnabled}>
-    <PermissionsGuard key={`permissions-guard-${linkProps.to}`} requiredPermissions={requiredPermissions || []}>
-      <div key={`wrapper-${linkProps.to}`}>
-        <Link to={linkProps.to} key={`link-${linkProps.to}`}>
-          <span key={`inner-${linkProps.to}`}>
-            {cloneElement(icon, { size: 20, key: `icon-${linkProps.to}` })}
-            <p key={`label-${linkProps.to}`}>{label}</p>
-          </span>
-        </Link>
-      </div>
-    </PermissionsGuard>
-  </DeveloperModeGuard>
-);
+export const renderLink = (
+  { linkProps, icon, label, requiredPermissions, requiresDevelopmentModeEnabled = false }: NavbarLink,
+  isCollapsed?: boolean,
+) => {
+  const linkContent = (
+    <Link to={linkProps.to} key={`link-${linkProps.to}`}>
+      <span key={`inner-${linkProps.to}`}>
+        {cloneElement(icon, { size: 20, key: `icon-${linkProps.to}` })}
+        {!isCollapsed && <p key={`label-${linkProps.to}`}>{label}</p>}
+      </span>
+    </Link>
+  );
+
+  const wrappedLink = isCollapsed ? (
+    <Tooltip key={`tooltip-${linkProps.to}`}>
+      <Tooltip.Trigger asChild>{linkContent}</Tooltip.Trigger>
+      <Tooltip.Content>{label}</Tooltip.Content>
+    </Tooltip>
+  ) : (
+    linkContent
+  );
+
+  return (
+    <DeveloperModeGuard key={`developer-mode-guard-${linkProps.to}`} enabled={requiresDevelopmentModeEnabled}>
+      <PermissionsGuard key={`permissions-guard-${linkProps.to}`} requiredPermissions={requiredPermissions || []}>
+        <div key={`wrapper-${linkProps.to}`}>{wrappedLink}</div>
+      </PermissionsGuard>
+    </DeveloperModeGuard>
+  );
+};

--- a/packages/web-main/src/components/Navbar/style.ts
+++ b/packages/web-main/src/components/Navbar/style.ts
@@ -1,7 +1,7 @@
 import { styled } from '@takaro/lib-components';
 import { motion } from 'framer-motion';
 
-export const Container = styled(motion.div)`
+export const Container = styled(motion.div)<{ $isCollapsed?: boolean }>`
   width: 0;
   position: relative;
   height: 100vh;
@@ -10,8 +10,12 @@ export const Container = styled(motion.div)`
   align-items: flex-start;
   flex-direction: column;
   justify-content: space-between;
-  padding: ${({ theme }) => `${theme.spacing[2]} ${theme.spacing[1]} ${theme.spacing['1_5']} ${theme.spacing[1]}`};
+  padding: ${({ theme, $isCollapsed }) =>
+    $isCollapsed
+      ? `${theme.spacing[2]} ${theme.spacing['0_5']} ${theme.spacing['1_5']} ${theme.spacing['0_5']}`
+      : `${theme.spacing[2]} ${theme.spacing[1]} ${theme.spacing['1_5']} ${theme.spacing[1]}`};
   gap: ${({ theme }) => theme.spacing[2]};
+  overflow: hidden;
 
   .company-icon {
     margin: 0 auto;
@@ -52,7 +56,7 @@ export const IconNavContainer = styled.div`
   gap: ${({ theme }) => theme.spacing[2]};
 `;
 
-export const Nav = styled.nav`
+export const Nav = styled.nav<{ $isCollapsed?: boolean }>`
   display: flex;
   gap: ${({ theme }) => theme.spacing['0_75']};
   width: 100%;
@@ -69,10 +73,13 @@ export const Nav = styled.nav`
   a {
     width: 100%;
     border-radius: ${({ theme }) => theme.borderRadius.medium};
-    padding: ${({ theme }) => `${theme.spacing['0_75']} ${theme.spacing['1']}`};
+    padding: ${({ theme, $isCollapsed }) =>
+      $isCollapsed
+        ? `${theme.spacing['0_75']} ${theme.spacing['0_5']}`
+        : `${theme.spacing['0_75']} ${theme.spacing['1']}`};
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: ${({ $isCollapsed }) => ($isCollapsed ? 'center' : 'space-between')};
     transition: 0.2s transform ease-in-out;
     font-weight: 500;
     white-space: nowrap;
@@ -81,6 +88,7 @@ export const Nav = styled.nav`
     span {
       display: flex;
       align-items: center;
+      justify-content: ${({ $isCollapsed }) => ($isCollapsed ? 'center' : 'flex-start')};
     }
 
     &:hover {


### PR DESCRIPTION
## Summary
- Add a collapse/expand toggle button to the navbar allowing users to minimize it to save screen space
- Navbar smoothly animates between expanded (325px) and collapsed (60px) states
- Collapse state is persisted in localStorage for user convenience

## Changes
- Added collapse state management to Navbar component with localStorage persistence
- Implemented toggle button with expand/collapse icons in top-right corner
- Updated styled components to handle padding and alignment for both states
- Modified renderLink function to show tooltips when navbar is collapsed
- Updated GameServerNav to accept and propagate collapsed state
- Hide domain/version info and external links when collapsed
- Show only icons with tooltips for navigation items when collapsed

## Testing
- [x] Code has been tested locally
- [x] All tests pass
- [x] No console errors
- [x] Build completes successfully

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update