### PR TITLE
Add health check for mock game server Takaro connection

### DIFF
--- a/packages/app-mock-gameserver/src/lib/ws-gameserver/gameserver.ts
+++ b/packages/app-mock-gameserver/src/lib/ws-gameserver/gameserver.ts
@@ -1070,5 +1070,9 @@ export class GameServer implements IGameServer {
   async listLocations(): Promise<ILocationDTO[]> {
     return [];
   }
+
+  isConnectedToTakaro(): boolean {
+    return this.wsClient.isConnectedToServer();
+  }
   //#endregion
 }


### PR DESCRIPTION
## Summary

This PR adds health check functionality to the mock game server to monitor its connection to Takaro. When the WebSocket connection is lost, the health check will fail, allowing external monitoring systems to detect the issue.

## Changes

- Added `isConnectedToTakaro()` method to GameServer class to expose WebSocket connection status
- Registered health hook named 'takaro-connection' in bin.ts that checks if the game server is connected
- The health check integrates with the existing `/readyz` endpoint provided by the HTTP server

## How it Works

1. When the mock server starts, it registers a health hook that checks the WebSocket connection status
2. The `/readyz` endpoint (already provided by the Meta controller) calls all registered health hooks
3. If not connected to Takaro, the endpoint returns `{ healthy: false }`
4. This matches the existing warning message pattern: 'Cannot send message - not connected'

## Additional Notes

- **Redis health check** is already automatically handled by the Redis client wrapper when `DataHandler.init()` creates the Redis client
- The system will return `{ healthy: false }` if either the Takaro connection is lost OR Redis is unavailable
- This allows proper health monitoring in containerized environments (K8s, Docker Compose, etc.)

## Testing

- [x] Code compiles without errors
- [x] Health hook properly registered
- [x] Integrates with existing health check system

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added connectivity-aware health check for the mock game server. The health status now reflects live connection to Takaro: healthy when connected, unhealthy when disconnected.
  - Health reporting integrates with existing health endpoints, enabling more accurate monitoring and automated readiness/liveness checks in deployment environments.
  - Works automatically after startup; no configuration changes required and no impact on other server endpoints or startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->