### PR TITLE
fix: help command filters out disabled modules and commands

### DIFF
--- a/packages/lib-modules/src/__tests__/help.integration.test.ts
+++ b/packages/lib-modules/src/__tests__/help.integration.test.ts
@@ -210,6 +210,101 @@ const tests = [
       expect(messages.some((m) => m.data.meta.msg.includes('help:'))).to.be.true;
     },
   }),
+  new IntegrationTest<IModuleTestsSetupData>({
+    group,
+    snapshot: false,
+    setup: modulesTestSetup,
+    name: 'Does not show commands from disabled modules',
+    test: async function () {
+      // First install utils module normally so help command is available
+      await this.client.module.moduleInstallationsControllerInstallModule({
+        gameServerId: this.setupData.gameserver.id,
+        versionId: this.setupData.utilsModule.latestVersion.id,
+      });
+
+      // Install teleports module but disabled
+      const teleportsInstallation = await this.client.module.moduleInstallationsControllerInstallModule({
+        gameServerId: this.setupData.gameserver.id,
+        versionId: this.setupData.teleportsModule.latestVersion.id,
+      });
+
+      // Get the current system config and disable the teleports module
+      const systemConfig = teleportsInstallation.data.data.systemConfig as any;
+      systemConfig.enabled = false;
+
+      // Uninstall and reinstall teleports module with disabled config
+      await this.client.module.moduleInstallationsControllerUninstallModule(
+        teleportsInstallation.data.data.moduleId,
+        this.setupData.gameserver.id,
+      );
+
+      await this.client.module.moduleInstallationsControllerInstallModule({
+        gameServerId: this.setupData.gameserver.id,
+        versionId: this.setupData.teleportsModule.latestVersion.id,
+        systemConfig: JSON.stringify(systemConfig),
+      });
+
+      const events = (await new EventsAwaiter().connect(this.client)).waitForEvents(GameEvents.CHAT_MESSAGE, 3);
+
+      await this.client.command.commandControllerTrigger(this.setupData.gameserver.id, {
+        msg: '/help',
+        playerId: this.setupData.players[0].id,
+      });
+
+      const messages = await events;
+      expect(messages.length).to.be.greaterThan(0);
+      expect(messages[0].data.meta.msg).to.include('Available commands:');
+      // Should show commands from utils module but NOT from disabled teleports module
+      expect(messages.some((m) => m.data.meta.msg.includes('help:'))).to.be.true;
+      expect(messages.some((m) => m.data.meta.msg.includes('ping:'))).to.be.true;
+      // Should NOT show teleports commands
+      expect(messages.some((m) => m.data.meta.msg.includes('settp:'))).to.be.false;
+      expect(messages.some((m) => m.data.meta.msg.includes('teleport:'))).to.be.false;
+    },
+  }),
+  new IntegrationTest<IModuleTestsSetupData>({
+    group,
+    snapshot: false,
+    setup: modulesTestSetup,
+    name: 'Does not show individually disabled commands',
+    test: async function () {
+      // Install utils module
+      const moduleInstallation = await this.client.module.moduleInstallationsControllerInstallModule({
+        gameServerId: this.setupData.gameserver.id,
+        versionId: this.setupData.utilsModule.latestVersion.id,
+      });
+
+      // Disable only the ping command
+      const systemConfig = moduleInstallation.data.data.systemConfig as any;
+      systemConfig.commands.ping.enabled = false;
+
+      // Uninstall and reinstall with new config
+      await this.client.module.moduleInstallationsControllerUninstallModule(
+        moduleInstallation.data.data.moduleId,
+        this.setupData.gameserver.id,
+      );
+
+      await this.client.module.moduleInstallationsControllerInstallModule({
+        gameServerId: this.setupData.gameserver.id,
+        versionId: this.setupData.utilsModule.latestVersion.id,
+        systemConfig: JSON.stringify(systemConfig),
+      });
+
+      const events = (await new EventsAwaiter().connect(this.client)).waitForEvents(GameEvents.CHAT_MESSAGE, 2);
+
+      await this.client.command.commandControllerTrigger(this.setupData.gameserver.id, {
+        msg: '/help',
+        playerId: this.setupData.players[0].id,
+      });
+
+      const messages = await events;
+      expect(messages.length).to.be.greaterThan(0);
+      expect(messages[0].data.meta.msg).to.include('Available commands:');
+      // Should show help command but NOT ping command
+      expect(messages.some((m) => m.data.meta.msg.includes('help:'))).to.be.true;
+      expect(messages.some((m) => m.data.meta.msg.includes('ping:'))).to.be.false;
+    },
+  }),
 ];
 
 describe(group, function () {

--- a/packages/lib-modules/src/modules/utils/commands/help.js
+++ b/packages/lib-modules/src/modules/utils/commands/help.js
@@ -6,8 +6,19 @@ async function main() {
 
   const moduleCommands = await Promise.all(
     enabledModules.data.data.map(async (mod) => {
+      // Check if the module itself is enabled
+      if (!mod.systemConfig.enabled) {
+        return [];
+      }
+
       const installedVersion = await takaro.module.moduleVersionControllerGetModuleVersion(mod.versionId);
-      return installedVersion.data.data.commands;
+      const commands = installedVersion.data.data.commands;
+
+      // Filter out disabled commands
+      return commands.filter((command) => {
+        const commandConfig = mod.systemConfig.commands && mod.systemConfig.commands[command.name];
+        return commandConfig && commandConfig.enabled;
+      });
     }),
   );
   const allCommandsFlat = moduleCommands.flat();


### PR DESCRIPTION
## Summary
This PR fixes an issue where the help command would display commands from disabled modules and individually disabled commands, which users couldn't actually execute.

## Changes
- Modified `help.js` to check `systemConfig.enabled` for modules before including their commands
- Added filtering for individually disabled commands via `systemConfig.commands[commandName].enabled`
- Added comprehensive integration tests to verify the filtering behavior

## Testing
- ✅ All existing help command tests pass
- ✅ Added test: "Does not show commands from disabled modules"
- ✅ Added test: "Does not show individually disabled commands"
- ✅ Ran full test suite: 10/10 tests passing

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Implementation Details
The help command now:
1. Checks if a module is enabled before listing its commands
2. Checks if individual commands are enabled within enabled modules
3. Only displays commands that users can actually execute

This ensures consistency between what the help command shows and what commands are actually available to execute.