### PR TITLE
Fix duplicate inventory data in player search responses

### DIFF
--- a/packages/app-api/src/db/playerOnGameserver.ts
+++ b/packages/app-api/src/db/playerOnGameserver.ts
@@ -426,7 +426,17 @@ export class PlayerOnGameServerRepo extends ITakaroRepo<
       .where('playerInventoryHistory.playerId', pogId)
       .andWhere('playerInventoryHistory.createdAt', latestSnapshot.createdAt);
 
-    return Promise.all(items.map((item) => new IItemDTO({ ...item, amount: item.quantity })));
+    return Promise.all(
+      items.map(
+        (item: any) =>
+          new IItemDTO({
+            name: item.name,
+            code: item.code,
+            description: item.description,
+            amount: item.quantity,
+          }),
+      ),
+    );
   }
 
   async setOnlinePlayers(gameServerId: string, players: IGamePlayer[]) {


### PR DESCRIPTION
## Summary
This PR fixes an issue where the PlayerOnGameServerControllerSearch endpoint was returning duplicate data for inventory items, with both `quantity` and `amount` fields containing the same value.

## Problem
The API was violating the IItemDTO schema by including both:
- `quantity` (from the database query)
- `amount` (the correct field per the DTO)

## Solution
Modified the `getInventoryFromDB` method to properly map database fields to DTO fields without including the original `quantity` field. The response now only contains the fields defined in IItemDTO.

## Changes
- Updated inventory mapping in `packages/app-api/src/db/playerOnGameserver.ts`
- Explicitly map only the required DTO fields instead of spreading all query results

## Testing
- [x] Code has been tested locally
- [x] TypeScript compilation passes
- [x] Linting passes
- [ ] All tests pass

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update