### PR TITLE
More resilient handling of giving items with quality parameter

### DIFF
--- a/packages/lib-gameserver/src/gameservers/7d2d/index.ts
+++ b/packages/lib-gameserver/src/gameservers/7d2d/index.ts
@@ -108,6 +108,12 @@ export class SevenDaysToDie implements IGameServer {
 
     if (this.connectionInfo.useCPM && !res.rawResult.includes('Item(s) given')) {
       this.logger.error('Failed to give item', { player, item, amount, quality, rawResult: res.rawResult });
+
+      if (res.rawResult.includes('does not support quality')) {
+        this.logger.warn('Item does not support quality, retrying without quality');
+        return this.giveItem(player, item, amount);
+      }
+
       throw new errors.BadRequestError(`Failed to give item. Result: "${res.rawResult}"`);
     }
   }


### PR DESCRIPTION
## Summary
- Add automatic retry mechanism for items that don't support quality in 7d2d
- Prevents unnecessary errors when giving items that cannot have quality attributes

## Changes
- Added check for 'does not support quality' error message in giveItem method
- Implemented automatic retry without quality parameter when this error is detected
- Added warning log to track when quality parameter is stripped

## Testing
- [ ] Code has been tested locally
- [ ] All tests pass
- [ ] No console errors

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when giving items in 7 Days to Die servers, allowing for automatic retries without the quality parameter if certain errors are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->