### PR TITLE
feat: add Apache ECharts integration with themed components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,8 @@
         "deep-equal-in-any-order": "2.0.6",
         "discord-api-types": "0.37.101",
         "discord.js": "14.16.3",
+        "echarts": "^5.6.0",
+        "echarts-for-react": "^3.0.2",
         "ejs": "3.1.10",
         "eventsource": "2.0.2",
         "express": "4.21.2",
@@ -7880,11 +7882,6 @@
         }
       }
     },
-    "node_modules/@nestjs/common/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/@nestjs/core": {
       "version": "10.4.15",
       "dev": true,
@@ -7926,11 +7923,6 @@
       "version": "3.3.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@nestjs/core/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8298,11 +8290,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@openapitools/openapi-generator-cli/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/@openapitools/openapi-generator-cli/node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -18454,6 +18441,36 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.2.tgz",
+      "integrity": "sha512-DRwIiTzx8JfwPOVgGttDytBqdp5VzCSyMRIxubgU/g2n9y3VLUmF2FK7Icmg/sNVkv4+rktmrLN9w22U2yy3fA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "license": "MIT"
@@ -24412,10 +24429,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/libmime/node_modules/libqp": {
-      "version": "2.1.1",
-      "license": "MIT"
-    },
     "node_modules/libphonenumber-js": {
       "version": "1.11.5",
       "license": "MIT"
@@ -24424,7 +24437,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
       "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lie": {
@@ -32042,6 +32054,12 @@
       "version": "5.0.2",
       "license": "MIT"
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.2.tgz",
+      "integrity": "sha512-2NCmWxY7A9pYKGXNBfteo4hy14gWu47rg5692peVMst6lQLPKrVjhY+UTEsPI5ceFRJSl3gVgMYaUi/hKuaiKw==",
+      "license": "ISC"
+    },
     "node_modules/skin-tone": {
       "version": "2.0.0",
       "license": "MIT",
@@ -35764,6 +35782,21 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/zustand": {
       "version": "4.5.5",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,8 @@
     "deep-equal-in-any-order": "2.0.6",
     "discord-api-types": "0.37.101",
     "discord.js": "14.16.3",
+    "echarts": "^5.6.0",
+    "echarts-for-react": "^3.0.2",
     "ejs": "3.1.10",
     "eventsource": "2.0.2",
     "express": "4.21.2",

--- a/packages/lib-components/src/components/charts/ECharts/index.tsx
+++ b/packages/lib-components/src/components/charts/ECharts/index.tsx
@@ -1,0 +1,358 @@
+import { useEffect, useRef, FC } from 'react';
+import ReactEChartsCore from 'echarts-for-react/lib/core';
+import * as echarts from 'echarts/core';
+import { LineChart, BarChart, PieChart, ScatterChart } from 'echarts/charts';
+import {
+  GridComponent,
+  TooltipComponent,
+  TitleComponent,
+  LegendComponent,
+  DataZoomComponent,
+  ToolboxComponent,
+  MarkPointComponent,
+  MarkLineComponent,
+  MarkAreaComponent,
+  PolarComponent,
+} from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+import { EChartsOption } from 'echarts';
+import { ParentSize } from '@visx/responsive';
+import { useTheme } from '../../../hooks';
+import { shade, lighten } from 'polished';
+
+// Register required components
+echarts.use([
+  LineChart,
+  BarChart,
+  PieChart,
+  ScatterChart,
+  GridComponent,
+  TooltipComponent,
+  TitleComponent,
+  LegendComponent,
+  DataZoomComponent,
+  ToolboxComponent,
+  MarkPointComponent,
+  MarkLineComponent,
+  MarkAreaComponent,
+  PolarComponent,
+  CanvasRenderer,
+]);
+
+export interface EChartsProps {
+  option: EChartsOption;
+  style?: React.CSSProperties;
+  className?: string;
+  loading?: boolean;
+  notMerge?: boolean;
+  lazyUpdate?: boolean;
+  onChartReady?: (instance: any) => void;
+  onEvents?: Record<string, (params: any) => void>;
+}
+
+const createTheme = (isDark: boolean, colors: any) => {
+  const backgroundColor = isDark ? colors.background : colors.background;
+  const textColor = isDark ? colors.text : colors.text;
+  const axisLineColor = isDark ? colors.backgroundAccent : colors.backgroundAlt;
+
+  return {
+    color: [
+      colors.primary,
+      colors.success,
+      colors.warning,
+      colors.error,
+      colors.info,
+      lighten(0.1, colors.primary),
+      shade(0.2, colors.success),
+      lighten(0.1, colors.warning),
+    ],
+    backgroundColor: backgroundColor,
+    textStyle: {
+      color: textColor,
+    },
+    title: {
+      textStyle: {
+        color: textColor,
+      },
+      subtextStyle: {
+        color: colors.textAlt,
+      },
+    },
+    line: {
+      itemStyle: {
+        borderWidth: 1,
+      },
+      lineStyle: {
+        width: 2,
+      },
+      symbolSize: 4,
+      symbol: 'circle',
+      smooth: true,
+    },
+    categoryAxis: {
+      axisLine: {
+        show: true,
+        lineStyle: {
+          color: axisLineColor,
+        },
+      },
+      axisTick: {
+        show: true,
+        lineStyle: {
+          color: axisLineColor,
+        },
+      },
+      axisLabel: {
+        show: true,
+        color: textColor,
+      },
+      splitLine: {
+        show: false,
+        lineStyle: {
+          color: [axisLineColor],
+        },
+      },
+      splitArea: {
+        show: false,
+        areaStyle: {
+          color: [backgroundColor],
+        },
+      },
+    },
+    valueAxis: {
+      axisLine: {
+        show: false,
+        lineStyle: {
+          color: axisLineColor,
+        },
+      },
+      axisTick: {
+        show: false,
+        lineStyle: {
+          color: axisLineColor,
+        },
+      },
+      axisLabel: {
+        show: true,
+        color: textColor,
+      },
+      splitLine: {
+        show: true,
+        lineStyle: {
+          color: [axisLineColor],
+          type: 'dashed',
+        },
+      },
+      splitArea: {
+        show: false,
+        areaStyle: {
+          color: [backgroundColor],
+        },
+      },
+    },
+    logAxis: {
+      axisLine: {
+        show: false,
+        lineStyle: {
+          color: axisLineColor,
+        },
+      },
+      axisTick: {
+        show: false,
+        lineStyle: {
+          color: axisLineColor,
+        },
+      },
+      axisLabel: {
+        show: true,
+        color: textColor,
+      },
+      splitLine: {
+        show: true,
+        lineStyle: {
+          color: [axisLineColor],
+        },
+      },
+      splitArea: {
+        show: false,
+        areaStyle: {
+          color: [backgroundColor],
+        },
+      },
+    },
+    timeAxis: {
+      axisLine: {
+        show: true,
+        lineStyle: {
+          color: axisLineColor,
+        },
+      },
+      axisTick: {
+        show: true,
+        lineStyle: {
+          color: axisLineColor,
+        },
+      },
+      axisLabel: {
+        show: true,
+        color: textColor,
+      },
+      splitLine: {
+        show: false,
+        lineStyle: {
+          color: [axisLineColor],
+        },
+      },
+      splitArea: {
+        show: false,
+        areaStyle: {
+          color: [backgroundColor],
+        },
+      },
+    },
+    toolbox: {
+      iconStyle: {
+        borderColor: textColor,
+      },
+      emphasis: {
+        iconStyle: {
+          borderColor: colors.primary,
+        },
+      },
+    },
+    legend: {
+      textStyle: {
+        color: textColor,
+      },
+    },
+    tooltip: {
+      backgroundColor: isDark ? colors.backgroundAlt : colors.white,
+      borderColor: axisLineColor,
+      borderWidth: 1,
+      textStyle: {
+        color: textColor,
+      },
+      axisPointer: {
+        lineStyle: {
+          color: axisLineColor,
+          width: 1,
+        },
+        crossStyle: {
+          color: axisLineColor,
+          width: 1,
+        },
+      },
+    },
+    timeline: {
+      lineStyle: {
+        color: axisLineColor,
+        width: 1,
+      },
+      itemStyle: {
+        color: colors.primary,
+        borderWidth: 1,
+      },
+      controlStyle: {
+        color: axisLineColor,
+        borderColor: axisLineColor,
+        borderWidth: 0.5,
+      },
+      checkpointStyle: {
+        color: colors.primary,
+        borderColor: colors.primary,
+      },
+      label: {
+        color: textColor,
+      },
+      emphasis: {
+        itemStyle: {
+          color: colors.primary,
+        },
+        controlStyle: {
+          color: axisLineColor,
+          borderColor: axisLineColor,
+          borderWidth: 0.5,
+        },
+        label: {
+          color: textColor,
+        },
+      },
+    },
+    visualMap: {
+      textStyle: {
+        color: textColor,
+      },
+    },
+    dataZoom: {
+      backgroundColor: 'transparent',
+      dataBackgroundColor: isDark ? colors.backgroundAccent : colors.backgroundAlt,
+      fillerColor: isDark ? 'rgba(102, 77, 229, 0.2)' : 'rgba(102, 77, 229, 0.15)',
+      handleColor: colors.primary,
+      handleSize: '100%',
+      textStyle: {
+        color: textColor,
+      },
+    },
+    markPoint: {
+      label: {
+        color: backgroundColor,
+      },
+      emphasis: {
+        label: {
+          color: backgroundColor,
+        },
+      },
+    },
+  };
+};
+
+export const EChartsBase: FC<EChartsProps> = ({
+  option,
+  style,
+  className,
+  loading = false,
+  notMerge = false,
+  lazyUpdate = true,
+  onChartReady,
+  onEvents,
+}) => {
+  const theme = useTheme();
+  const chartRef = useRef<any>(null);
+  const themeNameRef = useRef<string>('');
+
+  useEffect(() => {
+    const isDark = theme.name === 'dark';
+    const themeName = `takaro_${theme.name}`;
+
+    // Only register theme if it hasn't been registered or theme changed
+    if (themeNameRef.current !== themeName) {
+      const themeConfig = createTheme(isDark, theme.colors);
+      echarts.registerTheme(themeName, themeConfig);
+      themeNameRef.current = themeName;
+    }
+  }, [theme]);
+
+  return (
+    <ReactEChartsCore
+      ref={chartRef}
+      echarts={echarts}
+      option={option}
+      style={style}
+      className={className}
+      theme={`takaro_${theme.name}`}
+      notMerge={notMerge}
+      lazyUpdate={lazyUpdate}
+      showLoading={loading}
+      onChartReady={onChartReady}
+      onEvents={onEvents}
+    />
+  );
+};
+
+export const ECharts: FC<Omit<EChartsProps, 'style'>> = (props) => {
+  return (
+    <ParentSize>
+      {(parent) => <EChartsBase {...props} style={{ width: parent.width, height: parent.height }} />}
+    </ParentSize>
+  );
+};

--- a/packages/lib-components/src/components/charts/EChartsArea/EChartsArea.stories.tsx
+++ b/packages/lib-components/src/components/charts/EChartsArea/EChartsArea.stories.tsx
@@ -1,0 +1,492 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { ECharts, EChartsProps } from '../ECharts';
+import { styled } from '../../../styled';
+import { EChartsOption } from 'echarts';
+
+export default {
+  title: 'Charts/ECharts/Area',
+  component: ECharts,
+} as Meta<EChartsProps>;
+
+const Wrapper = styled.div`
+  height: 500px;
+  width: 100%;
+  padding: 20px;
+`;
+
+const generateTimeSeriesData = (days: number = 30) => {
+  const data = [];
+  const baseTime = new Date('2024-01-01').getTime();
+  const dayMs = 24 * 3600 * 1000;
+
+  for (let i = 0; i < days; i++) {
+    const date = new Date(baseTime + i * dayMs);
+    data.push({
+      date: date.toISOString().split('T')[0],
+      value: Math.floor(Math.random() * 100) + 50 + i * 2,
+    });
+  }
+  return data;
+};
+
+const generateMultiSeriesData = () => {
+  const categories = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const series1 = categories.map(() => Math.floor(Math.random() * 100) + 100);
+  const series2 = categories.map(() => Math.floor(Math.random() * 80) + 80);
+  const series3 = categories.map(() => Math.floor(Math.random() * 60) + 60);
+  return { categories, series1, series2, series3 };
+};
+
+export const BasicArea: StoryFn<EChartsProps> = () => {
+  const data = generateTimeSeriesData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Monthly Growth Trend',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'cross',
+        label: {
+          backgroundColor: '#6a7985',
+        },
+      },
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '3%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: data.map((item) => item.date),
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Value',
+    },
+    series: [
+      {
+        name: 'Growth',
+        type: 'line',
+        smooth: true,
+        data: data.map((item) => item.value),
+        areaStyle: {
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              {
+                offset: 0,
+                color: 'rgba(102, 77, 229, 0.6)',
+              },
+              {
+                offset: 1,
+                color: 'rgba(102, 77, 229, 0.05)',
+              },
+            ],
+          },
+        },
+        emphasis: {
+          focus: 'series',
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const StackedArea: StoryFn<EChartsProps> = () => {
+  const { categories, series1, series2, series3 } = generateMultiSeriesData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Revenue Streams',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'cross',
+        label: {
+          backgroundColor: '#6a7985',
+        },
+      },
+    },
+    legend: {
+      data: ['Product Sales', 'Services', 'Subscriptions'],
+      bottom: 10,
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '10%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: categories,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Revenue ($k)',
+    },
+    series: [
+      {
+        name: 'Product Sales',
+        type: 'line',
+        stack: 'Total',
+        smooth: true,
+        lineStyle: {
+          width: 0,
+        },
+        showSymbol: false,
+        areaStyle: {
+          opacity: 0.8,
+        },
+        emphasis: {
+          focus: 'series',
+        },
+        data: series1,
+      },
+      {
+        name: 'Services',
+        type: 'line',
+        stack: 'Total',
+        smooth: true,
+        lineStyle: {
+          width: 0,
+        },
+        showSymbol: false,
+        areaStyle: {
+          opacity: 0.8,
+        },
+        emphasis: {
+          focus: 'series',
+        },
+        data: series2,
+      },
+      {
+        name: 'Subscriptions',
+        type: 'line',
+        stack: 'Total',
+        smooth: true,
+        lineStyle: {
+          width: 0,
+        },
+        showSymbol: false,
+        areaStyle: {
+          opacity: 0.8,
+        },
+        emphasis: {
+          focus: 'series',
+        },
+        data: series3,
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const GradientStackedArea: StoryFn<EChartsProps> = () => {
+  const { categories, series1, series2, series3 } = generateMultiSeriesData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Platform Usage Statistics',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'cross',
+      },
+    },
+    legend: {
+      data: ['Desktop', 'Mobile', 'Tablet'],
+      bottom: 10,
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '10%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: categories,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Users (k)',
+    },
+    series: [
+      {
+        name: 'Desktop',
+        type: 'line',
+        stack: 'Total',
+        smooth: true,
+        lineStyle: {
+          width: 2,
+        },
+        showSymbol: false,
+        areaStyle: {
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              { offset: 0, color: 'rgba(102, 77, 229, 0.8)' },
+              { offset: 1, color: 'rgba(102, 77, 229, 0.2)' },
+            ],
+          },
+        },
+        emphasis: {
+          focus: 'series',
+        },
+        data: series1,
+      },
+      {
+        name: 'Mobile',
+        type: 'line',
+        stack: 'Total',
+        smooth: true,
+        lineStyle: {
+          width: 2,
+        },
+        showSymbol: false,
+        areaStyle: {
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              { offset: 0, color: 'rgba(60, 205, 106, 0.8)' },
+              { offset: 1, color: 'rgba(60, 205, 106, 0.2)' },
+            ],
+          },
+        },
+        emphasis: {
+          focus: 'series',
+        },
+        data: series2,
+      },
+      {
+        name: 'Tablet',
+        type: 'line',
+        stack: 'Total',
+        smooth: true,
+        lineStyle: {
+          width: 2,
+        },
+        showSymbol: false,
+        areaStyle: {
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              { offset: 0, color: 'rgba(245, 124, 0, 0.8)' },
+              { offset: 1, color: 'rgba(245, 124, 0, 0.2)' },
+            ],
+          },
+        },
+        emphasis: {
+          focus: 'series',
+        },
+        data: series3,
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const BandArea: StoryFn<EChartsProps> = () => {
+  const days = 30;
+  const dates = [];
+  const values = [];
+  const upper = [];
+  const lower = [];
+
+  const baseTime = new Date('2024-01-01').getTime();
+  const dayMs = 24 * 3600 * 1000;
+
+  for (let i = 0; i < days; i++) {
+    const date = new Date(baseTime + i * dayMs);
+    dates.push(date.toISOString().split('T')[0]);
+    const baseValue = 100 + Math.sin(i / 5) * 20 + Math.random() * 10;
+    values.push(baseValue);
+    upper.push(baseValue + 15 + Math.random() * 10);
+    lower.push(baseValue - 15 - Math.random() * 10);
+  }
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Confidence Interval',
+      subtext: 'With Upper and Lower Bounds',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'cross',
+      },
+    },
+    legend: {
+      data: ['Actual', 'L', 'U'],
+      selected: {
+        L: false,
+        U: false,
+      },
+      bottom: 10,
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '10%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: dates,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Value',
+    },
+    series: [
+      {
+        name: 'L',
+        type: 'line',
+        data: lower,
+        lineStyle: {
+          opacity: 0,
+        },
+        stack: 'confidence-band',
+        symbol: 'none',
+      },
+      {
+        name: 'U',
+        type: 'line',
+        data: upper.map((val, idx) => val - lower[idx]),
+        lineStyle: {
+          opacity: 0,
+        },
+        areaStyle: {
+          color: 'rgba(102, 77, 229, 0.2)',
+        },
+        stack: 'confidence-band',
+        symbol: 'none',
+      },
+      {
+        name: 'Actual',
+        type: 'line',
+        data: values,
+        smooth: true,
+        lineStyle: {
+          width: 2,
+        },
+        symbol: 'none',
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const PolarArea: StoryFn<EChartsProps> = () => {
+  const data = [];
+  for (let i = 0; i <= 360; i++) {
+    const t = (i / 180) * Math.PI;
+    const r = Math.sin(2 * t) * Math.cos(2 * t);
+    data.push([r, i]);
+  }
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Polar Area Chart',
+      left: 'center',
+    },
+    polar: {
+      center: ['50%', '50%'],
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'cross',
+      },
+    },
+    angleAxis: {
+      type: 'value',
+      startAngle: 0,
+    },
+    radiusAxis: {
+      min: 0,
+    },
+    series: [
+      {
+        coordinateSystem: 'polar',
+        name: 'Area',
+        type: 'line',
+        showSymbol: false,
+        data: data,
+        areaStyle: {
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 1,
+            y2: 1,
+            colorStops: [
+              { offset: 0, color: 'rgba(102, 77, 229, 0.8)' },
+              { offset: 0.5, color: 'rgba(60, 205, 106, 0.5)' },
+              { offset: 1, color: 'rgba(245, 124, 0, 0.3)' },
+            ],
+          },
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};

--- a/packages/lib-components/src/components/charts/EChartsBar/EChartsBar.stories.tsx
+++ b/packages/lib-components/src/components/charts/EChartsBar/EChartsBar.stories.tsx
@@ -1,0 +1,407 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { ECharts, EChartsProps } from '../ECharts';
+import { styled } from '../../../styled';
+import { EChartsOption } from 'echarts';
+
+export default {
+  title: 'Charts/ECharts/Bar',
+  component: ECharts,
+} as Meta<EChartsProps>;
+
+const Wrapper = styled.div`
+  height: 500px;
+  width: 100%;
+  padding: 20px;
+`;
+
+const generateBarData = () => {
+  const categories = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const data = categories.map(() => Math.floor(Math.random() * 300) + 50);
+  return { categories, data };
+};
+
+const generateMultiSeriesBarData = () => {
+  const categories = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];
+  const series1 = [120, 200, 150, 80, 70, 110];
+  const series2 = [90, 180, 120, 100, 90, 130];
+  const series3 = [60, 90, 80, 60, 50, 80];
+  return { categories, series1, series2, series3 };
+};
+
+export const BasicBar: StoryFn<EChartsProps> = () => {
+  const { categories, data } = generateBarData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Weekly Sales',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'shadow',
+      },
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '3%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'category',
+      data: categories,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Sales ($)',
+    },
+    series: [
+      {
+        name: 'Sales',
+        type: 'bar',
+        data: data,
+        emphasis: {
+          focus: 'series',
+        },
+        itemStyle: {
+          borderRadius: [8, 8, 0, 0],
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const HorizontalBar: StoryFn<EChartsProps> = () => {
+  const categories = ['Product A', 'Product B', 'Product C', 'Product D', 'Product E'];
+  const data = [320, 302, 301, 334, 390];
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Product Performance',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'shadow',
+      },
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '3%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'value',
+      name: 'Units Sold',
+    },
+    yAxis: {
+      type: 'category',
+      data: categories,
+    },
+    series: [
+      {
+        name: 'Sales',
+        type: 'bar',
+        data: data,
+        emphasis: {
+          focus: 'series',
+        },
+        itemStyle: {
+          borderRadius: [0, 8, 8, 0],
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const StackedBar: StoryFn<EChartsProps> = () => {
+  const { categories, series1, series2, series3 } = generateMultiSeriesBarData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Monthly Revenue by Product',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'shadow',
+      },
+    },
+    legend: {
+      data: ['Product A', 'Product B', 'Product C'],
+      bottom: 10,
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '10%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'category',
+      data: categories,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Revenue (k$)',
+    },
+    series: [
+      {
+        name: 'Product A',
+        type: 'bar',
+        stack: 'total',
+        emphasis: {
+          focus: 'series',
+        },
+        data: series1,
+      },
+      {
+        name: 'Product B',
+        type: 'bar',
+        stack: 'total',
+        emphasis: {
+          focus: 'series',
+        },
+        data: series2,
+      },
+      {
+        name: 'Product C',
+        type: 'bar',
+        stack: 'total',
+        emphasis: {
+          focus: 'series',
+        },
+        data: series3,
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const GroupedBar: StoryFn<EChartsProps> = () => {
+  const { categories, series1, series2, series3 } = generateMultiSeriesBarData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Quarterly Comparison',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'shadow',
+      },
+    },
+    legend: {
+      data: ['Q1', 'Q2', 'Q3'],
+      bottom: 10,
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '10%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'category',
+      data: categories,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Value',
+    },
+    series: [
+      {
+        name: 'Q1',
+        type: 'bar',
+        emphasis: {
+          focus: 'series',
+        },
+        data: series1,
+        itemStyle: {
+          borderRadius: [4, 4, 0, 0],
+        },
+      },
+      {
+        name: 'Q2',
+        type: 'bar',
+        emphasis: {
+          focus: 'series',
+        },
+        data: series2,
+        itemStyle: {
+          borderRadius: [4, 4, 0, 0],
+        },
+      },
+      {
+        name: 'Q3',
+        type: 'bar',
+        emphasis: {
+          focus: 'series',
+        },
+        data: series3,
+        itemStyle: {
+          borderRadius: [4, 4, 0, 0],
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const WaterfallBar: StoryFn<EChartsProps> = () => {
+  const categories = ['Start', 'Revenue', 'Costs', 'Tax', 'Other', 'End'];
+  const increaseData = [0, 900, 0, 0, 300, 0];
+  const decreaseData = [0, 0, -600, -200, 0, 0];
+  const totalData = [500, 0, 0, 0, 0, 900];
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Profit Waterfall',
+      subtext: 'Financial Analysis',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'shadow',
+      },
+      formatter: (params: any) => {
+        const tar = params[0];
+        return `${tar.name}<br/>${tar.seriesName}: ${Math.abs(tar.value)}`;
+      },
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '3%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'category',
+      data: categories,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Amount ($k)',
+    },
+    series: [
+      {
+        name: 'Placeholder',
+        type: 'bar',
+        stack: 'Total',
+        silent: true,
+        itemStyle: {
+          borderColor: 'transparent',
+          color: 'transparent',
+        },
+        emphasis: {
+          itemStyle: {
+            borderColor: 'transparent',
+            color: 'transparent',
+          },
+        },
+        data: [0, 500, 800, 600, 400, 0],
+      },
+      {
+        name: 'Increase',
+        type: 'bar',
+        stack: 'Total',
+        data: increaseData,
+        itemStyle: {
+          color: '#3ccd6a',
+        },
+      },
+      {
+        name: 'Decrease',
+        type: 'bar',
+        stack: 'Total',
+        data: decreaseData,
+        itemStyle: {
+          color: '#ff4252',
+        },
+      },
+      {
+        name: 'Total',
+        type: 'bar',
+        stack: 'Total',
+        data: totalData,
+        itemStyle: {
+          color: '#664de5',
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const PolarBar: StoryFn<EChartsProps> = () => {
+  const data = [
+    { value: 100, name: 'Mon' },
+    { value: 120, name: 'Tue' },
+    { value: 90, name: 'Wed' },
+    { value: 150, name: 'Thu' },
+    { value: 130, name: 'Fri' },
+    { value: 110, name: 'Sat' },
+    { value: 80, name: 'Sun' },
+  ];
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Weekly Activity',
+      left: 'center',
+    },
+    angleAxis: {
+      type: 'category',
+      data: data.map((item) => item.name),
+    },
+    radiusAxis: {},
+    polar: {},
+    series: [
+      {
+        type: 'bar',
+        data: data.map((item) => item.value),
+        coordinateSystem: 'polar',
+      },
+    ],
+    tooltip: {},
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};

--- a/packages/lib-components/src/components/charts/EChartsLine/EChartsLine.stories.tsx
+++ b/packages/lib-components/src/components/charts/EChartsLine/EChartsLine.stories.tsx
@@ -1,0 +1,296 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { ECharts, EChartsProps } from '../ECharts';
+import { styled } from '../../../styled';
+import { EChartsOption } from 'echarts';
+
+export default {
+  title: 'Charts/ECharts/Line',
+  component: ECharts,
+} as Meta<EChartsProps>;
+
+const Wrapper = styled.div`
+  height: 500px;
+  width: 100%;
+  padding: 20px;
+`;
+
+// Generate sample data
+const generateTimeSeriesData = () => {
+  const data = [];
+  const baseTime = new Date('2024-01-01').getTime();
+  const dayMs = 24 * 3600 * 1000;
+
+  for (let i = 0; i < 30; i++) {
+    const date = new Date(baseTime + i * dayMs);
+    data.push([date.toISOString().split('T')[0], Math.floor(Math.random() * 100) + 50]);
+  }
+  return data;
+};
+
+const generateMultiSeriesData = () => {
+  const categories = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const series1 = [120, 200, 150, 80, 70, 110, 130];
+  const series2 = [90, 180, 120, 100, 90, 130, 110];
+  const series3 = [60, 90, 80, 60, 50, 80, 90];
+
+  return { categories, series1, series2, series3 };
+};
+
+export const BasicLine: StoryFn<EChartsProps> = () => {
+  const data = generateTimeSeriesData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Daily Metrics',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+    },
+    xAxis: {
+      type: 'category',
+      data: data.map((item) => item[0]),
+      boundaryGap: false,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Value',
+    },
+    series: [
+      {
+        name: 'Metric',
+        type: 'line',
+        data: data.map((item) => item[1]),
+        smooth: true,
+        emphasis: {
+          focus: 'series',
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const MultipleLines: StoryFn<EChartsProps> = () => {
+  const { categories, series1, series2, series3 } = generateMultiSeriesData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Weekly Performance Comparison',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: {
+        type: 'cross',
+      },
+    },
+    legend: {
+      data: ['Product A', 'Product B', 'Product C'],
+      bottom: 0,
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '10%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: categories,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Sales',
+    },
+    series: [
+      {
+        name: 'Product A',
+        type: 'line',
+        data: series1,
+        smooth: true,
+      },
+      {
+        name: 'Product B',
+        type: 'line',
+        data: series2,
+        smooth: true,
+      },
+      {
+        name: 'Product C',
+        type: 'line',
+        data: series3,
+        smooth: true,
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const AreaLine: StoryFn<EChartsProps> = () => {
+  const data = generateTimeSeriesData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Area Chart with Gradient',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+    },
+    xAxis: {
+      type: 'category',
+      data: data.map((item) => item[0]),
+      boundaryGap: false,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Value',
+    },
+    series: [
+      {
+        name: 'Metric',
+        type: 'line',
+        data: data.map((item) => item[1]),
+        smooth: true,
+        areaStyle: {
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              {
+                offset: 0,
+                color: 'rgba(102, 77, 229, 0.5)',
+              },
+              {
+                offset: 1,
+                color: 'rgba(102, 77, 229, 0.05)',
+              },
+            ],
+          },
+        },
+        emphasis: {
+          focus: 'series',
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const StepLine: StoryFn<EChartsProps> = () => {
+  const categories = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'];
+  const data = [120, 120, 150, 150, 200, 200];
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Step Line Chart',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+    },
+    xAxis: {
+      type: 'category',
+      data: categories,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Price ($)',
+    },
+    series: [
+      {
+        name: 'Pricing Tier',
+        type: 'line',
+        step: 'end',
+        data: data,
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const WithDataZoom: StoryFn<EChartsProps> = () => {
+  const data = [];
+  const baseTime = new Date('2023-01-01').getTime();
+  const dayMs = 24 * 3600 * 1000;
+
+  for (let i = 0; i < 365; i++) {
+    const date = new Date(baseTime + i * dayMs);
+    data.push([date.toISOString().split('T')[0], Math.floor(Math.random() * 1000) + 500]);
+  }
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Yearly Data with Zoom',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'axis',
+    },
+    xAxis: {
+      type: 'category',
+      data: data.map((item) => item[0]),
+      boundaryGap: false,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Value',
+    },
+    dataZoom: [
+      {
+        type: 'slider',
+        start: 70,
+        end: 100,
+      },
+      {
+        type: 'inside',
+        start: 70,
+        end: 100,
+      },
+    ],
+    series: [
+      {
+        name: 'Daily Value',
+        type: 'line',
+        data: data.map((item) => item[1]),
+        smooth: true,
+        symbol: 'none',
+        lineStyle: {
+          width: 1.5,
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};

--- a/packages/lib-components/src/components/charts/EChartsPie/EChartsPie.stories.tsx
+++ b/packages/lib-components/src/components/charts/EChartsPie/EChartsPie.stories.tsx
@@ -1,0 +1,300 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { ECharts, EChartsProps } from '../ECharts';
+import { styled } from '../../../styled';
+import { EChartsOption } from 'echarts';
+
+export default {
+  title: 'Charts/ECharts/Pie',
+  component: ECharts,
+} as Meta<EChartsProps>;
+
+const Wrapper = styled.div`
+  height: 500px;
+  width: 100%;
+  padding: 20px;
+`;
+
+const generatePieData = () => [
+  { value: 1048, name: 'Search Engine' },
+  { value: 735, name: 'Direct' },
+  { value: 580, name: 'Email' },
+  { value: 484, name: 'Union Ads' },
+  { value: 300, name: 'Video Ads' },
+];
+
+export const BasicPie: StoryFn<EChartsProps> = () => {
+  const data = generatePieData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Traffic Sources',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: '{a} <br/>{b}: {c} ({d}%)',
+    },
+    legend: {
+      orient: 'vertical',
+      left: 'left',
+    },
+    series: [
+      {
+        name: 'Traffic Source',
+        type: 'pie',
+        radius: '50%',
+        data: data,
+        emphasis: {
+          itemStyle: {
+            shadowBlur: 10,
+            shadowOffsetX: 0,
+            shadowColor: 'rgba(0, 0, 0, 0.5)',
+          },
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const DonutChart: StoryFn<EChartsProps> = () => {
+  const data = generatePieData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Revenue Distribution',
+      subtext: 'Q4 2024',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: '{a} <br/>{b}: {c} ({d}%)',
+    },
+    legend: {
+      bottom: 10,
+      left: 'center',
+      orient: 'horizontal',
+    },
+    series: [
+      {
+        name: 'Revenue',
+        type: 'pie',
+        radius: ['40%', '70%'],
+        avoidLabelOverlap: false,
+        itemStyle: {
+          borderRadius: 10,
+          borderColor: '#fff',
+          borderWidth: 2,
+        },
+        label: {
+          show: false,
+          position: 'center',
+        },
+        emphasis: {
+          label: {
+            show: true,
+            fontSize: 20,
+            fontWeight: 'bold',
+          },
+        },
+        labelLine: {
+          show: false,
+        },
+        data: data,
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const RoseChart: StoryFn<EChartsProps> = () => {
+  const data = [
+    { value: 40, name: 'Product A' },
+    { value: 38, name: 'Product B' },
+    { value: 32, name: 'Product C' },
+    { value: 30, name: 'Product D' },
+    { value: 28, name: 'Product E' },
+    { value: 26, name: 'Product F' },
+    { value: 22, name: 'Product G' },
+    { value: 18, name: 'Product H' },
+  ];
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Product Performance',
+      subtext: 'Rose Diagram',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: '{a} <br/>{b}: {c} ({d}%)',
+    },
+    legend: {
+      left: 'center',
+      bottom: 10,
+      orient: 'horizontal',
+    },
+    series: [
+      {
+        name: 'Performance',
+        type: 'pie',
+        radius: [20, 140],
+        center: ['50%', '50%'],
+        roseType: 'area',
+        itemStyle: {
+          borderRadius: 8,
+        },
+        data: data,
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const HalfDonut: StoryFn<EChartsProps> = () => {
+  const data = [
+    { value: 335, name: 'Category A' },
+    { value: 310, name: 'Category B' },
+    { value: 234, name: 'Category C' },
+    { value: 135, name: 'Category D' },
+    { value: 148, name: 'Category E' },
+    {
+      value: 335 + 310 + 234 + 135 + 148,
+      itemStyle: {
+        color: 'none',
+        decal: {
+          symbol: 'none',
+        },
+      },
+      label: {
+        show: false,
+      },
+    },
+  ];
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Gauge Style Pie',
+      left: 'center',
+      top: '20%',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: any) => {
+        if (params.name) {
+          return `${params.seriesName} <br/>${params.name}: ${params.value} (${params.percent}%)`;
+        }
+        return '';
+      },
+    },
+    legend: {
+      bottom: 10,
+      left: 'center',
+      orient: 'horizontal',
+      data: ['Category A', 'Category B', 'Category C', 'Category D', 'Category E'],
+    },
+    series: [
+      {
+        name: 'Metrics',
+        type: 'pie',
+        radius: ['40%', '70%'],
+        center: ['50%', '60%'],
+        startAngle: 180,
+        endAngle: 360,
+        data: data,
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const NestedPie: StoryFn<EChartsProps> = () => {
+  const innerData = [
+    { value: 1548, name: 'Technology' },
+    { value: 735, name: 'Design' },
+    { value: 510, name: 'Marketing' },
+    { value: 434, name: 'Sales' },
+    { value: 335, name: 'Support' },
+  ];
+
+  const outerData = [
+    { value: 600, name: 'Frontend' },
+    { value: 500, name: 'Backend' },
+    { value: 448, name: 'DevOps' },
+    { value: 400, name: 'UI/UX' },
+    { value: 335, name: 'Graphics' },
+    { value: 310, name: 'Digital Marketing' },
+    { value: 200, name: 'Content' },
+    { value: 234, name: 'B2B Sales' },
+    { value: 200, name: 'B2C Sales' },
+    { value: 235, name: 'Customer Service' },
+    { value: 100, name: 'Technical Support' },
+  ];
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Department Structure',
+      subtext: 'Nested Pie Chart',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: '{a} <br/>{b}: {c} ({d}%)',
+    },
+    series: [
+      {
+        name: 'Department',
+        type: 'pie',
+        selectedMode: 'single',
+        radius: [0, '30%'],
+        label: {
+          position: 'inner',
+          fontSize: 14,
+        },
+        labelLine: {
+          show: false,
+        },
+        data: innerData,
+      },
+      {
+        name: 'Team',
+        type: 'pie',
+        radius: ['45%', '60%'],
+        labelLine: {
+          length: 30,
+        },
+        label: {
+          formatter: '{b}: {d}%',
+        },
+        data: outerData,
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};

--- a/packages/lib-components/src/components/charts/EChartsScatter/EChartsScatter.stories.tsx
+++ b/packages/lib-components/src/components/charts/EChartsScatter/EChartsScatter.stories.tsx
@@ -1,0 +1,533 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { ECharts, EChartsProps } from '../ECharts';
+import { styled } from '../../../styled';
+import { EChartsOption } from 'echarts';
+
+export default {
+  title: 'Charts/ECharts/Scatter',
+  component: ECharts,
+} as Meta<EChartsProps>;
+
+const Wrapper = styled.div`
+  height: 500px;
+  width: 100%;
+  padding: 20px;
+`;
+
+const generateScatterData = (count: number = 50) => {
+  const data = [];
+  for (let i = 0; i < count; i++) {
+    data.push([Math.random() * 100, Math.random() * 100]);
+  }
+  return data;
+};
+
+const generateCorrelationData = (count: number = 100) => {
+  const data = [];
+  for (let i = 0; i < count; i++) {
+    const x = Math.random() * 100;
+    const y = x + (Math.random() - 0.5) * 30;
+    data.push([x, Math.max(0, Math.min(100, y))]);
+  }
+  return data;
+};
+
+const generateBubbleData = (count: number = 30) => {
+  const data = [];
+  for (let i = 0; i < count; i++) {
+    data.push([Math.random() * 100, Math.random() * 100, Math.random() * 100]);
+  }
+  return data;
+};
+
+export const BasicScatter: StoryFn<EChartsProps> = () => {
+  const data = generateScatterData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Basic Scatter Plot',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: any) => {
+        return `X: ${params.value[0].toFixed(2)}<br/>Y: ${params.value[1].toFixed(2)}`;
+      },
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '3%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'value',
+      name: 'X Axis',
+      nameLocation: 'middle',
+      nameGap: 30,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Y Axis',
+      nameLocation: 'middle',
+      nameGap: 40,
+    },
+    series: [
+      {
+        name: 'Data Points',
+        type: 'scatter',
+        data: data,
+        emphasis: {
+          focus: 'self',
+          itemStyle: {
+            shadowBlur: 10,
+            shadowColor: 'rgba(0, 0, 0, 0.5)',
+          },
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const CorrelationScatter: StoryFn<EChartsProps> = () => {
+  const data1 = generateCorrelationData();
+  const data2 = generateCorrelationData().map(([x, y]) => [x, 100 - y + (Math.random() - 0.5) * 20]);
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Correlation Analysis',
+      subtext: 'Positive vs Negative Correlation',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: any) => {
+        return `${params.seriesName}<br/>X: ${params.value[0].toFixed(2)}<br/>Y: ${params.value[1].toFixed(2)}`;
+      },
+    },
+    legend: {
+      data: ['Positive Correlation', 'Negative Correlation'],
+      bottom: 10,
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '10%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'value',
+      name: 'Independent Variable',
+      nameLocation: 'middle',
+      nameGap: 30,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Dependent Variable',
+      nameLocation: 'middle',
+      nameGap: 40,
+    },
+    series: [
+      {
+        name: 'Positive Correlation',
+        type: 'scatter',
+        data: data1,
+        emphasis: {
+          focus: 'series',
+        },
+      },
+      {
+        name: 'Negative Correlation',
+        type: 'scatter',
+        data: data2,
+        emphasis: {
+          focus: 'series',
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const BubbleChart: StoryFn<EChartsProps> = () => {
+  const data = generateBubbleData();
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Bubble Chart',
+      subtext: 'Size Represents Third Dimension',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: any) => {
+        return `X: ${params.value[0].toFixed(2)}<br/>Y: ${params.value[1].toFixed(2)}<br/>Size: ${params.value[2].toFixed(2)}`;
+      },
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '3%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'value',
+      name: 'Performance',
+      nameLocation: 'middle',
+      nameGap: 30,
+      splitLine: {
+        show: true,
+        lineStyle: {
+          type: 'dashed',
+        },
+      },
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Efficiency',
+      nameLocation: 'middle',
+      nameGap: 40,
+      splitLine: {
+        show: true,
+        lineStyle: {
+          type: 'dashed',
+        },
+      },
+    },
+    series: [
+      {
+        name: 'Metrics',
+        type: 'scatter',
+        data: data,
+        symbolSize: (value: number[]) => {
+          return Math.sqrt(value[2]) * 3;
+        },
+        emphasis: {
+          focus: 'self',
+          itemStyle: {
+            shadowBlur: 10,
+            shadowColor: 'rgba(0, 0, 0, 0.5)',
+          },
+        },
+        itemStyle: {
+          opacity: 0.8,
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const MultipleBubbleSeries: StoryFn<EChartsProps> = () => {
+  const generateCategoryData = () => generateBubbleData(20);
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Product Comparison',
+      subtext: 'Price vs Quality vs Market Share',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: any) => {
+        return `${params.seriesName}<br/>Price: $${params.value[0].toFixed(0)}<br/>Quality: ${params.value[1].toFixed(0)}%<br/>Market Share: ${params.value[2].toFixed(0)}%`;
+      },
+    },
+    legend: {
+      data: ['Electronics', 'Clothing', 'Food', 'Services'],
+      bottom: 10,
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '10%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'value',
+      name: 'Price ($)',
+      nameLocation: 'middle',
+      nameGap: 30,
+      min: 0,
+      max: 100,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Quality Score (%)',
+      nameLocation: 'middle',
+      nameGap: 40,
+      min: 0,
+      max: 100,
+    },
+    series: [
+      {
+        name: 'Electronics',
+        type: 'scatter',
+        data: generateCategoryData(),
+        symbolSize: (value: number[]) => Math.sqrt(value[2]) * 4,
+        emphasis: {
+          focus: 'series',
+        },
+        itemStyle: {
+          opacity: 0.7,
+        },
+      },
+      {
+        name: 'Clothing',
+        type: 'scatter',
+        data: generateCategoryData(),
+        symbolSize: (value: number[]) => Math.sqrt(value[2]) * 4,
+        emphasis: {
+          focus: 'series',
+        },
+        itemStyle: {
+          opacity: 0.7,
+        },
+      },
+      {
+        name: 'Food',
+        type: 'scatter',
+        data: generateCategoryData(),
+        symbolSize: (value: number[]) => Math.sqrt(value[2]) * 4,
+        emphasis: {
+          focus: 'series',
+        },
+        itemStyle: {
+          opacity: 0.7,
+        },
+      },
+      {
+        name: 'Services',
+        type: 'scatter',
+        data: generateCategoryData(),
+        symbolSize: (value: number[]) => Math.sqrt(value[2]) * 4,
+        emphasis: {
+          focus: 'series',
+        },
+        itemStyle: {
+          opacity: 0.7,
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const ScatterWithRegression: StoryFn<EChartsProps> = () => {
+  const data = generateCorrelationData(50);
+
+  // Simple linear regression
+  const n = data.length;
+  const sumX = data.reduce((acc, [x]) => acc + x, 0);
+  const sumY = data.reduce((acc, [, y]) => acc + y, 0);
+  const sumXY = data.reduce((acc, [x, y]) => acc + x * y, 0);
+  const sumX2 = data.reduce((acc, [x]) => acc + x * x, 0);
+
+  const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+  const intercept = (sumY - slope * sumX) / n;
+
+  const regressionLine = [
+    [0, intercept],
+    [100, slope * 100 + intercept],
+  ];
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Scatter with Trend Line',
+      subtext: 'Linear Regression Analysis',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: any) => {
+        if (params.seriesName === 'Trend Line') {
+          return 'Trend Line';
+        }
+        return `Data Point<br/>X: ${params.value[0].toFixed(2)}<br/>Y: ${params.value[1].toFixed(2)}`;
+      },
+    },
+    legend: {
+      data: ['Data Points', 'Trend Line'],
+      bottom: 10,
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '10%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'value',
+      name: 'X Variable',
+      nameLocation: 'middle',
+      nameGap: 30,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Y Variable',
+      nameLocation: 'middle',
+      nameGap: 40,
+    },
+    series: [
+      {
+        name: 'Data Points',
+        type: 'scatter',
+        data: data,
+        emphasis: {
+          focus: 'self',
+        },
+      },
+      {
+        name: 'Trend Line',
+        type: 'line',
+        data: regressionLine,
+        lineStyle: {
+          type: 'dashed',
+          width: 2,
+        },
+        symbol: 'none',
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};
+
+export const DensityScatter: StoryFn<EChartsProps> = () => {
+  const generateClusterData = (centerX: number, centerY: number, count: number) => {
+    const data = [];
+    for (let i = 0; i < count; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const radius = Math.random() * 20;
+      data.push([centerX + Math.cos(angle) * radius, centerY + Math.sin(angle) * radius]);
+    }
+    return data;
+  };
+
+  const cluster1 = generateClusterData(30, 30, 150);
+  const cluster2 = generateClusterData(70, 70, 150);
+  const cluster3 = generateClusterData(30, 70, 100);
+  const cluster4 = generateClusterData(70, 30, 100);
+
+  const option: EChartsOption = {
+    title: {
+      text: 'Cluster Analysis',
+      subtext: 'Density Distribution',
+      left: 'center',
+    },
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: any) => {
+        return `${params.seriesName}<br/>X: ${params.value[0].toFixed(2)}<br/>Y: ${params.value[1].toFixed(2)}`;
+      },
+    },
+    legend: {
+      data: ['Cluster A', 'Cluster B', 'Cluster C', 'Cluster D'],
+      bottom: 10,
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '10%',
+      containLabel: true,
+    },
+    xAxis: {
+      type: 'value',
+      name: 'Feature 1',
+      nameLocation: 'middle',
+      nameGap: 30,
+      min: 0,
+      max: 100,
+    },
+    yAxis: {
+      type: 'value',
+      name: 'Feature 2',
+      nameLocation: 'middle',
+      nameGap: 40,
+      min: 0,
+      max: 100,
+    },
+    series: [
+      {
+        name: 'Cluster A',
+        type: 'scatter',
+        data: cluster1,
+        symbolSize: 3,
+        emphasis: {
+          focus: 'series',
+        },
+        itemStyle: {
+          opacity: 0.6,
+        },
+      },
+      {
+        name: 'Cluster B',
+        type: 'scatter',
+        data: cluster2,
+        symbolSize: 3,
+        emphasis: {
+          focus: 'series',
+        },
+        itemStyle: {
+          opacity: 0.6,
+        },
+      },
+      {
+        name: 'Cluster C',
+        type: 'scatter',
+        data: cluster3,
+        symbolSize: 3,
+        emphasis: {
+          focus: 'series',
+        },
+        itemStyle: {
+          opacity: 0.6,
+        },
+      },
+      {
+        name: 'Cluster D',
+        type: 'scatter',
+        data: cluster4,
+        symbolSize: 3,
+        emphasis: {
+          focus: 'series',
+        },
+        itemStyle: {
+          opacity: 0.6,
+        },
+      },
+    ],
+  };
+
+  return (
+    <Wrapper>
+      <ECharts option={option} />
+    </Wrapper>
+  );
+};

--- a/packages/lib-components/src/components/charts/index.tsx
+++ b/packages/lib-components/src/components/charts/index.tsx
@@ -24,3 +24,6 @@ export type { RadialBarChartProps } from './RadialBarChart';
 
 export { GeoMercator } from './GeoMercator';
 export type { GeoMercatorProps } from './GeoMercator';
+
+export { ECharts, EChartsBase } from './ECharts';
+export type { EChartsProps } from './ECharts';


### PR DESCRIPTION
- Install echarts and echarts-for-react packages
- Create base ECharts component with theme integration
- Add support for dark/light themes matching existing design system
- Create 5 chart type stories with multiple variations:
  - Line charts (basic, multiple, area, step, with zoom)
  - Pie charts (basic, donut, rose, half-donut, nested)
  - Bar charts (basic, horizontal, stacked, grouped, waterfall, polar)
  - Area charts (basic, stacked, gradient, band, polar)
  - Scatter charts (basic, correlation, bubble, multi-series, regression, density)
- Fix polar chart components registration
- Export ECharts components from main charts index