### PR TITLE
fix: add composite index to playerIpHistory for query performance

### DIFF
--- a/packages/lib-db/src/migrations/sql/20250802124307-add-playeriphistory-composite-index.ts
+++ b/packages/lib-db/src/migrations/sql/20250802124307-add-playeriphistory-composite-index.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('playerIpHistory', (table) => {
+    table.index(['domain', 'playerId', 'createdAt'], 'idx_playeriphistory_domain_playerid_createdat');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('playerIpHistory', (table) => {
+    table.dropIndex([], 'idx_playeriphistory_domain_playerid_createdat');
+  });
+}


### PR DESCRIPTION
## Summary
This PR adds a composite index to the `playerIpHistory` table to resolve severe performance issues with queries that were taking 49+ minutes in production.

## Problem
Two queries on the `playerIpHistory` table were experiencing extremely poor performance:
- Query fetching all columns: avg execution time of 2,944,825 ms (~49 minutes)
- Query fetching only IP column: avg execution time of 989,595 ms (~16 minutes)

Both queries filter by `domain` and `playerId`, then order by `createdAt` DESC.

## Solution
Created a composite index on `(domain, playerId, createdAt)` that:
- Covers all columns used in the WHERE clause
- Includes `createdAt` in the index to eliminate separate sort operations
- Enables index scans instead of sequential scans

## Expected Impact
- Query execution time reduction from minutes to milliseconds
- Significant performance improvement for production workloads
- No application code changes required

## Testing
- [x] Migration file created and follows existing patterns
- [x] Code has been linted and formatted
- [ ] Migration will be tested in development environment
- [ ] No breaking changes

## Type of Change
- [x] Bug fix (performance issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update