### PR TITLE
fix: stabilize events page pagination with consistent lessThan timestamp

### DIFF
--- a/packages/web-main/src/queries/event.tsx
+++ b/packages/web-main/src/queries/event.tsx
@@ -37,7 +37,8 @@ export const eventsFailedFunctionsQueryOptions = (queryParams: EventSearchInputD
 export const eventsInfiniteQueryOptions = (queryParams: EventSearchInputDTO) =>
   infiniteQueryOptions<EventOutputArrayDTOAPI, AxiosError<EventOutputArrayDTOAPI>>({
     queryKey: [eventKeys.list(), queryParamsToArray(queryParams)],
-    queryFn: async () => (await getApiClient().event.eventControllerSearch(queryParams)).data,
+    queryFn: async ({ pageParam }) =>
+      (await getApiClient().event.eventControllerSearch({ ...queryParams, page: pageParam as number })).data,
     initialPageParam: 0,
     getNextPageParam: (lastPage) => getNextPage(lastPage.meta),
     placeholderData: keepPreviousData,

--- a/packages/web-main/src/routes/_auth/_global/events.tsx
+++ b/packages/web-main/src/routes/_auth/_global/events.tsx
@@ -116,6 +116,11 @@ function Component() {
   } | null>(null);
   const { enqueueSnackbar } = useSnackbar();
 
+  // Stable timestamp for pagination - set on page load or when date range changes
+  const [stableLessThan, setStableLessThan] = useState<string | undefined>(
+    () => search.dateRange?.end || new Date().toISOString(),
+  );
+
   useEventSubscription({
     enabled: live,
     search: { eventName: search.eventNames.length > 0 ? search.eventNames : undefined },
@@ -140,8 +145,8 @@ function Component() {
       },
       sortBy: 'createdAt',
       sortDirection: 'desc',
-      greaterThan: { createdAt: live ? undefined : search.dateRange?.start },
-      lessThan: { createdAt: live ? undefined : search.dateRange?.end },
+      greaterThan: { createdAt: search.dateRange?.start },
+      lessThan: { createdAt: stableLessThan },
       extend: ['gameServer', 'module', 'player', 'user'],
     }),
     initialData: loaderData,
@@ -172,6 +177,11 @@ function Component() {
   }, [isExporting, events.length, isFetching, search.dateRange]);
 
   const onFilterChangeSubmit = (filter: EventFilterInputs) => {
+    // Update stable timestamp if date range changes
+    if (filter.dateRange?.end !== search.dateRange?.end) {
+      setStableLessThan(filter.dateRange?.end || new Date().toISOString());
+    }
+
     navigate({
       search: {
         gameServerIds: filter.gameServerIds.length > 0 ? filter.gameServerIds : [],


### PR DESCRIPTION
## Summary
- Fixed pagination issue where scrolling would show duplicate events
- Implemented stable timestamp mechanism for consistent pagination
- Properly integrated page parameter into infinite query

## Problem
The events page pagination was broken because:
1. The `eventsInfiniteQueryOptions` wasn't using the `pageParam` from React Query
2. The `lessThan` parameter was changing based on live mode, causing duplicate events

## Solution
1. Updated `queryFn` to properly destructure and use `pageParam`
2. Added `stableLessThan` state to maintain consistent timestamp across scroll operations
3. Modified query to use stable timestamp instead of dynamically changing it
4. Updated filter submission to reset stable timestamp only when date range changes

## Changes
- Modified `packages/web-main/src/queries/event.tsx` to use pageParam in queryFn
- Updated `packages/web-main/src/routes/_auth/_global/events.tsx` to implement stable timestamp logic

## Testing
- [ ] Verified pagination works correctly when scrolling
- [ ] Confirmed no duplicate events appear
- [ ] Tested date range filter updates properly reset pagination
- [ ] Ensured live mode continues to work as expected