### PR TITLE
Display error messages for inactive/maintenance domains on login

### DIFF
--- a/packages/app-api/src/service/AuthService.ts
+++ b/packages/app-api/src/service/AuthService.ts
@@ -191,6 +191,22 @@ export class AuthService extends DomainScoped {
         const identity = await ory.getIdentityFromReq(req);
         if (!identity) return null;
 
+        // If we have a domain cookie, validate that the domain is still active
+        if (domainId) {
+          const domain = await domainService.findOne(domainId);
+          if (domain && domain.state !== DOMAIN_STATES.ACTIVE) {
+            // Clear the invalid domain cookie
+            if (req.res?.cookie) {
+              req.res.cookie('takaro-domain', '', { maxAge: 0 });
+            }
+
+            // Instead of throwing error immediately, try to find another active domain
+            log.info(`Domain ${domainId} is ${domain.state}, attempting to find another active domain for user`);
+            domainId = null; // Reset domainId to trigger the domain selection logic below
+          }
+          // If domain not found or is active, continue with the existing domainId
+        }
+
         // If the client didn't provide a domain hint, we assume the first one.
         if (!domainId) {
           const domains = await domainService.resolveDomainByIdpId(identity.id);
@@ -205,6 +221,16 @@ export class AuthService extends DomainScoped {
             log.warn(
               `No active domain found for identity (but domains found: ${domains.map((d) => ({ id: d.id, state: d.state })).join(',')})`,
             );
+
+            // Check if any domain is in maintenance mode
+            const maintenanceDomain = domains.find((d) => d.state === DOMAIN_STATES.MAINTENANCE);
+            if (maintenanceDomain) {
+              throw new errors.BadRequestError(
+                'Domain is in maintenance mode. Please try again later or contact support if the issue persists.',
+              );
+            }
+
+            // Otherwise, domain is disabled
             throw new errors.BadRequestError('Domain is disabled. Please contact support.');
           }
 

--- a/packages/web-main/src/routes/login.tsx
+++ b/packages/web-main/src/routes/login.tsx
@@ -150,7 +150,18 @@ function Component() {
       console.log(error);
 
       if (isAxiosError(error)) {
-        setError(error.response?.data.ui.messages.map((message) => message.text));
+        // Check if this is an error from the Ory flow (has ui.messages)
+        if (error.response?.data?.ui?.messages) {
+          setError(error.response.data.ui.messages.map((message) => message.text));
+        }
+        // Check if this is an error from our API (has meta.error.message)
+        else if (error.response?.data?.meta?.error?.message) {
+          setError(error.response.data.meta.error.message);
+        }
+        // Fallback to generic error message
+        else {
+          setError('An error occurred during login. Please try again.');
+        }
       }
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary

This PR fixes the issue where users don't see error messages when trying to login to domains that are inactive or in maintenance mode. It also adds automatic domain switching when a user's selected domain is disabled but they have access to other active domains.

## Changes

- **Frontend**: Enhanced error handling in login.tsx to properly display API error messages
- **Backend**: 
  - Validate domain state even when a domain cookie exists
  - Return specific error messages for disabled vs maintenance states
  - Auto-switch to active domain when current domain is disabled
- **Tests**: Added comprehensive Playwright E2E tests for all domain state scenarios

## Problem Solved

Previously, if a user had a domain cookie set and that domain became disabled/maintenance, they would get a silent failure with no error message. Now:
1. Users see clear error messages when their domain is unavailable
2. If they have access to other active domains, the system automatically switches to an available one
3. Only shows error if NO active domains are available

## Testing

- [x] Code has been tested locally
- [x] All E2E tests pass
- [x] No console errors
- [x] Manually verified with disabled/maintenance domains

## Type of Change

- [x] Bug fix
- [x] User experience improvement
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during login to clearly indicate when a domain is in maintenance or disabled state.
  * Enhanced error handling to provide more specific feedback for different types of login failures.

* **Tests**
  * Added end-to-end tests to verify login behavior for users in disabled or maintenance domains, and to ensure automatic domain switching when the current domain is inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->