### PR TITLE
fix: add nextCronJobRun to Monaco editor type definitions

### DIFF
--- a/packages/web-main/src/routes/_auth/-module-builder/Editor/customTypes.ts
+++ b/packages/web-main/src/routes/_auth/-module-builder/Editor/customTypes.ts
@@ -20,6 +20,7 @@ export function setExtraLibs(monaco: typeof mon, dataType: FunctionType) {
     '    declare const takaro: Client;',
     '    declare const checkPermission: (pog: PlayerOnGameserverOutputWithRolesDTO, permission: string) => boolean;',
     '    declare const TakaroUserError: { new (message: string) => Error };',
+    '    export const nextCronJobRun: (cron: string) => Date | null;',
     '    export const axios: Axios',
     '}',
   ].join('\n');


### PR DESCRIPTION
## Summary
The `nextCronJobRun` function from `@takaro/helpers` was missing from the hardcoded module declaration used by Monaco editor, causing TypeScript errors when trying to import it.

## Problem
- When using `import { nextCronJobRun } from '@takaro/helpers'` in the Monaco editor, TypeScript would show an error: "Module '@takaro/helpers' has no exported member 'nextCronJobRun'"
- The generated types from `getMonacoCustomTypes.mjs` script actually include all the correct exports, but the hardcoded module declaration in `customTypes.ts` was overriding them

## Solution
Added the missing `nextCronJobRun` export to the hardcoded module declaration to match the actual module exports.

## Testing
- The Monaco editor should now recognize `nextCronJobRun` as a valid import from `@takaro/helpers`
- No TypeScript errors when using the function in module code
