### PR TITLE
Add missing action buttons to module table view

### DIFF
--- a/packages/web-main/src/routes/_auth/_global/-modules/ModulesTableView.tsx
+++ b/packages/web-main/src/routes/_auth/_global/-modules/ModulesTableView.tsx
@@ -12,6 +12,8 @@ import {
   AiOutlineEye as ViewIcon,
   AiOutlineTag as TagIcon,
   AiOutlineMore as ActionsIcon,
+  AiOutlineLink as LinkIcon,
+  AiOutlineBook as DocumentationIcon,
 } from 'react-icons/ai';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { getApiClient } from '../../../../util/getApiClient';
@@ -249,6 +251,22 @@ export const ModulesTableView: FC<ModulesTableViewProps> = () => {
             },
           });
         }
+
+        menuItems.push({
+          label: 'Open in Module Builder',
+          icon: <LinkIcon />,
+          onClick: () => {
+            window.open(`/module-builder/${module.id}`, '_blank');
+          },
+        });
+
+        menuItems.push({
+          label: 'View module documentation',
+          icon: <DocumentationIcon />,
+          onClick: () => {
+            window.open('https://docs.takaro.io/advanced/modules', '_blank');
+          },
+        });
 
         return (
           <ActionsContainer>


### PR DESCRIPTION
## Summary
This PR adds missing action buttons to the module table view to ensure consistency with the card layout view.

## Changes
- Added 'Open in Module Builder' action that opens the module in a new tab at `/module-builder/{moduleId}`
- Added 'View module documentation' action that links to the Takaro documentation
- Imported missing icons (LinkIcon, DocumentationIcon) from react-icons
- Both actions are now available in the dropdown menu for all modules (built-in and custom)

## Testing
- [x] Code has been tested locally
- [x] All tests pass
- [x] No console errors
- [x] Verified actions work in both table and card views

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Screenshots
The table view dropdown menu now includes all the same actions as the card view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Open in Module Builder" action to each module's actions menu, opening the Module Builder in a new tab.
  * Added "View module documentation" action to each module's actions menu, linking to external documentation in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->