### PR TITLE
Allow setting player currency to 0

### DIFF
--- a/packages/app-api/src/controllers/PlayerOnGameserverController.ts
+++ b/packages/app-api/src/controllers/PlayerOnGameserverController.ts
@@ -88,7 +88,7 @@ class PlayerOnGameServerSearchInputDTO extends ITakaroQuery<PlayerOnGameserverOu
 
 class PlayerOnGameServerSetCurrencyInputDTO {
   @IsNumber()
-  @Min(0.01)
+  @Min(0)
   currency!: number;
 }
 

--- a/packages/app-api/src/controllers/__tests__/PlayerOnGameserverController.integration.test.ts
+++ b/packages/app-api/src/controllers/__tests__/PlayerOnGameserverController.integration.test.ts
@@ -69,6 +69,47 @@ const tests = [
   }),
   new IntegrationTest<SetupGameServerPlayers.ISetupData>({
     group,
+    snapshot: false,
+    name: 'Can set currency to zero',
+    setup: SetupGameServerPlayers.setup,
+    test: async function () {
+      const res = await this.client.playerOnGameserver.playerOnGameServerControllerSearch();
+
+      const player = res.data.data[0];
+
+      await this.client.settings.settingsControllerSet('economyEnabled', {
+        gameServerId: player.gameServerId,
+        value: 'true',
+      });
+
+      // First set currency to some value
+      await this.client.playerOnGameserver.playerOnGameServerControllerSetCurrency(
+        player.gameServerId,
+        player.playerId,
+        {
+          currency: 100,
+        },
+      );
+
+      // Now set it to zero
+      await this.client.playerOnGameserver.playerOnGameServerControllerSetCurrency(
+        player.gameServerId,
+        player.playerId,
+        {
+          currency: 0,
+        },
+      );
+
+      const playerRes = await this.client.playerOnGameserver.playerOnGameServerControllerGetOne(
+        player.gameServerId,
+        player.playerId,
+      );
+
+      expect(playerRes.data.data.currency).to.be.eq(0);
+    },
+  }),
+  new IntegrationTest<SetupGameServerPlayers.ISetupData>({
+    group,
     snapshot: true,
     name: 'Rejects negative currency',
     setup: SetupGameServerPlayers.setup,
@@ -441,33 +482,6 @@ const tests = [
         player.playerId,
         {
           currency: -50,
-        },
-      );
-
-      expect(rejectedRes.data.meta.error.message).to.be.eq('Validation error');
-      return rejectedRes;
-    },
-  }),
-  new IntegrationTest<SetupGameServerPlayers.ISetupData>({
-    group,
-    snapshot: true,
-    name: 'Rejects zero amount for addCurrency',
-    setup: SetupGameServerPlayers.setup,
-    expectedStatus: 400,
-    test: async function () {
-      const res = await this.client.playerOnGameserver.playerOnGameServerControllerSearch();
-      const player = res.data.data[0];
-
-      await this.client.settings.settingsControllerSet('economyEnabled', {
-        gameServerId: player.gameServerId,
-        value: 'true',
-      });
-
-      const rejectedRes = await this.client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
-        player.gameServerId,
-        player.playerId,
-        {
-          currency: 0,
         },
       );
 

--- a/packages/test/src/__snapshots__/PlayerOnGameserverController/Rejects negative amount for addCurrency.json
+++ b/packages/test/src/__snapshots__/PlayerOnGameserverController/Rejects negative amount for addCurrency.json
@@ -12,7 +12,7 @@
             "property": "currency",
             "children": [],
             "constraints": {
-              "min": "currency must not be less than 0.01"
+              "min": "currency must not be less than 0"
             }
           }
         ],

--- a/packages/test/src/__snapshots__/PlayerOnGameserverController/Rejects negative amount for deductCurrency.json
+++ b/packages/test/src/__snapshots__/PlayerOnGameserverController/Rejects negative amount for deductCurrency.json
@@ -12,7 +12,7 @@
             "property": "currency",
             "children": [],
             "constraints": {
-              "min": "currency must not be less than 0.01"
+              "min": "currency must not be less than 0"
             }
           }
         ],

--- a/packages/test/src/__snapshots__/PlayerOnGameserverController/Rejects negative amount for transfer.json
+++ b/packages/test/src/__snapshots__/PlayerOnGameserverController/Rejects negative amount for transfer.json
@@ -12,7 +12,7 @@
             "property": "currency",
             "children": [],
             "constraints": {
-              "min": "currency must not be less than 0.01"
+              "min": "currency must not be less than 0"
             }
           }
         ],

--- a/packages/test/src/__snapshots__/PlayerOnGameserverController/Rejects negative currency.json
+++ b/packages/test/src/__snapshots__/PlayerOnGameserverController/Rejects negative currency.json
@@ -12,7 +12,7 @@
             "property": "currency",
             "children": [],
             "constraints": {
-              "min": "currency must not be less than 0.01"
+              "min": "currency must not be less than 0"
             }
           }
         ],

--- a/packages/web-main/src/components/dialogs/PlayerCurrencyDialog.tsx
+++ b/packages/web-main/src/components/dialogs/PlayerCurrencyDialog.tsx
@@ -8,7 +8,7 @@ import { z } from 'zod';
 import { RequiredDialogOptions } from '.';
 
 const currencySchema = z.object({
-  currency: z.number().positive({ message: 'Currency must be greater than 0' }),
+  currency: z.number().min(0, { message: 'Currency must be 0 or greater' }),
   variant: z.enum(['add', 'deduct']).default('add'),
 });
 


### PR DESCRIPTION
## Summary
This PR removes the minimum currency constraint that prevented setting player currency to 0. The validation was changed from requiring a minimum of 0.01 to allowing 0 or greater.

## Changes
- Updated backend API validation in `PlayerOnGameserverController` to accept 0 as valid currency value (changed `@Min(0.01)` to `@Min(0)`)
- Updated frontend dialog validation in `PlayerCurrencyDialog` to allow 0 (changed from `.positive()` to `.min(0)`)
- Removed the "Rejects zero amount for addCurrency" test since 0 is now a valid value
- Added new test "Can set currency to zero" to verify the functionality works correctly
- Updated 4 test snapshots to reflect the new validation message

## Testing
- [x] All PlayerOnGameserverController tests pass (15/15)
- [x] All EconomyUtils integration tests pass (9/9)
- [x] New test confirms currency can be set to 0
- [x] Snapshots updated for new validation messages

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Context
The database already supports 0 values with its `CHECK currency >= 0` constraint, so no migration was needed. This change aligns the API and UI validation with the database constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now set a player's currency to zero on a game server.

* **Bug Fixes**
  * Updated validation messages and input requirements to allow zero as a valid currency value across relevant dialogs and error messages.

* **Tests**
  * Added a test to verify setting player currency to zero is successful.
  * Removed a test that previously rejected zero as a valid currency amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->