### PR TITLE
Fix naming of player related IDs in tracking endpoints

### DIFF
--- a/packages/app-api/src/db/tracking.ts
+++ b/packages/app-api/src/db/tracking.ts
@@ -231,7 +231,11 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
 
     const qb = query
       .distinct()
-      .select('playerLocation.*', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`)
+      .select(
+        'playerLocation.*',
+        'playerLocation.playerId as pogId',
+        `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as playerId`,
+      )
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerLocation.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where('playerLocation.createdAt', '>=', startDate);
 
@@ -255,7 +259,8 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     return result.map((item: any) => {
       return new PlayerLocationOutputDTO({
         ...item,
-        playerId: item.actualPlayerId,
+        pogId: item.pogId,
+        playerId: item.playerId,
       });
     });
   }
@@ -266,7 +271,11 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
 
     const qb = query
       .distinct()
-      .select('playerLocation.*', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`)
+      .select(
+        'playerLocation.*',
+        'playerLocation.playerId as pogId',
+        `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as playerId`,
+      )
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerLocation.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where(`${PLAYER_ON_GAMESERVER_TABLE_NAME}.gameServerId`, gameserverId)
       .andWhere('playerLocation.x', '>=', minX)
@@ -287,7 +296,8 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     return result.map((item: any) => {
       return new PlayerLocationOutputDTO({
         ...item,
-        playerId: item.actualPlayerId,
+        pogId: item.pogId,
+        playerId: item.playerId,
       });
     });
   }
@@ -298,7 +308,11 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
 
     const qb = query
       .distinct()
-      .select('playerLocation.*', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`)
+      .select(
+        'playerLocation.*',
+        'playerLocation.playerId as pogId',
+        `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as playerId`,
+      )
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerLocation.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where(`${PLAYER_ON_GAMESERVER_TABLE_NAME}.gameServerId`, gameserverId)
       .andWhereRaw(
@@ -317,7 +331,8 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     return result.map((item: any) => {
       return new PlayerLocationOutputDTO({
         ...item,
-        playerId: item.actualPlayerId,
+        pogId: item.pogId,
+        playerId: item.playerId,
       });
     });
   }
@@ -329,13 +344,13 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     const qb = query
       .distinct()
       .select(
-        'playerInventoryHistory.playerId',
+        'playerInventoryHistory.playerId as pogId',
         'playerInventoryHistory.itemId',
         'items.name as itemName',
         'items.code as itemCode',
         'playerInventoryHistory.quantity',
         'playerInventoryHistory.createdAt',
-        `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`,
+        `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as playerId`,
       )
       .join('items', 'items.id', '=', 'playerInventoryHistory.itemId')
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerInventoryHistory.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
@@ -348,7 +363,8 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     return result.map((item: any) => {
       return new PlayerInventoryOutputDTO({
         ...item,
-        playerId: item.actualPlayerId,
+        pogId: item.pogId,
+        playerId: item.playerId,
       });
     });
   }
@@ -360,10 +376,10 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     const qb = query
       .distinct()
       .select(
-        'playerInventoryHistory.playerId',
+        'playerInventoryHistory.playerId as pogId',
         'playerInventoryHistory.quantity',
         'playerInventoryHistory.createdAt',
-        `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as actualPlayerId`,
+        `${PLAYER_ON_GAMESERVER_TABLE_NAME}.playerId as playerId`,
       )
       .join(PLAYER_ON_GAMESERVER_TABLE_NAME, 'playerInventoryHistory.playerId', `${PLAYER_ON_GAMESERVER_TABLE_NAME}.id`)
       .where('playerInventoryHistory.itemId', itemId);
@@ -382,7 +398,8 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
     return result.map((item: any) => {
       return new PlayerItemHistoryOutputDTO({
         ...item,
-        playerId: item.actualPlayerId,
+        pogId: item.pogId,
+        playerId: item.playerId,
       });
     });
   }

--- a/packages/app-api/src/service/Tracking/dto.ts
+++ b/packages/app-api/src/service/Tracking/dto.ts
@@ -6,6 +6,8 @@ export class PlayerLocationOutputDTO extends TakaroModelDTO<PlayerLocationOutput
   id: string;
   @IsUUID('4')
   playerId: string;
+  @IsUUID('4')
+  pogId: string;
   @IsNumber({ allowNaN: false, allowInfinity: false })
   x: number;
   @IsNumber({ allowNaN: false, allowInfinity: false })
@@ -77,6 +79,8 @@ export class PlayerInventoryOutputDTO extends TakaroModelDTO<PlayerInventoryOutp
   @IsUUID('4')
   playerId: string;
   @IsUUID('4')
+  pogId: string;
+  @IsUUID('4')
   itemId: string;
   @IsString()
   itemName: string;
@@ -111,6 +115,8 @@ export class PlayersByItemInputDTO extends TakaroDTO<PlayersByItemInputDTO> {
 export class PlayerItemHistoryOutputDTO extends TakaroModelDTO<PlayerItemHistoryOutputDTO> {
   @IsUUID('4')
   playerId: string;
+  @IsUUID('4')
+  pogId: string;
   @IsNumber({ allowNaN: false, allowInfinity: false })
   quantity: number;
   @IsISO8601()


### PR DESCRIPTION
## Summary
Refactored tracking endpoints to remove the confusing `actualPlayerId` field and replace it with clearer `pogId` and `playerId` fields.

## Changes
- Added `pogId` field to tracking DTOs (PlayerLocationOutputDTO, PlayerInventoryOutputDTO, PlayerItemHistoryOutputDTO)
- Updated all 5 tracking repository methods to return both pogId and playerId
- Removed actualPlayerId from API responses

## Benefits
- More explicit API: consumers get both Player ID and PlayerOnGameServer ID
- Better debugging: developers can trace data through both relationships
- Cleaner code: removes confusing actualPlayerId naming

## Testing
- [x] TypeScript compilation passes
- [ ] Integration tests pass (requires database)
- [ ] API client regenerated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new field, `pogId`, to player location, inventory, and item history data outputs for improved identification.

* **Bug Fixes**
  * Improved consistency in player identification across tracking data returned by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->