### PR TITLE
Add explicit LIMIT 1 to inventory snapshot query to prevent fetching 150k rows

### DIFF
--- a/packages/app-api/src/db/playerOnGameserver.ts
+++ b/packages/app-api/src/db/playerOnGameserver.ts
@@ -397,6 +397,7 @@ export class PlayerOnGameServerRepo extends ITakaroRepo<
       .select('createdAt')
       .where('playerId', pogId)
       .orderBy('createdAt', 'desc')
+      .limit(1)
       .first();
 
     if (!latestSnapshot) {


### PR DESCRIPTION
## Summary
This PR fixes a critical performance issue in the inventory query that was fetching ~150k rows instead of just 1.

## Problem
According to CloudSQL query analytics, the `latestSnapshot` query in `getInventoryFromDB` was executing without a LIMIT clause, causing it to fetch all inventory history rows for a player (averaging 150k rows) before applying `.first()` in JavaScript.

## Solution
Added an explicit `.limit(1)` before `.first()` to ensure the database query only returns a single row.

## Changes
- Modified `packages/app-api/src/db/playerOnGameserver.ts` line 400
- Added `.limit(1)` to the query chain before `.first()`

## Performance Impact
- **Before**: Query fetching ~150k rows on average
- **After**: Query fetching exactly 1 row
- Expected significant reduction in database load and query execution time

## Testing
- [x] Code has been tested locally
- [x] TypeScript compilation passes
- [x] Linting passes
- [ ] Integration tests pass

## Type of Change
- [x] Bug fix (performance)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensures the most recent inventory snapshot is consistently used, reducing chances of outdated inventory displays.
- Performance
  - Minor optimization to inventory loading that may slightly improve response times for inventory-related views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->