### PR TITLE
feat: display domain name instead of ID in navbar

### DIFF
--- a/packages/e2e/src/web-main/domainMemory.spec.ts
+++ b/packages/e2e/src/web-main/domainMemory.spec.ts
@@ -72,7 +72,7 @@ test.describe('Domain Memory Feature', () => {
     await page.waitForURL((url) => url.pathname === '/dashboard', { waitUntil: 'domcontentloaded' });
 
     // Verify we're on the second domain
-    await expect(page.locator('text=Domain:').locator('..').getByText(secondDomain.createdDomain.id)).toBeVisible();
+    await expect(page.locator('text=Domain:').locator('..').getByText(secondDomain.createdDomain.name)).toBeVisible();
 
     // Logout via user dropdown
     await page.getByRole('button', { name: new RegExp(takaro.rootUser.name || takaro.rootUser.email, 'i') }).click();
@@ -84,7 +84,7 @@ test.describe('Domain Memory Feature', () => {
     await page.waitForURL((url) => url.pathname === '/dashboard', { waitUntil: 'domcontentloaded' });
 
     // Should auto-select the remembered second domain (not the alphabetically first one)
-    await expect(page.locator('text=Domain:').locator('..').getByText(secondDomain.createdDomain.id)).toBeVisible();
+    await expect(page.locator('text=Domain:').locator('..').getByText(secondDomain.createdDomain.name)).toBeVisible();
   });
 
   test('remembers domain when switching via navbar dropdown', async ({ page, takaro }) => {
@@ -110,7 +110,7 @@ test.describe('Domain Memory Feature', () => {
     await page.waitForURL((url) => url.pathname === '/dashboard', { waitUntil: 'domcontentloaded' });
 
     // Verify we switched to second domain
-    await expect(page.locator('text=Domain:').locator('..').getByText(secondDomain.createdDomain.id)).toBeVisible();
+    await expect(page.locator('text=Domain:').locator('..').getByText(secondDomain.createdDomain.name)).toBeVisible();
 
     // Logout
     await page.getByRole('button', { name: new RegExp(takaro.rootUser.name || takaro.rootUser.email, 'i') }).click();
@@ -122,7 +122,7 @@ test.describe('Domain Memory Feature', () => {
     await page.waitForURL((url) => url.pathname === '/dashboard', { waitUntil: 'domcontentloaded' });
 
     // Should auto-select the remembered second domain
-    await expect(page.locator('text=Domain:').locator('..').getByText(secondDomain.createdDomain.id)).toBeVisible();
+    await expect(page.locator('text=Domain:').locator('..').getByText(secondDomain.createdDomain.name)).toBeVisible();
   });
 
   test('falls back to auto-selecting first domain when no last used domain cookie exists', async ({ page, takaro }) => {
@@ -138,9 +138,9 @@ test.describe('Domain Memory Feature', () => {
 
     // Verify one of the domains is selected (backend auto-selects first available)
     const domainText = await page.locator('text=Domain:').locator('..').textContent();
-    const selectedDomainId = domainText?.split('Domain:')[1]?.trim();
-    expect(selectedDomainId).toBeTruthy();
-    expect([takaro.domain.createdDomain.id, secondDomain.createdDomain.id]).toContain(selectedDomainId);
+    const selectedDomainName = domainText?.split('Domain:')[1]?.trim();
+    expect(selectedDomainName).toBeTruthy();
+    expect([takaro.domain.createdDomain.name, secondDomain.createdDomain.name]).toContain(selectedDomainName);
   });
 
   test('handles invalid last used domain gracefully by auto-selecting first domain', async ({ page, takaro }) => {
@@ -163,8 +163,8 @@ test.describe('Domain Memory Feature', () => {
 
     // Verify a valid domain is selected (backend ignores invalid cookie)
     const domainText = await page.locator('text=Domain:').locator('..').textContent();
-    const selectedDomainId = domainText?.split('Domain:')[1]?.trim();
-    expect(selectedDomainId).toBeTruthy();
-    expect([takaro.domain.createdDomain.id, secondDomain.createdDomain.id]).toContain(selectedDomainId);
+    const selectedDomainName = domainText?.split('Domain:')[1]?.trim();
+    expect(selectedDomainName).toBeTruthy();
+    expect([takaro.domain.createdDomain.name, secondDomain.createdDomain.name]).toContain(selectedDomainName);
   });
 });

--- a/packages/web-main/src/components/Navbar/index.tsx
+++ b/packages/web-main/src/components/Navbar/index.tsx
@@ -4,6 +4,7 @@ import { Chip, RequiredPermissions, Tooltip, useTheme, IconButton } from '@takar
 import { UserDropdown } from './UserDropdown';
 import { Nav, IconNav, Container, IconNavContainer } from './style';
 import { PERMISSIONS } from '@takaro/apiclient';
+import { useSession } from '../../hooks/useSession';
 import {
   AiOutlineAppstore as DashboardIcon,
   AiOutlineSetting as SettingsIcon,
@@ -24,7 +25,6 @@ import {
 
 import { FaDiscord as DiscordIcon } from 'react-icons/fa';
 import { GameServerNav } from './GameServerNav';
-import { TAKARO_DOMAIN_COOKIE_REGEX } from '../../util/domainCookieRegex';
 import { getConfigVar, getTakaroVersionComponents } from '../../util/getConfigVar';
 import { renderLink } from './renderLink';
 
@@ -129,6 +129,10 @@ export const Navbar: FC<NavbarProps> = ({ showGameServerNav }) => {
   const theme = useTheme();
   const { version } = getTakaroVersionComponents(getConfigVar('takaroVersion'));
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const { session } = useSession();
+
+  // Find the current domain from the session
+  const currentDomain = session.domains.find((domain) => domain.id === session.domain);
 
   // Load collapsed state from localStorage on mount
   useEffect(() => {
@@ -180,12 +184,7 @@ export const Navbar: FC<NavbarProps> = ({ showGameServerNav }) => {
             style={{ display: 'flex', justifyContent: 'center', marginTop: theme.spacing['1'], alignItems: 'center' }}
           >
             <span style={{ marginRight: theme.spacing['0_5'] }}>Domain: </span>
-            <Chip
-              showIcon="hover"
-              color="secondary"
-              variant="outline"
-              label={`${document.cookie.replace(TAKARO_DOMAIN_COOKIE_REGEX, '$1')}`}
-            />
+            <Chip showIcon="hover" color="secondary" variant="outline" label={currentDomain?.name || 'Unknown'} />
           </div>
           <div
             style={{


### PR DESCRIPTION
## Summary
Display the human-readable domain name instead of the domain ID in the bottom left of the navbar.

## Changes
- Import `useSession` hook to access session data with domain information
- Find current domain from `session.domains` array using `session.domain` ID
- Display domain name in the Chip component instead of cookie value
- Remove unused `TAKARO_DOMAIN_COOKIE_REGEX` import

## Why this change?
The UI currently shows an opaque domain ID extracted from a cookie. This change makes it more user-friendly by displaying the actual domain name, which is already available in the session data.

## Testing
- [ ] Domain name displays correctly in the navbar
- [ ] Fallback to "Unknown" works when domain is not found
- [ ] No TypeScript errors
- [ ] UI layout remains consistent

## Type of Change
- [ ] Bug fix
- [x] New feature / Enhancement
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the navigation bar to display the current domain name using session data instead of cookies, improving reliability. If the domain is not found, it now shows 'Unknown'. No changes to user interaction or interface appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->