### PR TITLE
Fixed player action menus being cut off when clicking on players at the bottom of the player list

### DIFF
--- a/packages/lib-components/src/components/actions/Dropdown/useDropdown.tsx
+++ b/packages/lib-components/src/components/actions/Dropdown/useDropdown.tsx
@@ -11,6 +11,7 @@ import {
   useTypeahead,
   useClick,
   shift,
+  flip,
 } from '@floating-ui/react';
 
 export interface UseDropdownOptions {
@@ -42,7 +43,13 @@ export function useDropdown({
     open,
     onOpenChange: setOpen,
     whileElementsMounted: autoUpdate,
-    middleware: [offset({ mainAxis: 10 }), shift()],
+    middleware: [
+      offset({ mainAxis: 10 }),
+      flip({
+        fallbackPlacements: ['top', 'bottom'],
+      }),
+      shift(),
+    ],
   });
 
   const interactions = useInteractions([


### PR DESCRIPTION
## Summary

This PR fixes the issue where dropdown menus get cut off when triggered near the bottom of the viewport. The player action menu on the players page would be partially hidden when clicking on players at the bottom of the table.

## Changes

- Added `flip()` middleware from @floating-ui/react to the useDropdown hook
- Configured flip with fallback placements for top/bottom positioning
- Dropdown menus now automatically flip to appear above triggers when they would overflow

## Testing

- [x] Code has been tested locally
- [x] Verified dropdown menus flip correctly at viewport edges
- [x] Player action menus now fully visible for bottom table rows
- [x] No console errors

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown positioning to better handle cases where the preferred placement does not fit on the screen, allowing the dropdown to flip between top and bottom placements automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->