### PR TITLE
Return actual player ID instead of POG ID in tracking endpoints

### DIFF
--- a/packages/app-api/src/controllers/__tests__/TrackingController.integration.test.ts
+++ b/packages/app-api/src/controllers/__tests__/TrackingController.integration.test.ts
@@ -858,7 +858,7 @@ const tests = [
       // Should only find records from hour 10
       data.forEach((location) => {
         const date = new Date(location.createdAt);
-        expect(date.getHours()).to.equal(10);
+        expect(date.getUTCHours()).to.equal(10);
         expect(date.toISOString().startsWith('2024-01-01')).to.be.true;
       });
     },

--- a/packages/app-api/src/controllers/__tests__/TrackingController.integration.test.ts
+++ b/packages/app-api/src/controllers/__tests__/TrackingController.integration.test.ts
@@ -507,7 +507,7 @@ const tests = [
 
       // Should find at least player 0
       const playerIds = data.map((location) => location.playerId);
-      expect(playerIds).to.include(this.setupData.pogs1[0].id);
+      expect(playerIds).to.include(this.setupData.pogs1[0].playerId);
     },
   }),
 
@@ -574,7 +574,7 @@ const tests = [
 
       // Should find at least player 2
       const playerIds = data.map((location) => location.playerId);
-      expect(playerIds).to.include(this.setupData.pogs1[2].id);
+      expect(playerIds).to.include(this.setupData.pogs1[2].playerId);
     },
   }),
 

--- a/packages/app-api/src/controllers/__tests__/TrackingController.integration.test.ts
+++ b/packages/app-api/src/controllers/__tests__/TrackingController.integration.test.ts
@@ -148,14 +148,14 @@ async function setupHistoricalData(domainId: string, pogs: PlayerOnGameserverOut
         box: { minX: 0, maxX: 200, minY: 0, maxY: 100, minZ: 0, maxZ: 200 },
         startDate: '2024-01-15T11:30:00Z',
         endDate: '2024-01-15T12:30:00Z',
-        expectedPlayers: pogs.length > 0 ? [pogs[0].id] : [],
+        expectedPlayers: pogs.length > 0 ? [pogs[0].playerId] : [],
       },
       radiusTest: {
         center: { x: 500, y: 100, z: 500 },
         radius: 50,
         startDate: '2024-01-15T11:30:00Z',
         endDate: '2024-01-15T12:30:00Z',
-        expectedPlayers: pogs.length > 1 ? [pogs[1].id] : [],
+        expectedPlayers: pogs.length > 1 ? [pogs[1].playerId] : [],
       },
     },
   };
@@ -1002,7 +1002,7 @@ const tests = [
         throw new Error('Test setup failed: No players found in setupData.pogs1');
       }
 
-      const playerId = this.setupData.pogs1[0].id;
+      const playerId = this.setupData.pogs1[0].playerId;
       const startDate = '2024-01-05T00:00:00Z';
       const endDate = '2024-01-10T23:59:59Z';
 

--- a/packages/app-api/src/db/tracking.ts
+++ b/packages/app-api/src/db/tracking.ts
@@ -293,12 +293,10 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
       .select('playerLocation.*', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`)
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerLocation.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where(`${PLAYER_ON_GAMESERVER_TABLE_NAME}.gameServerId`, gameserverId)
-      .andWhereRaw('sqrt((playerLocation.x - ?) ^ 2 + (playerLocation.y - ?) ^ 2 + (playerLocation.z - ?) ^ 2) <= ?', [
-        x,
-        y,
-        z,
-        radius,
-      ]);
+      .andWhereRaw(
+        'sqrt(("playerLocation"."x" - ?) ^ 2 + ("playerLocation"."y" - ?) ^ 2 + ("playerLocation"."z" - ?) ^ 2) <= ?',
+        [x, y, z, radius],
+      );
 
     if (startDate) {
       qb.andWhere('playerLocation.createdAt', '>=', startDate);

--- a/packages/app-api/src/db/tracking.ts
+++ b/packages/app-api/src/db/tracking.ts
@@ -225,6 +225,7 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     }
 
     const qb = query
+      .distinct()
       .select('playerLocation.*', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`)
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerLocation.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where('playerLocation.createdAt', '>=', startDate);
@@ -259,6 +260,7 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     const { minX, maxX, minY, maxY, minZ, maxZ, startDate, endDate, gameserverId } = input;
 
     const qb = query
+      .distinct()
       .select('playerLocation.*', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`)
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerLocation.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where(`${PLAYER_ON_GAMESERVER_TABLE_NAME}.gameServerId`, gameserverId)
@@ -290,6 +292,7 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     const { x, y, z, radius, startDate, endDate, gameserverId } = input;
 
     const qb = query
+      .distinct()
       .select('playerLocation.*', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`)
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerLocation.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where(`${PLAYER_ON_GAMESERVER_TABLE_NAME}.gameServerId`, gameserverId)
@@ -319,6 +322,7 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     const { playerId, startDate, endDate } = input;
 
     const qb = query
+      .distinct()
       .select(
         'playerInventoryHistory.playerId',
         'playerInventoryHistory.itemId',
@@ -349,6 +353,7 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     const { itemId, startDate, endDate } = input;
 
     const qb = query
+      .distinct()
       .select(
         'playerInventoryHistory.playerId',
         'playerInventoryHistory.quantity',

--- a/packages/app-api/src/db/tracking.ts
+++ b/packages/app-api/src/db/tracking.ts
@@ -224,14 +224,17 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
       startDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
     }
 
-    const qb = query.where('createdAt', '>=', startDate);
+    const qb = query
+      .select('playerLocation.*', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`)
+      .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerLocation.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
+      .where('playerLocation.createdAt', '>=', startDate);
 
     if (playerId && playerId.length > 0) {
-      qb.whereIn('playerId', playerId);
+      qb.whereIn(`${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId`, playerId);
     }
 
     if (endDate) {
-      qb.where('createdAt', '<=', endDate);
+      qb.where('playerLocation.createdAt', '<=', endDate);
     }
 
     if (limit) {
@@ -240,11 +243,14 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
       qb.limit(1000);
     }
 
-    qb.orderBy('createdAt', 'DESC');
+    qb.orderBy('playerLocation.createdAt', 'DESC');
 
     const result = await qb;
-    return result.map((item) => {
-      return new PlayerLocationOutputDTO(item);
+    return result.map((item: any) => {
+      return new PlayerLocationOutputDTO({
+        ...item,
+        playerId: item.actualPlayerId,
+      });
     });
   }
 
@@ -253,14 +259,15 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     const { minX, maxX, minY, maxY, minZ, maxZ, startDate, endDate, gameserverId } = input;
 
     const qb = query
+      .select('playerLocation.*', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`)
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerLocation.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where(`${PLAYER_ON_GAMESERVER_TABLE_NAME}.gameServerId`, gameserverId)
-      .andWhere('x', '>=', minX)
-      .andWhere('x', '<=', maxX)
-      .andWhere('y', '>=', minY)
-      .andWhere('y', '<=', maxY)
-      .andWhere('z', '>=', minZ)
-      .andWhere('z', '<=', maxZ);
+      .andWhere('playerLocation.x', '>=', minX)
+      .andWhere('playerLocation.x', '<=', maxX)
+      .andWhere('playerLocation.y', '>=', minY)
+      .andWhere('playerLocation.y', '<=', maxY)
+      .andWhere('playerLocation.z', '>=', minZ)
+      .andWhere('playerLocation.z', '<=', maxZ);
 
     if (startDate) {
       qb.andWhere('playerLocation.createdAt', '>=', startDate);
@@ -270,8 +277,11 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     }
 
     const result = await qb;
-    return result.map((item) => {
-      return new PlayerLocationOutputDTO(item);
+    return result.map((item: any) => {
+      return new PlayerLocationOutputDTO({
+        ...item,
+        playerId: item.actualPlayerId,
+      });
     });
   }
 
@@ -280,9 +290,15 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     const { x, y, z, radius, startDate, endDate, gameserverId } = input;
 
     const qb = query
+      .select('playerLocation.*', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`)
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerLocation.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where(`${PLAYER_ON_GAMESERVER_TABLE_NAME}.gameServerId`, gameserverId)
-      .andWhereRaw('sqrt((x - ?) ^ 2 + (y - ?) ^ 2 + (z - ?) ^ 2) <= ?', [x, y, z, radius]);
+      .andWhereRaw('sqrt((playerLocation.x - ?) ^ 2 + (playerLocation.y - ?) ^ 2 + (playerLocation.z - ?) ^ 2) <= ?', [
+        x,
+        y,
+        z,
+        radius,
+      ]);
 
     if (startDate) {
       qb.andWhere('playerLocation.createdAt', '>=', startDate);
@@ -292,8 +308,11 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     }
 
     const result = await qb;
-    return result.map((item) => {
-      return new PlayerLocationOutputDTO(item);
+    return result.map((item: any) => {
+      return new PlayerLocationOutputDTO({
+        ...item,
+        playerId: item.actualPlayerId,
+      });
     });
   }
 
@@ -309,16 +328,21 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
         'items.code as itemCode',
         'playerInventoryHistory.quantity',
         'playerInventoryHistory.createdAt',
+        `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`,
       )
       .join('items', 'items.id', '=', 'playerInventoryHistory.itemId')
-      .where('playerInventoryHistory.playerId', playerId)
+      .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerInventoryHistory.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
+      .where(`${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId`, playerId)
       .andWhere('playerInventoryHistory.createdAt', '>=', startDate)
       .andWhere('playerInventoryHistory.createdAt', '<=', endDate)
       .orderBy('playerInventoryHistory.createdAt', 'desc');
 
     const result = await qb;
-    return result.map((item) => {
-      return new PlayerInventoryOutputDTO(item);
+    return result.map((item: any) => {
+      return new PlayerInventoryOutputDTO({
+        ...item,
+        playerId: item.actualPlayerId,
+      });
     });
   }
 
@@ -327,7 +351,13 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     const { itemId, startDate, endDate } = input;
 
     const qb = query
-      .select('playerInventoryHistory.playerId', 'playerInventoryHistory.quantity', 'playerInventoryHistory.createdAt')
+      .select(
+        'playerInventoryHistory.playerId',
+        'playerInventoryHistory.quantity',
+        'playerInventoryHistory.createdAt',
+        `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`,
+      )
+      .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerInventoryHistory.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where('playerInventoryHistory.itemId', itemId);
 
     if (startDate) {
@@ -341,8 +371,11 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     qb.orderBy('playerInventoryHistory.createdAt', 'desc');
 
     const result = await qb;
-    return result.map((item) => {
-      return new PlayerItemHistoryOutputDTO(item);
+    return result.map((item: any) => {
+      return new PlayerItemHistoryOutputDTO({
+        ...item,
+        playerId: item.actualPlayerId,
+      });
     });
   }
 }

--- a/packages/app-api/src/service/Tracking/index.ts
+++ b/packages/app-api/src/service/Tracking/index.ts
@@ -79,10 +79,10 @@ export class TrackingService extends TakaroService<
       for (const id of input.playerId) {
         const { isPlayerId, isPogId } = await this.checkIdType(id);
 
-        if (isPlayerId && !isPogId) {
+        if (isPogId && !isPlayerId) {
           throw new errors.BadRequestError(
-            `No tracking data found for ID: ${id}. This appears to be a Player ID, but this endpoint requires a PlayerOnGameserver ID. ` +
-              `Please use the PlayerOnGameserver ID instead. You can find the correct ID by querying /gameservers/{gameServerId}/players/{playerId}`,
+            `No tracking data found for ID: ${id}. This appears to be a PlayerOnGameserver ID, but this endpoint now requires a Player ID. ` +
+              `Please use the Player ID instead.`,
           );
         }
       }
@@ -106,10 +106,10 @@ export class TrackingService extends TakaroService<
     if (result.length === 0) {
       const { isPlayerId, isPogId } = await this.checkIdType(input.playerId);
 
-      if (isPlayerId && !isPogId) {
+      if (isPogId && !isPlayerId) {
         throw new errors.BadRequestError(
-          `No tracking data found for ID: ${input.playerId}. This appears to be a Player ID, but this endpoint requires a PlayerOnGameserver ID. ` +
-            `Please use the PlayerOnGameserver ID instead. You can find the correct ID by querying /gameservers/{gameServerId}/players/{playerId}`,
+          `No tracking data found for ID: ${input.playerId}. This appears to be a PlayerOnGameserver ID, but this endpoint now requires a Player ID. ` +
+            `Please use the Player ID instead.`,
         );
       }
     }


### PR DESCRIPTION
## Summary

This PR fixes the player tracking endpoints to return the correct `playerId` instead of the POG (PlayerOnGameserver) ID. Previously, the endpoints were returning the POG ID as the 'playerId' in the response, which was incorrect and confusing for API consumers.

## Changes

- Modified tracking repository methods to join with playerOnGameServer table to fetch actual player IDs
- Updated `getPlayerMovementHistory`, `getBoundingBoxPlayers`, `getRadiusPlayers` to return player.playerId
- Updated inventory tracking methods (`getPlayerInventoryHistory`, `getPlayersByItem`) similarly
- Reversed validation logic in TrackingService to expect Player IDs instead of POG IDs
- Updated tests to use player IDs when calling APIs and fixed assertions
- Fixed TypeScript compilation by adding type annotations for query results

## Breaking Change

⚠️ **BREAKING CHANGE**: Tracking endpoints now expect and return Player IDs instead of PlayerOnGameserver IDs. This affects:
- POST `/tracking/location` - Get movement history
- POST `/tracking/location/box` - Find players in bounding box
- POST `/tracking/location/radius` - Find players in radius
- POST `/tracking/inventory/player` - Get inventory history
- POST `/tracking/inventory/item` - Find players by item

## Testing

- [x] Code has been tested locally
- [x] TypeScript compilation passes
- [x] Updated integration tests to match new behavior
- [ ] All tests pass

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected test cases and error messages to ensure proper usage and validation of Player IDs versus PlayerOnGameserver IDs.
  * Updated internal queries to accurately return the actual Player ID in relevant data endpoints.

* **Tests**
  * Improved test consistency by aligning identifier usage and updating test descriptions and assertions for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->