### PR TITLE
Gameserver players table sorting not sorting properly

### DIFF
--- a/packages/web-main/src/routes/_auth/gameserver.$gameServerId/dashboard.players.tsx
+++ b/packages/web-main/src/routes/_auth/gameserver.$gameServerId/dashboard.players.tsx
@@ -168,7 +168,9 @@ function Component() {
     ...playersOnGameServersQueryOptions(queryParams),
     // Only use initialData if the query params match the initial load
     initialData:
-      pagination.paginationState.pageIndex === 0 && columnFilters.columnFiltersState.length === 0
+      pagination.paginationState.pageIndex === 0 &&
+      columnFilters.columnFiltersState.length === 0 &&
+      sorting.sortingState.length === 0
         ? loaderData.playersData
         : undefined,
   });


### PR DESCRIPTION
## Summary
The gameserver players table sorting was not working properly - clicking sort buttons did not trigger network requests. Sorting would only work after clicking around or changing focus multiple times.

## Root Cause
The `initialData` condition in the gameserver players table was not checking for sorting state changes. When sorting changed, React Query would continue using cached data instead of making new requests.

## Solution
Added `sorting.sortingState.length === 0` to the initialData condition to ensure any sorting change triggers a fresh network request.

## Changes
- Modified `dashboard.players.tsx` to include sorting state in the initialData condition
- This ensures React Query fetches fresh data when sorting changes

## Testing
- [x] Tested sorting on gameserver players table
- [x] Verified network requests are sent when clicking sort buttons
- [x] Confirmed sorting works immediately without needing to click multiple times
- [x] Linting and formatting checks passed

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of player data display by ensuring initial data is only used when there are no filters, no sorting, and the first page is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->