### PR TITLE
Hide shop categories with 0 items from shoppers

### DIFF
--- a/packages/web-main/src/components/shop/CategoryFilter.tsx
+++ b/packages/web-main/src/components/shop/CategoryFilter.tsx
@@ -147,15 +147,18 @@ export const CategoryFilter: FC<CategoryFilterProps> = ({
 
   // Build a proper category tree from the flat array
   const buildCategoryTree = (categories: ShopCategoryOutputDTO[]): ShopCategoryOutputDTO[] => {
+    // Filter out categories with no listings
+    const categoriesWithListings = categories.filter((cat) => (cat.listingCount || 0) > 0);
+
     // Create a map of all categories for quick lookup
     const categoryMap = new Map<string, ShopCategoryOutputDTO>();
-    categories.forEach((cat) => {
+    categoriesWithListings.forEach((cat) => {
       categoryMap.set(cat.id, { ...cat });
     });
 
     // Build the tree by assigning children to their parents
     const rootCategories: ShopCategoryOutputDTO[] = [];
-    categories.forEach((cat) => {
+    categoriesWithListings.forEach((cat) => {
       if (cat.parentId) {
         const parent = categoryMap.get(cat.parentId);
         if (parent) {


### PR DESCRIPTION
## Summary
Hide empty categories from the shop listings page to improve the shopping experience. Categories with 0 items are now filtered out automatically.

## Changes
- Added filtering logic in the `buildCategoryTree` function of `CategoryFilter.tsx`
- Categories with `listingCount === 0` are excluded from display
- Maintains existing functionality for category selection and filtering

## Implementation Details
The backend already provides `listingCount` for each category, which includes:
- Parent categories: total count of listings in themselves and their children
- Child categories: count of listings directly assigned to them

## Testing
- [x] Code has been tested locally
- [x] Build passes without TypeScript errors
- [x] Category filtering still works correctly
- [x] Uncategorized filter still functions properly

## Type of Change
- [x] Bug fix / UI improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated category filtering to ensure only categories with available listings are displayed in the category filter. Categories without listings are now excluded from the filter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->