### PR TITLE
Remove inventory cache debug log lines

### DIFF
--- a/packages/app-api/src/db/playerOnGameserver.ts
+++ b/packages/app-api/src/db/playerOnGameserver.ts
@@ -367,7 +367,6 @@ export class PlayerOnGameServerRepo extends ITakaroRepo<
     try {
       const cached = await redis.get(cacheKey);
       if (cached) {
-        this.log.debug('Inventory cache hit', { pogId });
         return JSON.parse(cached);
       }
     } catch (error) {

--- a/packages/app-api/src/db/tracking.ts
+++ b/packages/app-api/src/db/tracking.ts
@@ -182,7 +182,6 @@ export class TrackingRepo extends ITakaroRepo<PlayerLocationTrackingModel, Playe
       });
 
       await redis.set(cacheKey, JSON.stringify(inventoryItems), { EX: 1800 });
-      this.log.debug('Inventory cache updated', { playerId, itemCount: items.length });
     } catch (error) {
       this.log.warn('Failed to update inventory cache', { error, playerId });
     }


### PR DESCRIPTION
## Summary
Remove debug log lines for inventory cache operations to reduce log noise in production environments.

## Changes
- Removed `this.log.debug('Inventory cache hit', { pogId })` from playerOnGameserver.ts:370
- Removed `this.log.debug('Inventory cache updated', { playerId, itemCount: items.length })` from tracking.ts:185

## Testing
- [x] Code has been tested locally
- [x] All tests pass
- [x] No console errors

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Maintenance/Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Reduced log verbosity around inventory caching by removing non-essential debug messages. Cache behavior and error handling are unchanged, including fallback to the database on cache misses and timed expiry. This streamlines logs and improves signal for operational monitoring without altering user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->